### PR TITLE
Docs: Updated README to reflect project

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,20 @@
 [![Join the chat at https://gitter.im/openMF/self-service-app](https://badges.gitter.im/openMF/self-service-app.svg)](https://gitter.im/openMF/self-service-app?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/openMF/mifos-mobile.svg?branch=development)](https://travis-ci.org/openMF/mifos-mobile)
 
+![App Screenshots](https://user-images.githubusercontent.com/24931732/48102172-b0ccc800-e1de-11e8-9fb9-17c41234636e.png)
+
 # Self Service Android Application for MifosX
 
-This is an Android Application built on top of the MifosX Self-Service platform for end-user customers to view/transact on the accounts and loans they hold. Data visible to Customers will be a sub-set of what Staff can see. This is a native Android Application written purely in Java.
+An Android Application built on top of the MifosX Self-Service platform for end-user customers to view/transact on the accounts and loans they hold. Data visible to customers will be a sub-set of what staff can see. This is a native Android Application written in Java with POJO classes in Kotlin.
 
-# Wiki
+## Contributing
+If you want to start contributing to the project, make sure to read the contributing guidelines [here](https://github.com/openMF/mifos-mobile/blob/development/.github/CONTRIBUTING.md).
 
-https://github.com/openMF/self-service-app/wiki
+## Wiki
 
-# Product Roadmap
+View the [wiki](https://github.com/openMF/self-service-app/wiki) to see pages that provide details on the project.
 
-https://github.com/openMF/self-service-app/wiki/Design-&-Requirements - Product Mockup
+## Specification
+
+See the [requirements](https://github.com/openMF/self-service-app/wiki/Design-&-Requirements) for an initial design mockup and documentation on the Fineract API.
 


### PR DESCRIPTION
Updated README to provide graphics of the app and writing that is more clear on the certain parts of the project. Described the difference between contributing and wiki and put quick-access hyperlinks on the README. Use of headers is now correct and existing status is uninterrupted. 