### PR TITLE
Fix #932: Snackbar pops on the FAB on deleting Beneficiary

### DIFF
--- a/app/src/main/java/org/mifos/mobilebanking/ui/fragments/BeneficiaryApplicationFragment.java
+++ b/app/src/main/java/org/mifos/mobilebanking/ui/fragments/BeneficiaryApplicationFragment.java
@@ -3,6 +3,7 @@ package org.mifos.mobilebanking.ui.fragments;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.design.widget.TextInputLayout;
+import android.support.v4.app.Fragment;
 import android.support.v4.widget.NestedScrollView;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -286,10 +287,12 @@ public class BeneficiaryApplicationFragment extends BaseFragment implements
      */
     @Override
     public void showBeneficiaryUpdatedSuccessfully() {
-        Toaster.show(rootView, getString(R.string.beneficiary_updated_successfully));
+        String className = BeneficiaryListFragment.class.getName();
+        Fragment fragment = getActivity().getSupportFragmentManager().findFragmentByTag(className);
+        BeneficiaryListFragment castedListFragment = (BeneficiaryListFragment) fragment;
+        castedListFragment.showSnackbar(getString(R.string.beneficiary_updated_successfully));
         getActivity().getSupportFragmentManager().popBackStack();
         getActivity().getSupportFragmentManager().popBackStack();
-
     }
 
 

--- a/app/src/main/java/org/mifos/mobilebanking/ui/fragments/BeneficiaryDetailFragment.java
+++ b/app/src/main/java/org/mifos/mobilebanking/ui/fragments/BeneficiaryDetailFragment.java
@@ -3,6 +3,7 @@ package org.mifos.mobilebanking.ui.fragments;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -150,7 +151,10 @@ public class BeneficiaryDetailFragment extends BaseFragment implements Beneficia
      */
     @Override
     public void showBeneficiaryDeletedSuccessfully() {
-        Toaster.show(rootView, getString(R.string.beneficiary_deleted_successfully));
+        String className = BeneficiaryListFragment.class.getName();
+        Fragment fragment = getActivity().getSupportFragmentManager().findFragmentByTag(className);
+        BeneficiaryListFragment castedListFragment = (BeneficiaryListFragment) fragment;
+        castedListFragment.showSnackbar(getString(R.string.beneficiary_deleted_successfully));
         getActivity().getSupportFragmentManager().popBackStack();
     }
 

--- a/app/src/main/java/org/mifos/mobilebanking/ui/fragments/BeneficiaryListFragment.java
+++ b/app/src/main/java/org/mifos/mobilebanking/ui/fragments/BeneficiaryListFragment.java
@@ -27,6 +27,7 @@ import org.mifos.mobilebanking.utils.Constants;
 import org.mifos.mobilebanking.utils.DividerItemDecoration;
 import org.mifos.mobilebanking.utils.Network;
 import org.mifos.mobilebanking.utils.RecyclerItemClickListener;
+import org.mifos.mobilebanking.utils.Toaster;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -65,7 +66,7 @@ public class BeneficiaryListFragment extends BaseFragment implements RecyclerIte
     private View rootView;
     private List<Beneficiary> beneficiaryList;
     private SweetUIErrorHandler sweetUIErrorHandler;
-
+    private String snackbarContent = null;
     public static BeneficiaryListFragment newInstance() {
         BeneficiaryListFragment fragment = new BeneficiaryListFragment();
         return fragment;
@@ -87,7 +88,6 @@ public class BeneficiaryListFragment extends BaseFragment implements RecyclerIte
         if (savedInstanceState == null) {
             beneficiaryListPresenter.loadBeneficiaries();
         }
-
         return rootView;
     }
 
@@ -134,6 +134,7 @@ public class BeneficiaryListFragment extends BaseFragment implements RecyclerIte
                 startActivity(new Intent(getActivity(), AddBeneficiaryActivity.class));
             }
         });
+        checkForSnackbarAndShow();
     }
 
 
@@ -240,6 +241,16 @@ public class BeneficiaryListFragment extends BaseFragment implements RecyclerIte
                 getString(R.string.beneficiary),
                 R.drawable.ic_beneficiaries_48px, rvBeneficiaries, layoutError);
         rvBeneficiaries.setVisibility(View.GONE);
+    }
+
+    public void showSnackbar(String content) {
+        snackbarContent = content;
+    }
+    public void checkForSnackbarAndShow() {
+        if (snackbarContent != null) {
+            Toaster.show(rootView, snackbarContent);
+            snackbarContent = null;
+        }
     }
 
 }


### PR DESCRIPTION
Fixes #932 

The bug was caused by the snackbar being a part of the wrong layout. Previously, the snackbar had been set to appear in the layout of a BeneficiaryDetailFragment. The snackbar would appear in the BeneficiaryDetailFragment, but the fragment would be quickly destroyed, as the work is done when the fragment is being destroyed. This leaves the snackbar to just "be there" and appear above any other UI elements.

My solution moves the snackbar to be a part of the BeneficiaryListFragment layout, the screen that lists out the beneficiaries and has the FAB. By doing this, the FAB is able to be aware of the snackbar and naturally moves up. I also implemented the same functionality for the "update beneficiary" action, as my solution scales to fix other cases of the issue. No more left out snackbars! 🍫🍬
  
![image](https://user-images.githubusercontent.com/24931732/48689121-e5953380-eb7d-11e8-910c-0e030a5b8a05.png)


