### PR TITLE
Fix #847: Username and Image should be shown when Internet is not there in Home Fragment.

### DIFF
--- a/app/src/main/java/org/mifos/mobilebanking/ui/activities/HomeActivity.java
+++ b/app/src/main/java/org/mifos/mobilebanking/ui/activities/HomeActivity.java
@@ -106,6 +106,7 @@ public class HomeActivity extends BaseActivity implements UserDetailsView, Navig
 
         if (savedInstanceState == null) {
             detailsPresenter.attachView(this);
+            tvUsername.setText(preferencesHelper.getUserName());
             detailsPresenter.getUserDetails();
             detailsPresenter.getUserImage();
             showUserImage(null);

--- a/app/src/main/java/org/mifos/mobilebanking/ui/activities/LoginActivity.java
+++ b/app/src/main/java/org/mifos/mobilebanking/ui/activities/LoginActivity.java
@@ -9,6 +9,7 @@ import android.widget.LinearLayout;
 import android.widget.Toast;
 
 import org.mifos.mobilebanking.R;
+import org.mifos.mobilebanking.api.local.PreferencesHelper;
 import org.mifos.mobilebanking.presenters.LoginPresenter;
 import org.mifos.mobilebanking.ui.activities.base.BaseActivity;
 import org.mifos.mobilebanking.ui.views.LoginView;
@@ -63,6 +64,8 @@ public class LoginActivity extends BaseActivity implements LoginView {
     @Override
     public void onLoginSuccess(String userName) {
         this.userName = userName;
+        PreferencesHelper preferencesHelper = new PreferencesHelper(this);
+        preferencesHelper.setUserName(userName);
         loginPresenter.loadClient();
     }
 

--- a/app/src/main/java/org/mifos/mobilebanking/ui/fragments/HomeOldFragment.java
+++ b/app/src/main/java/org/mifos/mobilebanking/ui/fragments/HomeOldFragment.java
@@ -205,6 +205,8 @@ public class HomeOldFragment extends BaseFragment implements HomeOldView,
     }
 
     private void loadClientData() {
+        tvSavingTotalAmount.setText("N/A");
+        tvLoanTotalAmount.setText("N/A");
         presenter.loadClientAccountDetails();
         presenter.getUserDetails();
         presenter.getUserImage();


### PR DESCRIPTION
Description:

I've stored the entered username while login in the prefrenceHelper.java and set the navigational username initially from prefrenceHelper, set the totalLoanAmount and totalSavingsAmount to "N/A" just before the API call and so in case of slow internet user won't see empty textView and the shared prefs and data on the fields will update, when the response from the Server is fetched.

#Issue_Number : #847 
Username and Image should be shown when the Internet is not there in Home Fragment.

Screenshots.

![screenshot_1535541506](https://user-images.githubusercontent.com/32436867/44785056-3ca5f080-abad-11e8-990b-7c05f415f897.png)

![screenshot_1535541502](https://user-images.githubusercontent.com/32436867/44785065-47608580-abad-11e8-84fc-d916c6ccf482.png)

