### PR TITLE
Fixes not hidden issue template hints

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,26 +1,26 @@
 **Summary:**
 
-Summarize your issue in one sentence (what goes wrong, what did you expect to happen).
+<!--Summarize your issue in one sentence (what goes wrong, what did you expect to happen).-->
 
 **Steps to reproduce:**
 
-How can we reproduce the issue?
+<!--How can we reproduce the issue?-->
 
 **Expected behaviour:**
 
-What did you expect the app to do?
+<!--What did you expect the app to do?-->
 
 **Observed behaviour:**
 
-What did you see instead?  Describe your issue in detail here.
+<!--What did you see instead?  Describe your issue in detail here.-->
 
 **Device and Android version:**
 
-What make and model device (e.g., Samsung Galaxy S3) did you encounter this on?  What Android
+<!--What make and model device (e.g., Samsung Galaxy S3) did you encounter this on?  What Android
 version (e.g., Android 4.0 Ice Cream Sandwich or Android 6.0 Marshmallow) are you running?  Is it
  the stock
-version from the manufacturer or a custom ROM?
+version from the manufacturer or a custom ROM?-->
 
 **Screenshots:**
 
-Can be created by pressing the Volume Down and Power Button at the same time on Android 4.0 and higher.
+<!--Can be created by pressing the Volume Down and Power Button at the same time on Android 4.0 and higher.-->


### PR DESCRIPTION
Improved the issue template so that is hides the hints in each section.

**Screenshot**
![screen](https://user-images.githubusercontent.com/38397893/70819754-4c177000-1dd7-11ea-80f9-9b0180a5f484.jpg)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.