### PR TITLE
Fix #898: Submission/Disbursement date pickers

### DIFF
--- a/app/src/main/java/org/mifos/mobilebanking/ui/fragments/LoanApplicationFragment.java
+++ b/app/src/main/java/org/mifos/mobilebanking/ui/fragments/LoanApplicationFragment.java
@@ -102,8 +102,7 @@ public class LoanApplicationFragment extends BaseFragment implements LoanApplica
     private int purposeId;
     private String disbursementDate;
     private String submittedDate;
-    private boolean isDisbursebemntDate = false;
-    private boolean isSubmissionDate = false;
+    private boolean isDisbursementDate = false;
     private boolean isLoanUpdatePurposesInitialization = true;
 
 
@@ -295,7 +294,6 @@ public class LoanApplicationFragment extends BaseFragment implements LoanApplica
      * Initializes {@code tvSubmissionDate} with current Date
      */
     public void inflateSubmissionDate() {
-        mfDatePicker = MFDatePicker.newInsance(this);
         tvSubmissionDate.setText(MFDatePicker.getDatePickedAsString());
     }
 
@@ -303,7 +301,7 @@ public class LoanApplicationFragment extends BaseFragment implements LoanApplica
      * Initializes {@code tvExpectedDisbursementDate} with current Date
      */
     public void inflateDisbursementDate() {
-        mfDatePicker = MFDatePicker.newInsance(this);
+        mfDatePicker = MFDatePicker.newInstance(this, MFDatePicker.FUTURE_DAYS);
         tvExpectedDisbursementDate.setText(MFDatePicker.getDatePickedAsString());
     }
 
@@ -323,17 +321,7 @@ public class LoanApplicationFragment extends BaseFragment implements LoanApplica
      */
     @OnClick(R.id.ll_expected_disbursement_date_edit)
     public void setTvDisbursementOnDate() {
-        isDisbursebemntDate = true;
-        mfDatePicker.show(getActivity().getSupportFragmentManager(), Constants
-                .DFRAG_DATE_PICKER);
-    }
-
-    /**
-     * Shows a {@link DialogFragment} for selecting a Date for Submission
-     */
-    @OnClick(R.id.ll_submission_date_edit)
-    public void setTvSubmittedOnDate() {
-        isSubmissionDate = true;
+        isDisbursementDate = true;
         mfDatePicker.show(getActivity().getSupportFragmentManager(), Constants
                 .DFRAG_DATE_PICKER);
     }
@@ -345,16 +333,10 @@ public class LoanApplicationFragment extends BaseFragment implements LoanApplica
      */
     @Override
     public void onDatePicked(String date) {
-        if (isSubmissionDate) {
-            tvSubmissionDate.setText(date);
-            submittedDate = date;
-            isSubmissionDate = false;
-        }
-
-        if (isDisbursebemntDate) {
+        if (isDisbursementDate) {
             tvExpectedDisbursementDate.setText(date);
             disbursementDate = date;
-            isDisbursebemntDate = false;
+            isDisbursementDate = false;
         }
         setSubmissionDisburseDate();
     }

--- a/app/src/main/java/org/mifos/mobilebanking/ui/fragments/SavingAccountsTransactionFragment.java
+++ b/app/src/main/java/org/mifos/mobilebanking/ui/fragments/SavingAccountsTransactionFragment.java
@@ -145,7 +145,7 @@ public class SavingAccountsTransactionFragment extends BaseFragment
         rvSavingAccountsTransaction.setAdapter(transactionListAdapter);
 
         radioGroup.setOnCheckedChangeListener(this);
-        mfDatePicker = MFDatePicker.newInsance(this);
+        mfDatePicker = MFDatePicker.newInstance(this, MFDatePicker.ALL_DAYS);
     }
 
     /**
@@ -232,7 +232,6 @@ public class SavingAccountsTransactionFragment extends BaseFragment
     @OnClick(R.id.tv_end_date)
     public void endDatePick() {
         datePick = DatePick.END;
-        mfDatePicker.isStartOrEndDate(false);
         mfDatePicker.show(getActivity().getSupportFragmentManager(), Constants
                 .DFRAG_DATE_PICKER);
     }
@@ -337,8 +336,8 @@ public class SavingAccountsTransactionFragment extends BaseFragment
     private void filter(long startDate , long endDate) {
 
         dummyTransactionList = new ArrayList<>(transactionsList);
-        savingAccountsTransactionPresenter.filterTransactionList(dummyTransactionList ,
-                                                                    startDate , endDate);
+        savingAccountsTransactionPresenter.filterTransactionList(dummyTransactionList,
+                                                                    startDate, endDate);
     }
 
     @Override

--- a/app/src/main/java/org/mifos/mobilebanking/utils/Constants.java
+++ b/app/src/main/java/org/mifos/mobilebanking/utils/Constants.java
@@ -114,4 +114,6 @@ public class Constants {
     public static final String GUARANTOR_STATE = "guarantorState";
 
     public static final String INDEX = "index";
+
+    public static final String DATE_PICKER_TYPE = "datePickerType";
 }

--- a/app/src/main/java/org/mifos/mobilebanking/utils/MFDatePicker.java
+++ b/app/src/main/java/org/mifos/mobilebanking/utils/MFDatePicker.java
@@ -28,7 +28,12 @@ public class MFDatePicker extends DialogFragment implements DatePickerDialog.OnD
     static Calendar calendar;
     private String startDateString;
     private long startDate;
-    private boolean isStartOrEnd;
+    private int datePickerType = ALL_DAYS;
+
+    /* Constants used to select which type of date picker is being called */
+    public static final int PREVIOUS_DAYS = 1; // only past days
+    public static final int FUTURE_DAYS = 2; // only future days
+    public static final int ALL_DAYS = 3;  // any day can be picked
 
 
 
@@ -51,11 +56,17 @@ public class MFDatePicker extends DialogFragment implements DatePickerDialog.OnD
     OnDatePickListener onDatePickListener;
 
     public MFDatePicker() {
-        isStartOrEnd = true;
+
     }
 
-    public static MFDatePicker newInsance(Fragment fragment) {
+    public static MFDatePicker newInstance(Fragment fragment, int datePickerType) {
         MFDatePicker mfDatePicker = new MFDatePicker();
+
+        Bundle args = new Bundle();
+        args.putInt(Constants.DATE_PICKER_TYPE, datePickerType);
+
+        mfDatePicker.setArguments(args);
+
         mfDatePicker.onDatePickListener = (OnDatePickListener) fragment;
         return mfDatePicker;
     }
@@ -74,11 +85,17 @@ public class MFDatePicker extends DialogFragment implements DatePickerDialog.OnD
                 calendar.get(Calendar.MONTH),
                 calendar.get(Calendar.DAY_OF_MONTH));
 
-        if (isStartOrEnd) {
-            dialog.getDatePicker().setMaxDate(new Date().getTime());
-        } else {
-            dialog.getDatePicker().setMaxDate(new Date().getTime());
-            dialog.getDatePicker().setMinDate(startDate);
+        Bundle args = getArguments();
+        this.datePickerType = args.getInt(Constants.DATE_PICKER_TYPE, this.ALL_DAYS);
+
+        switch (datePickerType) {
+            case FUTURE_DAYS:
+                dialog.getDatePicker().setMinDate(new Date().getTime());
+                break;
+
+            case PREVIOUS_DAYS:
+                dialog.getDatePicker().setMaxDate(new Date().getTime());
+                break;
         }
         return dialog;
     }
@@ -101,10 +118,6 @@ public class MFDatePicker extends DialogFragment implements DatePickerDialog.OnD
 
     public interface OnDatePickListener {
         public void onDatePicked(String date);
-    }
-
-    public void isStartOrEndDate(boolean startOrEnd) {
-        isStartOrEnd = startOrEnd;
     }
 
 }

--- a/app/src/main/res/layout/fragment_add_loan_application.xml
+++ b/app/src/main/res/layout/fragment_add_loan_application.xml
@@ -155,11 +155,8 @@
                         android:id="@+id/tv_submission_date"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        android:layout_marginRight="30dp"
                         android:textAppearance="@style/Base.TextAppearance.AppCompat.Medium"/>
-                    <ImageView
-                        android:layout_width="30dp"
-                        android:layout_height="match_parent"
-                        app:srcCompat="@drawable/ic_edit_black_24dp"/>
                 </LinearLayout>
             </LinearLayout>
 


### PR DESCRIPTION
Fixes #898 

<img src='https://user-images.githubusercontent.com/6632800/47745063-b1afa800-dc7a-11e8-88d6-96669f03bc62.gif' height=640 width=360/>

![image](https://user-images.githubusercontent.com/6632800/48017525-5ff99880-e126-11e8-9102-ebc557bb9c6c.png)
_Updated (pencil was removed) - the rest is the same, look at the above gif_



- Submission Date is now not using a DatePicker because it should not be selectable
- Expected Disbursement Date is using a DatePicker where we can only choose the future and the current day
- Some grammar errors fixed in variables' names
- Created constants in **MFDatePicker** so that it supports the choice of what **type** of calendar we want to instantiate:
- - `ALL_DAYS` -> Any day can be selected
- - `STARTS_CURRENT_DAY` -> Days starting the current day can be selected
- - `ENDS_CURRENT_DAY` -> Days until current day can be selected
- - `ONLY_CURRENT_DAY` -> Only the current day can be selected
- Fixed all `newInstance(this)` cases where a new argument was needed - in this case, the constant.

Example of use:

`mfDatePicker = MFDatePicker.newInstance(this, MFDatePicker.ALL_DAYS);`


- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.