### PR TITLE
Switched order of jcenter() / google() references

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
         maven { url "https://www.jitpack.io" }
         maven { url 'https://maven.fabric.io/public' }
     }


### PR DESCRIPTION
Switching the order of the references helps prevent Gradle build issues when trying to reference certain support libraries.