### PR TITLE
fix:Blank toast on login

### DIFF
--- a/app/src/commonTest/java/org.mifos.selfserviceapp/RetrofitUtils.java
+++ b/app/src/commonTest/java/org.mifos.selfserviceapp/RetrofitUtils.java
@@ -1,0 +1,24 @@
+package org.mifos.selfserviceapp;
+
+import okhttp3.MediaType;
+import okhttp3.ResponseBody;
+import retrofit2.HttpException;
+import retrofit2.Response;
+
+/**
+ * Created by dilpreet on 29/7/17.
+ */
+
+public class RetrofitUtils {
+
+    public static Exception get404Exception() {
+        return new HttpException(Response.error(404, ResponseBody.create(MediaType.
+                parse("application/json"), "Not Found")));
+    }
+
+    public static Exception get401Exception() {
+        return new HttpException(Response.error(401, ResponseBody.create(MediaType.
+                parse("application/json"), "UnAuthorized")));
+    }
+
+}

--- a/app/src/main/java/org/mifos/selfserviceapp/presenters/LoginPresenter.java
+++ b/app/src/main/java/org/mifos/selfserviceapp/presenters/LoginPresenter.java
@@ -137,8 +137,16 @@ public class LoginPresenter extends BasePresenter<LoginView> {
 
                     @Override
                     public void onError(Throwable e) {
-                        getMvpView().showMessage(context.getString(R.string.error_fetching_client));
                         getMvpView().hideProgress();
+                        if (((HttpException) e).code() == 401) {
+                            getMvpView().showMessage(context.getString(R.string.
+                                    unauthorized_client));
+                        } else {
+                            getMvpView().showMessage(context.getString(R.string.
+                                    error_fetching_client));
+                        }
+                        preferencesHelper.clear();
+                        BaseApiManager.createService(preferencesHelper.getToken());
                     }
 
                     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -143,6 +143,7 @@
     <string name="error_deleting_beneficiary">Failed to delete Beneficiary</string>
     <string name="error_loan_account_withdraw">Error in withdrawing loan account</string>
     <string name="error_fetching_third_party_transfer_template">Error to fetch Third Party Transfer template</string>
+    <string name="unauthorized_client">You are not authorized</string>
 
     <string name="fetching_client">Fetching Client</string>
 

--- a/app/src/test/java/org/mifos/selfserviceapp/LoginPresenterTest.java
+++ b/app/src/test/java/org/mifos/selfserviceapp/LoginPresenterTest.java
@@ -101,9 +101,8 @@ public class LoginPresenterTest {
 
     @Test
     public void testLoadClientFails() throws Exception {
-        long clientId = clientPage.getPageItems().get(0).getId();
-        when(dataManager.getClients()).thenReturn(Observable.<Page<Client>>error(new
-                RuntimeException()));
+        when(dataManager.getClients()).thenReturn(Observable.<Page<Client>>error(RetrofitUtils.
+                get404Exception()));
 
         presenter.loadClient();
 
@@ -113,6 +112,18 @@ public class LoginPresenterTest {
         verify(view, never()).showPassCodeActivity();
     }
 
+    @Test
+    public void testLoadClientUnauthorized() throws Exception {
+        when(dataManager.getClients()).thenReturn(Observable.<Page<Client>>error(RetrofitUtils.
+                get401Exception()));
+
+        presenter.loadClient();
+
+        verify(view).showProgress();
+        verify(view).hideProgress();
+        verify(view).showMessage(context.getString(R.string.unauthorized_client));
+        verify(view, never()).showPassCodeActivity();
+    }
     @After
     public void tearDown() throws Exception {
         presenter.detachView();


### PR DESCRIPTION
Fixes #213

On logging in with `Mifos` and `password` we are not authorized to fetch client using the self service apis due to which it returns 401 and if we try to login again we were presented with a blank toast which was happening due to the presence of `Mifos` token in `BaseApiManager` so there was a need to clean the preference and reset the `BaseApiManager` also.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.