### PR TITLE
Fix #897: Username is shown as null on login

### DIFF
--- a/app/src/main/java/org/mifos/mobilebanking/models/User.kt
+++ b/app/src/main/java/org/mifos/mobilebanking/models/User.kt
@@ -11,7 +11,7 @@ data class User (
 
     var userId: Long = 0,
     var isAuthenticated: Boolean = false,
-    var userName: String? = null,
+    var username: String? = null,
     var base64EncodedAuthenticationKey: String? = null,
     var permissions: List<String> = ArrayList()
     )

--- a/app/src/main/java/org/mifos/mobilebanking/presenters/LoginPresenter.java
+++ b/app/src/main/java/org/mifos/mobilebanking/presenters/LoginPresenter.java
@@ -112,7 +112,7 @@ public class LoginPresenter extends BasePresenter<LoginView> {
                         @Override
                         public void onNext(User user) {
                             if (user != null) {
-                                final String userName = user.getUserName();
+                                final String userName = user.getUsername();
                                 final long userID = user.getUserId();
                                 final String authToken = Constants.BASIC +
                                         user.getBase64EncodedAuthenticationKey();

--- a/app/src/test/java/org/mifos/mobilebanking/LoginPresenterTest.java
+++ b/app/src/test/java/org/mifos/mobilebanking/LoginPresenterTest.java
@@ -72,7 +72,7 @@ public class LoginPresenterTest {
         presenter.login("selfservice", "password");
 
         verify(view).showProgress();
-        verify(view).onLoginSuccess(user.getUserName());
+        verify(view).onLoginSuccess(user.getUsername());
     }
 
     @Test


### PR DESCRIPTION
Fixes #897

The welcome toast shows the "Welcome" with the username, instead of "Welcome null". I solved the issue by addressing an error in the Retrofit implementation. The change helps Retrofit recognize the field properly.
![screenshot_20181023-215845](https://user-images.githubusercontent.com/24931732/47586893-38c8ed00-d916-11e8-9d05-20021dd8d9c3.png)