### PR TITLE
fix: currency before amount in savingaccountdetails

### DIFF
--- a/app/src/main/java/org/mifos/mobilebanking/ui/fragments/SavingAccountsDetailFragment.java
+++ b/app/src/main/java/org/mifos/mobilebanking/ui/fragments/SavingAccountsDetailFragment.java
@@ -233,9 +233,9 @@ public class SavingAccountsDetailFragment extends BaseFragment implements Saving
 
             if (savingsWithAssociations.getTransactions() != null &&
                     !savingsWithAssociations.getTransactions().isEmpty()) {
-                tvLastTransaction.setText(getString(R.string.double_and_string,
-                        savingsWithAssociations.getTransactions().get(0).getAmount(),
-                        currencySymbol));
+                tvLastTransaction.setText(getString(R.string.string_and_double,
+                        currencySymbol,
+                        savingsWithAssociations.getTransactions().get(0).getAmount()));
                 tvMadeOnTransaction.setText(DateHelper.getDateAsString(
                         savingsWithAssociations.getLastActiveTransactionDate()));
             } else {


### PR DESCRIPTION
Fixes #1081 
![screenshot_2019-03-02-22-13-40-879_org mifos mobilebanking](https://user-images.githubusercontent.com/38163725/53684845-ab206280-3d38-11e9-8e05-8dc7f10599bd.png)
- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.