### PR TITLE
fix: Image (Mifos logo) present in the navigation drawer is not properly displayed

### DIFF
--- a/app/src/main/res/layout/nav_drawer_header.xml
+++ b/app/src/main/res/layout/nav_drawer_header.xml
@@ -5,7 +5,7 @@
               android:background="@drawable/mifos_logo"
               android:gravity="center_vertical|bottom"
               android:orientation="vertical"
-              android:paddingStart="16dp">
+              android:layout_marginTop='24dp'>
 
     <TextView
         android:id="@+id/tv_user_name"


### PR DESCRIPTION

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.

After resolving the issue - 

![screenshot_20170314-200231](https://cloud.githubusercontent.com/assets/20839661/23907025/d2b67d3a-08f5-11e7-9bdd-9c02f65f9acd.png)