### PR TITLE
Fixed Groovy warnings

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -103,7 +103,7 @@ dependencies {
     implementation "com.jakewharton:butterknife:$rootProject.butterKnifeVersion"
     annotationProcessor "com.jakewharton:butterknife-compiler:$rootProject.butterKnifeVersion"
     implementation('com.crashlytics.sdk.android:crashlytics:2.6.7@aar') {
-        transitive = true;
+        transitive = true
     }
 
     //qr code

--- a/config/quality/quality.gradle
+++ b/config/quality/quality.gradle
@@ -18,7 +18,7 @@ dependencies {
     checkstyle 'com.puppycrawl.tools:checkstyle:6.5'
 }
 
-def qualityConfigDir = "$project.rootDir/config/quality";
+def qualityConfigDir = "$project.rootDir/config/quality"
 def reportsDir = "$project.buildDir/reports"
 
 check.dependsOn 'checkstyle', 'findbugs', 'pmd'


### PR DESCRIPTION
**Summary**
Fixes some part of the #940 
Fixed Groovy warnings ( 2 warnings )
Removed unnecessary semi-columns in `build.gradle` file and `quality.gradle` file

**Screenshots**
**Before fixing:**
![screenshot from 2019-01-29 15-50-28](https://user-images.githubusercontent.com/30550059/51906186-75aaf100-23e9-11e9-97d6-28aa829ed4df.png)

**After fixing:**
![screenshot from 2019-01-29 17-08-18](https://user-images.githubusercontent.com/30550059/51906189-79d70e80-23e9-11e9-84df-45640fdb5228.png)

**Changes**
Fixed Groovy warnings

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.