### PR TITLE
Fix:#1075 SweetUIErrorHandler for Apply for Loan fragment

### DIFF
--- a/app/src/main/res/layout/fragment_add_loan_application.xml
+++ b/app/src/main/res/layout/fragment_add_loan_application.xml
@@ -209,6 +209,6 @@
     </android.support.v4.widget.NestedScrollView>
     <include
         android:visibility="gone"
-        android:id="@+id/ll_error"
-        layout="@layout/layout_error"/>
+        android:id="@+id/layout_error"
+        layout="@layout/layout_sweet_exception_handler"/>
 </RelativeLayout>


### PR DESCRIPTION
Fixes #1075
Implemented SweetUIErrorHandler for Apply for Loan fragment, just like every other fragment


![ezgif com-video-to-gif](https://user-images.githubusercontent.com/34986121/53698933-f3a75100-3e08-11e9-8407-b44e1ceb187d.gif)



Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.
