### PR TITLE
Fix #723 : Added check for Empty Remark during Loan Withdrawal

### DIFF
--- a/app/src/main/java/org/mifos/mobilebanking/ui/fragments/LoanAccountWithdrawFragment.java
+++ b/app/src/main/java/org/mifos/mobilebanking/ui/fragments/LoanAccountWithdrawFragment.java
@@ -92,11 +92,13 @@ public class LoanAccountWithdrawFragment extends BaseFragment implements LoanAcc
      */
     @OnClick(R.id.btn_withdraw_loan)
     public void onLoanWithdraw() {
-        LoanWithdraw loanWithdraw = new LoanWithdraw();
-        loanWithdraw.setNote(etWithdrawReason.getText().toString());
-        loanWithdraw.setWithdrawnOnDate(DateHelper
-                .getDateAsStringFromLong(System.currentTimeMillis()));
-        loanAccountWithdrawPresenter.withdrawLoanAccount(loanAccount.getId(), loanWithdraw);
+        if (isFieldsValid()) {
+            LoanWithdraw loanWithdraw = new LoanWithdraw();
+            loanWithdraw.setNote(etWithdrawReason.getText().toString().trim());
+            loanWithdraw.setWithdrawnOnDate(DateHelper
+                    .getDateAsStringFromLong(System.currentTimeMillis()));
+            loanAccountWithdrawPresenter.withdrawLoanAccount(loanAccount.getId(), loanWithdraw);
+        }
     }
 
     /**
@@ -126,6 +128,15 @@ public class LoanAccountWithdrawFragment extends BaseFragment implements LoanAcc
     @Override
     public void hideProgress() {
         hideProgressBar();
+    }
+
+    public boolean isFieldsValid() {
+        if (etWithdrawReason.getText().toString().trim().length() == 0) {
+            Toaster.show(rootView, getResources().getString(R.string.error_validation_blank,
+                    getResources().getString(R.string.reason_of_withdrawal)));
+            return false;
+        }
+        return true;
     }
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -130,6 +130,7 @@
     <string name="guarantor_details">Guarantor Details</string>
     <string name="joined_date">Joined Date</string>
     <string name="submit">Submit</string>
+    <string name="reason_of_withdrawal">Reason of Withdrawal</string>
 
     <string name="account_not_active_to_perform_deposit">Account should to be Active to perform a
         deposit


### PR DESCRIPTION
Fixes #723 

![pr_no_check_for_withdrawal](https://user-images.githubusercontent.com/22195621/37339072-78862ea6-26df-11e8-8604-aa3aa01d7ad7.gif)


- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.