### PR TITLE
Fix #794 : User Profile directly shows Username

### DIFF
--- a/app/src/main/res/layout/fragment_user_profile.xml
+++ b/app/src/main/res/layout/fragment_user_profile.xml
@@ -31,6 +31,7 @@
                 android:background="@drawable/scrim"/>
             <android.support.v7.widget.Toolbar
                 android:id="@+id/toolbar"
+                app:title="@string/blank"
                 android:layout_height="?attr/actionBarSize"
                 android:layout_width="match_parent"
                 android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,6 +116,7 @@
     <string name="rb_mobile">mobile</string>
     <string name="rb_email">email</string>
     <string name="verification_mode">Verification Mode</string>
+    <string name="blank">&#160;</string>
 
     <string name="account_not_active_to_perform_deposit">Account should to be Active to perform a
         deposit


### PR DESCRIPTION
Fixes #794 


![pr_user_profile](https://user-images.githubusercontent.com/22195621/38211477-3340f570-36d8-11e8-95ce-24b85e6c6bc5.gif)


- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.