### PR TITLE
Fix #625 : Transfer and 3rd party transfer confirmation fragment is scrollable till the bottom

### DIFF
--- a/app/src/main/res/layout/fragment_transfer_process.xml
+++ b/app/src/main/res/layout/fragment_transfer_process.xml
@@ -4,12 +4,12 @@
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:layout_margin="@dimen/login_padding_left">
     <LinearLayout
         android:orientation="vertical"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_margin="@dimen/login_padding_left">
+        android:layout_height="match_parent">
         <android.support.v7.widget.CardView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"


### PR DESCRIPTION
Fixes #625 

![scroll_pr](https://user-images.githubusercontent.com/22195621/36241152-7ee126f2-123a-11e8-9b84-94b60a2e7541.gif)


- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.