### PR TITLE
fix: remove transactions menu item on transactions fragment

### DIFF
--- a/app/src/main/java/org/mifos/selfserviceapp/ui/fragments/SavingAccountsTransactionFragment.java
+++ b/app/src/main/java/org/mifos/selfserviceapp/ui/fragments/SavingAccountsTransactionFragment.java
@@ -9,7 +9,6 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.Menu;
-import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
@@ -122,6 +121,7 @@ public class SavingAccountsTransactionFragment extends BaseFragment
         MenuItem item = menu.findItem(R.id.item_transactions);
         item.setVisible(false);
     }
+
     @Override
     public void showUserInterface() {
         LinearLayoutManager layoutManager = new LinearLayoutManager(getActivity());

--- a/app/src/main/java/org/mifos/selfserviceapp/ui/fragments/SavingAccountsTransactionFragment.java
+++ b/app/src/main/java/org/mifos/selfserviceapp/ui/fragments/SavingAccountsTransactionFragment.java
@@ -8,6 +8,9 @@ import android.support.v4.app.DialogFragment;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
@@ -95,6 +98,7 @@ public class SavingAccountsTransactionFragment extends BaseFragment
         if (getArguments() != null) {
             savingsId = getArguments().getLong(Constants.SAVINGS_ID);
         }
+        setHasOptionsMenu(true);
     }
 
     @Nullable
@@ -113,6 +117,11 @@ public class SavingAccountsTransactionFragment extends BaseFragment
         return rootView;
     }
 
+    @Override
+    public void onPrepareOptionsMenu(Menu menu) {
+        MenuItem item = menu.findItem(R.id.item_transactions);
+        item.setVisible(false);
+    }
     @Override
     public void showUserInterface() {
         LinearLayoutManager layoutManager = new LinearLayoutManager(getActivity());


### PR DESCRIPTION

Transactions menu item is also visible in the transactions fragment itself. Remove the menu item when in savings account transactions fragment.

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.