### PR TITLE
Fix#1102-Pressing back on Settings activity takes to Home activity

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/activities/SettingsActivity.java
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/SettingsActivity.java
@@ -30,10 +30,8 @@ public class SettingsActivity extends BaseActivity {
     @Override
     public void onBackPressed() {
         super.onBackPressed();
-        if (hasSettingsChanged) {
-            ActivityCompat.finishAffinity(this);
-            Intent i = new Intent(this, HomeActivity.class);
-            startActivity(i);
-        }
+        ActivityCompat.finishAffinity(this);
+        Intent i = new Intent(this, HomeActivity.class);
+        startActivity(i);
     }
 }


### PR DESCRIPTION
Fixes #1102  

Pressing back on the Settings activity takes to Home activity

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.