### PR TITLE
Fix: #894: Progress Bar shown on top of Input Fields

### DIFF
--- a/app/src/main/java/org/mifos/mobilebanking/presenters/BeneficiaryApplicationPresenter.java
+++ b/app/src/main/java/org/mifos/mobilebanking/presenters/BeneficiaryApplicationPresenter.java
@@ -1,6 +1,7 @@
 package org.mifos.mobilebanking.presenters;
 
 import android.content.Context;
+import android.view.View;
 
 import org.mifos.mobilebanking.R;
 import org.mifos.mobilebanking.api.DataManager;
@@ -57,6 +58,7 @@ public class BeneficiaryApplicationPresenter extends BasePresenter<BeneficiaryAp
      */
     public void loadBeneficiaryTemplate() {
         checkViewAttached();
+        getMvpView().setVisibility(View.GONE);
         getMvpView().showProgress();
         compositeDisposable.add(dataManager.getBeneficiaryTemplate()
                 .observeOn(AndroidSchedulers.mainThread())
@@ -64,7 +66,7 @@ public class BeneficiaryApplicationPresenter extends BasePresenter<BeneficiaryAp
                 .subscribeWith(new DisposableObserver<BeneficiaryTemplate>() {
                     @Override
                     public void onComplete() {
-
+                        getMvpView().setVisibility(View.VISIBLE);
                     }
 
                     @Override

--- a/app/src/main/java/org/mifos/mobilebanking/ui/fragments/BeneficiaryApplicationFragment.java
+++ b/app/src/main/java/org/mifos/mobilebanking/ui/fragments/BeneficiaryApplicationFragment.java
@@ -318,6 +318,11 @@ public class BeneficiaryApplicationFragment extends BaseFragment implements
     }
 
     @Override
+    public void setVisibility(int state) {
+        llApplicationBeneficiary.setVisibility(state);
+    }
+
+    @Override
     public void showProgress() {
         showProgressBar();
     }

--- a/app/src/main/java/org/mifos/mobilebanking/ui/views/BeneficiaryApplicationView.java
+++ b/app/src/main/java/org/mifos/mobilebanking/ui/views/BeneficiaryApplicationView.java
@@ -18,4 +18,6 @@ public interface BeneficiaryApplicationView extends MVPView {
     void showBeneficiaryUpdatedSuccessfully();
 
     void showError(String msg);
+
+    void setVisibility(int state);
 }


### PR DESCRIPTION
Fixes #894

My solution makes sure that the progress bar is never laid on top of the UI. I achieved this functionality by hiding the UI, whenever the loading spinner is been called to show its progress, and then redisplaying the UI after the UI has loaded up.

![image](https://user-images.githubusercontent.com/24931732/47611001-79109400-da18-11e8-8fb0-7db2a3f68964.png)


