### PR TITLE
Fixes #1353-Displaying currency code if currency symbol is null and added 8dp margin to status's image

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/fragments/LoanAccountSummaryFragment.java
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/LoanAccountSummaryFragment.java
@@ -113,7 +113,7 @@ public class LoanAccountSummaryFragment extends BaseFragment {
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
-            @Nullable Bundle savedInstanceState) {
+                             @Nullable Bundle savedInstanceState) {
         rootView = inflater.inflate(R.layout.fragment_loan_account_summary, container, false);
         setToolbarTitle(getString(R.string.loan_summary));
 
@@ -132,6 +132,9 @@ public class LoanAccountSummaryFragment extends BaseFragment {
     public void showLoanAccountsDetail(LoanWithAssociations loanWithAssociations) {
         llLoanSummary.setVisibility(View.VISIBLE);
         String currencySymbol = loanWithAssociations.getCurrency().getDisplaySymbol();
+        if (currencySymbol == null) {
+            currencySymbol = loanWithAssociations.getCurrency().getCode();
+        }
         tvLoanProductName.setText(loanWithAssociations.getLoanProductName());
         tvPrincipalName.setText(getString(R.string.string_and_double,
                 currencySymbol,
@@ -160,11 +163,9 @@ public class LoanAccountSummaryFragment extends BaseFragment {
         tvFeesWaivedName.setText(getString(R.string.string_and_double,
                 currencySymbol,
                 loanWithAssociations.getSummary().getFeeChargesWaived()));
-        ;
         tvOutstandingBalanceName.setText(getResources().getString(R.string.string_and_string,
-                loanWithAssociations.getSummary().getCurrency().getDisplaySymbol(), CurrencyUtil.
-                        formatCurrency(getActivity(),
-                                loanWithAssociations.getSummary().getTotalOutstanding())));
+                currencySymbol, CurrencyUtil.formatCurrency(getActivity(),
+                        loanWithAssociations.getSummary().getTotalOutstanding())));
         tvLoanAccountNumber.setText(loanWithAssociations.getAccountNo());
         if (loanWithAssociations.getLoanPurposeName() != null) {
             llLoanPurpose.setVisibility(View.VISIBLE);

--- a/app/src/main/res/layout/fragment_loan_account_summary.xml
+++ b/app/src/main/res/layout/fragment_loan_account_summary.xml
@@ -466,8 +466,10 @@
                             <ImageView
                                 android:id="@+id/iv_account_status"
                                 android:layout_gravity="center_vertical"
+                                android:layout_marginStart="@dimen/default_margin"
                                 android:layout_height="@dimen/icon_small"
-                                android:layout_width="@dimen/icon_small"/>
+                                android:layout_width="@dimen/icon_small"
+                                android:layout_marginLeft="@dimen/default_margin" />
 
                         </LinearLayout>
 


### PR DESCRIPTION
Fixes #1353 

Please Add Screenshots If there are any UI changes.
![Screenshot_1581804992](https://user-images.githubusercontent.com/49963168/74595954-4a378a80-506e-11ea-8d21-761a6a364b79.png)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.