### PR TITLE
fix: Transfer Screens accepting '0' as Amount

### DIFF
--- a/app/src/main/java/org/mifos/selfserviceapp/ui/fragments/SavingsMakeTransferFragment.java
+++ b/app/src/main/java/org/mifos/selfserviceapp/ui/fragments/SavingsMakeTransferFragment.java
@@ -315,6 +315,11 @@ public class SavingsMakeTransferFragment extends BaseFragment implements
             return;
         }
 
+        if (etAmount.getText().toString().matches("^0*")) {
+            showToaster(getString(R.string.amount_greater_than_zero));
+            return;
+        }
+
         pvThree.setCurrentCompeleted();
         pvFour.setCurrentActive();
 

--- a/app/src/main/java/org/mifos/selfserviceapp/ui/fragments/ThirdPartyTransferFragment.java
+++ b/app/src/main/java/org/mifos/selfserviceapp/ui/fragments/ThirdPartyTransferFragment.java
@@ -254,6 +254,11 @@ public class ThirdPartyTransferFragment extends BaseFragment implements ThirdPar
             return;
         }
 
+        if (etAmount.getText().toString().matches("^0*")) {
+            showToaster(getString(R.string.amount_greater_than_zero));
+            return;
+        }
+
         pvThree.setCurrentCompeleted();
         pvFour.setCurrentActive();
 

--- a/app/src/main/java/org/mifos/selfserviceapp/utils/Toaster.java
+++ b/app/src/main/java/org/mifos/selfserviceapp/utils/Toaster.java
@@ -1,8 +1,10 @@
 package org.mifos.selfserviceapp.utils;
 
+import android.content.Context;
 import android.graphics.Color;
 import android.support.design.widget.Snackbar;
 import android.view.View;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.TextView;
 
 import org.mifos.selfserviceapp.MifosSelfServiceApp;
@@ -14,6 +16,9 @@ public class Toaster {
     public static final int SHORT = Snackbar.LENGTH_SHORT;
 
     public static void show(View view, String text, int duration) {
+        InputMethodManager imm = (InputMethodManager) MifosSelfServiceApp.getContext().
+                getSystemService(Context.INPUT_METHOD_SERVICE);
+        imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
         final Snackbar snackbar = Snackbar.make(view, text, duration);
         View sbView = snackbar.getView();
         TextView textView = (TextView) sbView.findViewById(android.support.design.R.id

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -266,6 +266,7 @@
     <string name="save">Save</string>
     <string name="passcode_setup">Setup a passcode to login</string>
     <string name="forgot_passcode">Forgot passcode, login manually</string>
+    <string name="amount_greater_than_zero">Amount should be greater than zero</string>
 
     <!--Customer care details-->
     <string name="need_help">Contact Us</string>


### PR DESCRIPTION
Fixes #186 
I have also added : 
```
InputMethodManager imm = (InputMethodManager) MifosSelfServiceApp.getContext(). getSystemService(Context.INPUT_METHOD_SERVICE);
imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
```
which hides keyboard(if any) before displaying the snackbar.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.