### PR TITLE
fix: amount section in TRANSFER fragment can accept .(dot or decimal)  without any number written before and after the decimal and causes the app to crash

### DIFF
--- a/app/src/main/java/org/mifos/selfserviceapp/ui/fragments/SavingsMakeTransferFragment.java
+++ b/app/src/main/java/org/mifos/selfserviceapp/ui/fragments/SavingsMakeTransferFragment.java
@@ -119,6 +119,11 @@ public class SavingsMakeTransferFragment extends BaseFragment implements
             return;
         }
 
+        if (etAmount.getText().toString().equals(".")) {
+            showToaster(getString(R.string.invalid_amount));
+            return;
+        }
+
         if (etRemark.getText().toString().equals("")) {
             showToaster(getString(R.string.remark_is_mandatory));
             return;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -196,5 +196,6 @@
     <!--Format Strings-->
     <string name="double_and_String">%1$.2f%2$s</string>
     <string name="string_and_string">%1$s%2$s</string>
+    <string name="invalid_amount">Invalid Amount</string>
 
 </resources>


### PR DESCRIPTION
Fixes #256  Amount section in TRANSFER fragment can accept .(dot or decimal)  without any number written before and after the decimal and causes the app to crash

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.