### PR TITLE
Fix #704: Allow spaces in between the password but don't allow in start and end of the password

### DIFF
--- a/app/src/main/java/org/mifos/mobilebanking/presenters/LoginPresenter.java
+++ b/app/src/main/java/org/mifos/mobilebanking/presenters/LoginPresenter.java
@@ -186,7 +186,7 @@ public class LoginPresenter extends BasePresenter<LoginView> {
                     R.string.error_validation_cannot_contain_spaces,
                     correctUsername, context.getString(R.string.not_contain_username)));
             return false;
-        } else if (password == null || password.matches("\\s*") || password.isEmpty()) {
+        } else if (password == null || password.isEmpty()) {
             getMvpView().showPasswordError(context.getString(R.string.error_validation_blank,
                     context.getString(R.string.password)));
             return false;

--- a/app/src/main/java/org/mifos/mobilebanking/ui/fragments/RegistrationFragment.java
+++ b/app/src/main/java/org/mifos/mobilebanking/ui/fragments/RegistrationFragment.java
@@ -134,6 +134,12 @@ public class RegistrationFragment extends BaseFragment implements RegistrationVi
             Toaster.show(rootView, getString(R.string.error_validation_blank, getString(R.string.
                     password)));
             return false;
+        } else if (etPassword.getText().toString().trim().length()
+                                        < etPassword.getText().toString().length()) {
+            Toaster.show(rootView,
+                    getString(R.string.error_validation_cannot_contain_leading_or_trailing_spaces,
+                    getString(R.string.password)));
+            return false;
         } else if (etUsername.getText().length() < 6) {
             Toaster.show(rootView, getString(R.string.error_username_greater_than_six));
             return false;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -133,6 +133,7 @@
     <string name="error_validation_blank">%1$s cannot be blank</string>
     <string name="error_validation_minimum_chars">%1$s cannot be less than %2$d characters</string>
     <string name="error_validation_cannot_contain_spaces">%1$s cannot contain %2$s</string>
+    <string name="error_validation_cannot_contain_leading_or_trailing_spaces">%1$s cannot begin or end with blank space</string>
     <string name="error_internal_server">Error in internal server, please try again</string>
     <string name="error_client_loading">Error loading client list</string>
     <string name="error_loan_accounts_list_loading">Error loading in loan accounts list</string>


### PR DESCRIPTION
Fixes #704 

![pr_space_in_password](https://user-images.githubusercontent.com/22195621/37137556-45379bd2-22cc-11e8-8553-ade733b2e7b1.png)


- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.