### PR TITLE
fix: remove menuitem from Saving Account Transaction activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,6 +39,7 @@
             android:name=".ui.activities.SavingsAccountContainerActivity"
             android:label="@string/saving_account_details"
             android:screenOrientation="portrait"/>
+        <activity android:name=".ui.activities.SavingsAccountTransactionContainerActivity"/>
 
         <activity android:name=".ui.activities.LoanAccountContainerActivity"/>
 

--- a/app/src/main/java/org/mifos/selfserviceapp/ui/activities/SavingsAccountContainerActivity.java
+++ b/app/src/main/java/org/mifos/selfserviceapp/ui/activities/SavingsAccountContainerActivity.java
@@ -1,5 +1,6 @@
 package org.mifos.selfserviceapp.ui.activities;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -8,7 +9,6 @@ import android.view.MenuItem;
 import org.mifos.selfserviceapp.R;
 import org.mifos.selfserviceapp.ui.activities.base.BaseActivity;
 import org.mifos.selfserviceapp.ui.fragments.SavingAccountsDetailFragment;
-import org.mifos.selfserviceapp.ui.fragments.SavingAccountsTransactionFragment;
 import org.mifos.selfserviceapp.utils.Constants;
 
 /**
@@ -38,10 +38,12 @@ public class SavingsAccountContainerActivity extends BaseActivity {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
+        Intent intent;
         switch (item.getItemId()) {
             case R.id.item_transactions:
-                replaceFragment(SavingAccountsTransactionFragment.newInstance(savingsId),
-                        true, R.id.container);
+                intent = new Intent(this, SavingsAccountTransactionContainerActivity.class);
+                intent.putExtra(Constants.SAVINGS_ID, savingsId);
+                startActivity(intent);
                 break;
         }
         return super.onOptionsItemSelected(item);

--- a/app/src/main/java/org/mifos/selfserviceapp/ui/activities/SavingsAccountTransactionContainerActivity.java
+++ b/app/src/main/java/org/mifos/selfserviceapp/ui/activities/SavingsAccountTransactionContainerActivity.java
@@ -1,0 +1,28 @@
+package org.mifos.selfserviceapp.ui.activities;
+
+import android.os.Bundle;
+
+import org.mifos.selfserviceapp.R;
+import org.mifos.selfserviceapp.ui.activities.base.BaseActivity;
+import org.mifos.selfserviceapp.ui.fragments.SavingAccountsTransactionFragment;
+import org.mifos.selfserviceapp.utils.Constants;
+
+/**
+ * Created by AMIT on 22-Mar-17.
+ */
+
+public class SavingsAccountTransactionContainerActivity extends BaseActivity {
+
+    private long savingsId;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_container);
+        savingsId = getIntent().getExtras().getLong(Constants.SAVINGS_ID);
+        replaceFragment(SavingAccountsTransactionFragment.newInstance(savingsId), false,
+                R.id.container);
+        showBackButton();
+    }
+}
+


### PR DESCRIPTION
Fixes #218      Remove Transaction menuitem from Saving Account Transaction activity as we are already in Saving Account Transaction Activity.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.