### PR TITLE
Fix #1337 -  Loan transactions RecyclerView height and margins refactored

### DIFF
--- a/app/src/main/res/layout/fragment_loan_account_transactions.xml
+++ b/app/src/main/res/layout/fragment_loan_account_transactions.xml
@@ -13,8 +13,7 @@
 
     <LinearLayout
         android:id="@+id/ll_loan_account_trans"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/default_margin"
+        android:layout_height="match_parent"
         android:layout_width="match_parent"
         android:orientation="vertical"
         android:visibility="gone">
@@ -22,8 +21,9 @@
         <TextView
             android:id="@+id/tv_loan_product_name"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="@dimen/default_margin"
-            android:layout_marginStart="@dimen/default_margin"
+            android:layout_marginStart="@dimen/margin_16dp"
+            android:layout_marginLeft="@dimen/margin_16dp"
+            android:layout_marginTop="@dimen/margin_16dp"
             android:layout_width="wrap_content"
             android:textAppearance="@style/Base.TextAppearance.AppCompat.Large"
             android:textColor="@color/black"

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ ext {
     buildToolsVersion = '28.0.3'
 
     // App dependencies
-    supportLibraryVersion = '1.1.0'
+    supportLibraryVersion = '1.0.0'
     designLibraryVersion = '1.0.0'
     daggerVersion = '2.5'
     retrofitVersion = '2.2.0'

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ ext {
     buildToolsVersion = '28.0.3'
 
     // App dependencies
-    supportLibraryVersion = '1.0.0'
+    supportLibraryVersion = '1.1.0'
     designLibraryVersion = '1.0.0'
     daggerVersion = '2.5'
     retrofitVersion = '2.2.0'


### PR DESCRIPTION
Fixes #1337 

Loan transactions RecyclerView height and margins refactored. Because it was not covering the entire screen which ideally it is supposed to do. Swiping across them results in bad user experience and also it was not according to material design guidelines.
**Before:**
![Screenshot_2020-02-13-23-57-06](https://user-images.githubusercontent.com/49963168/74469068-eff9c680-4ec1-11ea-93af-4e8d0af77823.png)
![Screenshot_2020-02-13-23-57-13](https://user-images.githubusercontent.com/49963168/74469033-e1abaa80-4ec1-11ea-9f68-9befd1e2ce05.png)

**Now:**
![Screenshot_2020-02-13-23-41-59](https://user-images.githubusercontent.com/49963168/74469015-d9ec0600-4ec1-11ea-87aa-5145f9bc9bce.png)
![Screenshot_2020-02-13-23-45-04](https://user-images.githubusercontent.com/49963168/74469080-f5571100-4ec1-11ea-87e1-b31029414c0a.png)
#1337 