### PR TITLE
fix: Username field (EditText) in the Log In Activity should ignore trailing spaces of the value entered by the user

### DIFF
--- a/app/src/main/java/org/mifos/selfserviceapp/presenters/LoginPresenter.java
+++ b/app/src/main/java/org/mifos/selfserviceapp/presenters/LoginPresenter.java
@@ -161,7 +161,7 @@ public class LoginPresenter extends BasePresenter<LoginView> {
     private boolean isCredentialsValid(final String username, final String password) {
 
         final Resources resources = context.getResources();
-
+        final String correctUsername = username.replaceFirst("\\s++$", "").trim();
         if (username == null || username.trim().isEmpty()) {
             showEmptyInputError(context.getString(R.string.username));
             return false;
@@ -169,10 +169,10 @@ public class LoginPresenter extends BasePresenter<LoginView> {
             showMinimumInputLengthNotAchievedError(resources.getString(R.string.username),
                     resources.getInteger(R.integer.username_minimum_length));
             return false;
-        } else if (username.contains(" ")) {
+        } else if (correctUsername.contains(" ")) {
             getMvpView().showMessage(context.getString(
                     R.string.error_validation_cannot_contain_spaces,
-                    username, context.getString(R.string.not_contain_username)));
+                    correctUsername, context.getString(R.string.not_contain_username)));
             return false;
         } else if (password == null || password.trim().isEmpty()) {
             showEmptyInputError(context.getString(R.string.password));


### PR DESCRIPTION
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.

**Before fixing the issue**

![screenshot_20170316-173733](https://cloud.githubusercontent.com/assets/20839661/24035876/3c337906-0b1d-11e7-9903-34e03dd64b3b.png)

Here, we can clearly see that the trailing spaces are being read which should be ideally ignored in the username field. Only spaces entered in between the value entered by the user should be read and the corresponding error message should be displayed.

**After fixing the issue**

![screenshot_20170317-142006](https://cloud.githubusercontent.com/assets/20839661/24035908/66097848-0b1d-11e7-8d14-7ad7c0143835.png)

Here, only the space entered in between the username field is read while the trailing spaces are ignored, as expected.

And in the below screenshots we can see that the trailing spaces in the username is being ignored and the user is able to log in successfully.

![screenshot_20170317-143303](https://cloud.githubusercontent.com/assets/20839661/24036276/db46833e-0b1e-11e7-80c5-1112d2e08377.png)

![screenshot_20170317-143307](https://cloud.githubusercontent.com/assets/20839661/24036277/db4e5b22-0b1e-11e7-9041-ffe10bf6c106.png)
