### PR TITLE
Fix #806 : Replaced Dialog Spinner in Add Beneficiary

### DIFF
--- a/app/src/main/res/layout/fragment_beneficiary_application.xml
+++ b/app/src/main/res/layout/fragment_beneficiary_application.xml
@@ -30,8 +30,7 @@
                 android:layout_height="wrap_content"
                 android:paddingBottom="@dimen/default_margin"
                 android:paddingTop="@dimen/default_margin"
-                style="@style/Widget.AppCompat.Spinner.Underlined"
-                android:spinnerMode="dialog"/>
+                style="@style/Widget.AppCompat.Spinner.Underlined" />
 
             <android.support.design.widget.TextInputLayout
                 android:layout_width="match_parent"


### PR DESCRIPTION
Fixes #806 

![pr_806](https://user-images.githubusercontent.com/22195621/38958773-da7a1d9e-437b-11e8-9b1b-22012d9c49a8.gif)

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.