### PR TITLE
fix:Opens Gmail on clicking contact email on home screen

### DIFF
--- a/app/src/main/res/layout/fragment_home_old.xml
+++ b/app/src/main/res/layout/fragment_home_old.xml
@@ -353,6 +353,7 @@
                         android:layout_marginTop="@dimen/divider_margin"
                         android:textAppearance="@style/Base.TextAppearance.AppCompat.Medium"/>
                     <TextView
+                        android:autoLink="email"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:text="@string/contact_email"


### PR DESCRIPTION
Fixes #538 
The contact email on clicking now opens in Gmail.

Home Screen after changes

![whatsapp image 2018-01-20 at 12 17 21 am](https://user-images.githubusercontent.com/25136650/35166306-7369c09a-fd77-11e7-9792-6486f2a0a9a3.jpeg)

Clicking on email takes user to gmail

![whatsapp image 2018-01-20 at 12 17 21 am 1](https://user-images.githubusercontent.com/25136650/35166338-8d4e9fb2-fd77-11e7-836e-bbf7b744c4ea.jpeg)

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.