### PR TITLE
chore: #1136 remove obsolete configurations

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -97,7 +97,7 @@ dependencies {
     //Dagger dependencies
     annotationProcessor "com.google.dagger:dagger-compiler:$rootProject.daggerVersion"
     implementation "com.google.dagger:dagger:$rootProject.daggerVersion"
-    provided 'javax.annotation:jsr250-api:1.0'                //Required by Dagger2
+    compileOnly 'javax.annotation:jsr250-api:1.0'                //Required by Dagger2
 
     //Butter Knife
     implementation "com.jakewharton:butterknife:$rootProject.butterKnifeVersion"


### PR DESCRIPTION
Fixes #1136

Replaced obsolete configuration 'provided' with 'compileOnly' 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.