### PR TITLE
fix:savings account status colors

### DIFF
--- a/app/src/main/java/org/mifos/selfserviceapp/models/accounts/savings/Status.java
+++ b/app/src/main/java/org/mifos/selfserviceapp/models/accounts/savings/Status.java
@@ -46,6 +46,22 @@ public class Status implements Parcelable {
     @SerializedName("matured")
     Boolean matured;
 
+    public Boolean getPrematureClosed() {
+        return prematureClosed;
+    }
+
+    public void setPrematureClosed(Boolean prematureClosed) {
+        this.prematureClosed = prematureClosed;
+    }
+
+    public Boolean getMatured() {
+        return matured;
+    }
+
+    public void setMatured(Boolean matured) {
+        this.matured = matured;
+    }
+
     public Integer getId() {
         return id;
     }

--- a/app/src/main/java/org/mifos/selfserviceapp/ui/adapters/SavingAccountsListAdapter.java
+++ b/app/src/main/java/org/mifos/selfserviceapp/ui/adapters/SavingAccountsListAdapter.java
@@ -74,10 +74,13 @@ public class SavingAccountsListAdapter extends RecyclerView.Adapter<RecyclerView
                 ((ViewHolder) holder).iv_status_indicator.setImageDrawable(
                         Utils.setCircularBackground(R.color.light_yellow, context));
 
+            } else if (savingAccount.getStatus().getMatured()) {
+                ((ViewHolder) holder).iv_status_indicator.setImageDrawable(
+                        Utils.setCircularBackground(R.color.red_light, context));
             } else {
 
                 ((ViewHolder) holder).iv_status_indicator.setImageDrawable(
-                        Utils.setCircularBackground(R.color.light_blue, context));
+                        Utils.setCircularBackground(R.color.black, context));
 
             }
 

--- a/app/src/main/java/org/mifos/selfserviceapp/ui/fragments/SavingAccountsDetailFragment.java
+++ b/app/src/main/java/org/mifos/selfserviceapp/ui/fragments/SavingAccountsDetailFragment.java
@@ -195,6 +195,10 @@ public class SavingAccountsDetailFragment extends BaseFragment implements Saving
             ivCircularStatus.setImageDrawable(
                     Utils.setCircularBackground(R.color.light_yellow, getActivity()));
             tvAccountStatus.setText(R.string.pending);
+        } else if (status.getMatured()) {
+            ivCircularStatus.setImageDrawable(
+                    Utils.setCircularBackground(R.color.red_light, getActivity()));
+            tvAccountStatus.setText(R.string.matured);
         } else {
             ivCircularStatus.setImageDrawable(
                     Utils.setCircularBackground(R.color.black, getActivity()));

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,6 +72,7 @@
     <string name="closed">Closed</string>
     <string name="need_approval">Need Approval</string>
     <string name="pending">Pending</string>
+    <string name="matured">Matured</string>
 
     <string name="empty_savings_accounts">Their is no SavingsAccount associated with you</string>
     <string name="empty_loan_accounts">Their is no LoanAccount associated with you</string>


### PR DESCRIPTION
Fixes #297 

<img src="https://cloud.githubusercontent.com/assets/12071739/26695225/b728a1ea-4727-11e7-8c43-fc7bdd368d22.png" width="250" height="450"/>

In Mifos X Client, prematureClosed and closed accounts are set to black and matured accounts are set to red, so made changes accordingly.   

<img src="https://cloud.githubusercontent.com/assets/12071739/26695285/fe6acdb2-4727-11e7-8831-c8c88f479543.png" />

<img src="https://cloud.githubusercontent.com/assets/12071739/26696191/26289df4-472b-11e7-852d-5f6a1885c4c7.png" />

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `MifosStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.