### PR TITLE
fix#1364 - added functionality to display transaction details

### DIFF
--- a/app/src/main/java/org/mifos/mobile/api/DataManager.java
+++ b/app/src/main/java/org/mifos/mobile/api/DataManager.java
@@ -4,6 +4,7 @@ import org.mifos.mobile.FakeRemoteDataSource;
 import org.mifos.mobile.api.local.DatabaseHelper;
 import org.mifos.mobile.api.local.PreferencesHelper;
 import org.mifos.mobile.models.Charge;
+import org.mifos.mobile.models.accounts.savings.Transactions;
 import org.mifos.mobile.models.client.Client;
 import org.mifos.mobile.models.guarantor.GuarantorApplicationPayload;
 import org.mifos.mobile.models.guarantor.GuarantorPayload;
@@ -95,6 +96,23 @@ public class DataManager {
     public Observable<Page<Transaction>> getRecentTransactions(int offset, int limit) {
         return baseApiManager.getRecentTransactionsApi()
                 .getRecentTransactionsList(clientId, offset, limit);
+    }
+
+    public Observable<Transactions> getSavingAccountTransactionDetails(long accountId,
+                                                                       long transactionId) {
+        return baseApiManager.getSavingAccountsListApi().getSavingsAccountTransaction(accountId,
+                transactionId);
+    }
+
+    public Observable<Transaction> getLoanAccountTransactionDetails(long loanId,
+                                                                    long transactionId) {
+        return baseApiManager.getLoanAccountsListApi().getLoanAccountTransaction(loanId,
+                transactionId);
+    }
+
+    public Observable<Transaction> getClientTransaction(long transactionId) {
+        return baseApiManager.getRecentTransactionsApi().getClientTransaction(clientId,
+                transactionId);
     }
 
     public Observable<Page<Charge>> getClientCharges(long clientId) {

--- a/app/src/main/java/org/mifos/mobile/api/services/LoanAccountsListService.java
+++ b/app/src/main/java/org/mifos/mobile/api/services/LoanAccountsListService.java
@@ -1,12 +1,12 @@
 package org.mifos.mobile.api.services;
 
 import org.mifos.mobile.api.ApiEndPoints;
+import org.mifos.mobile.models.Transaction;
 import org.mifos.mobile.models.accounts.loan.LoanAccount;
 import org.mifos.mobile.models.accounts.loan.LoanWithAssociations;
 import org.mifos.mobile.models.accounts.loan.LoanWithdraw;
 import org.mifos.mobile.models.payload.LoansPayload;
 import org.mifos.mobile.models.templates.loans.LoanTemplate;
-import org.mifos.mobile.utils.Constants;
 
 import io.reactivex.Observable;
 import okhttp3.ResponseBody;
@@ -17,6 +17,8 @@ import retrofit2.http.PUT;
 import retrofit2.http.Path;
 import retrofit2.http.Query;
 
+import static org.mifos.mobile.utils.Constants.LOAN_ID;
+
 /**
  * @author Vishwajeet
  * @since 23/6/16.
@@ -24,11 +26,11 @@ import retrofit2.http.Query;
 public interface LoanAccountsListService {
 
     @GET(ApiEndPoints.LOANS + "/{loanId}/")
-    Observable<LoanAccount> getLoanAccountsDetail(@Path("loanId") long loanId);
+    Observable<LoanAccount> getLoanAccountsDetail(@Path(LOAN_ID) long loanId);
 
     @GET(ApiEndPoints.LOANS + "/{loanId}")
     Observable<LoanWithAssociations> getLoanWithAssociations(
-            @Path("loanId") long loanId,
+            @Path(LOAN_ID) long loanId,
             @Query("associations") String associationType);
 
     @GET(ApiEndPoints.LOANS + "/template?templateType=individual")
@@ -43,10 +45,15 @@ public interface LoanAccountsListService {
     Observable<ResponseBody> createLoansAccount(@Body LoansPayload loansPayload);
 
     @PUT(ApiEndPoints.LOANS + "/{loanId}/")
-    Observable<ResponseBody> updateLoanAccount(@Path("loanId") long loanId,
+    Observable<ResponseBody> updateLoanAccount(@Path(LOAN_ID) long loanId,
                                               @Body LoansPayload loansPayload);
 
     @POST(ApiEndPoints.LOANS + "/{loanId}?command=withdrawnByApplicant")
-    Observable<ResponseBody> withdrawLoanAccount(@Path(Constants.LOAN_ID) long loanId,
+    Observable<ResponseBody> withdrawLoanAccount(@Path(LOAN_ID) long loanId,
                                                  @Body LoanWithdraw loanWithdraw);
+
+    @GET(ApiEndPoints.LOANS + "/{loanId}/transactions/{transactionId}")
+    Observable<Transaction> getLoanAccountTransaction(
+            @Path(LOAN_ID) long loanId,
+            @Path("transactionId") long transactionId);
 }

--- a/app/src/main/java/org/mifos/mobile/api/services/RecentTransactionsService.java
+++ b/app/src/main/java/org/mifos/mobile/api/services/RecentTransactionsService.java
@@ -19,4 +19,10 @@ public interface RecentTransactionsService {
             @Path("clientId") long clientId,
             @Query("offset") int offset,
             @Query("limit") int limit);
+
+    @GET(ApiEndPoints.LOANS + "/{clientId}/transaction/{transactionId}")
+    Observable<Transaction> getClientTransaction(
+            @Path("clientId") long clientId,
+            @Path("transactionId") long transactionId);
+
 }

--- a/app/src/main/java/org/mifos/mobile/api/services/SavingAccountsListService.java
+++ b/app/src/main/java/org/mifos/mobile/api/services/SavingAccountsListService.java
@@ -5,6 +5,7 @@ import org.mifos.mobile.models.accounts.savings.SavingsAccountApplicationPayload
 import org.mifos.mobile.models.accounts.savings.SavingsAccountUpdatePayload;
 import org.mifos.mobile.models.accounts.savings.SavingsAccountWithdrawPayload;
 import org.mifos.mobile.models.accounts.savings.SavingsWithAssociations;
+import org.mifos.mobile.models.accounts.savings.Transactions;
 import org.mifos.mobile.models.payload.TransferPayload;
 import org.mifos.mobile.models.templates.account.AccountOptionsTemplate;
 import org.mifos.mobile.models.templates.savings.SavingsAccountTemplate;
@@ -50,4 +51,9 @@ public interface SavingAccountsListService {
     @POST(ApiEndPoints.SAVINGS_ACCOUNTS + "/{savingsId}?command=withdrawnByApplicant")
     Observable<ResponseBody> submitWithdrawSavingsAccount(
             @Path("savingsId") String savingsId, @Body SavingsAccountWithdrawPayload payload);
+
+    @GET(ApiEndPoints.SAVINGS_ACCOUNTS + "/{accountId}/transactions/{transactionId}")
+    Observable<Transactions> getSavingsAccountTransaction(
+            @Path("accountId") long accountId,
+            @Path("transactionId") long transactionId);
 }

--- a/app/src/main/java/org/mifos/mobile/injection/component/ActivityComponent.java
+++ b/app/src/main/java/org/mifos/mobile/injection/component/ActivityComponent.java
@@ -38,6 +38,7 @@ import org.mifos.mobile.ui.fragments.SavingsAccountApplicationFragment;
 import org.mifos.mobile.ui.fragments.SavingsAccountWithdrawFragment;
 import org.mifos.mobile.ui.fragments.SavingsMakeTransferFragment;
 import org.mifos.mobile.ui.fragments.ThirdPartyTransferFragment;
+import org.mifos.mobile.ui.fragments.TransactionDetailsFragment;
 import org.mifos.mobile.ui.fragments.TransferProcessFragment;
 import org.mifos.mobile.ui.fragments.UpdatePasswordFragment;
 import org.mifos.mobile.ui.fragments.UserProfileFragment;
@@ -129,4 +130,6 @@ public interface ActivityComponent {
     void inject(SavingsAccountWithdrawFragment savingsAccountWithdrawFragment);
 
     void inject(ReviewLoanApplicationFragment reviewLoanApplicationFragment);
+
+    void inject (TransactionDetailsFragment transactionDetailsFragment);
 }

--- a/app/src/main/java/org/mifos/mobile/models/accounts/loan/LoanAccount.kt
+++ b/app/src/main/java/org/mifos/mobile/models/accounts/loan/LoanAccount.kt
@@ -59,7 +59,7 @@ data class LoanAccount(
         var amountPaid: Double = 0.toDouble(),
 
         @SerializedName("currency")
-        var currency: Currency,
+        var currency: Currency? = null,
 
         @SerializedName("inArrears")
         var inArrears: Boolean? = null,

--- a/app/src/main/java/org/mifos/mobile/models/accounts/loan/Timeline.kt
+++ b/app/src/main/java/org/mifos/mobile/models/accounts/loan/Timeline.kt
@@ -26,13 +26,13 @@ data class Timeline(
         var approvedOnDate: List<Int>,
 
         @SerializedName("approvedByUsername")
-        var approvedByUsername: String,
+        var approvedByUsername: String? = null,
 
         @SerializedName("approvedByFirstname")
-        var approvedByFirstname: String,
+        var approvedByFirstname: String? = null,
 
         @SerializedName("approvedByLastname")
-        var approvedByLastname: String,
+        var approvedByLastname: String? = null,
 
         @SerializedName("expectedDisbursementDate")
         var expectedDisbursementDate: List<Int>,
@@ -41,13 +41,13 @@ data class Timeline(
         var actualDisbursementDate: List<Int>,
 
         @SerializedName("disbursedByUsername")
-        var disbursedByUsername: String,
+        var disbursedByUsername: String? = null,
 
         @SerializedName("disbursedByFirstname")
-        var disbursedByFirstname: String,
+        var disbursedByFirstname: String? = null,
 
         @SerializedName("disbursedByLastname")
-        var disbursedByLastname: String,
+        var disbursedByLastname: String? = null,
 
         @SerializedName("closedOnDate")
         var closedOnDate: List<Int>,

--- a/app/src/main/java/org/mifos/mobile/models/accounts/savings/TimeLine.kt
+++ b/app/src/main/java/org/mifos/mobile/models/accounts/savings/TimeLine.kt
@@ -26,25 +26,25 @@ data class TimeLine(
         var approvedOnDate: List<Int> = ArrayList(),
 
         @SerializedName("approvedByUsername")
-        var approvedByUsername: String,
+        var approvedByUsername: String? = null,
 
         @SerializedName("approvedByFirstname")
-        var approvedByFirstname: String,
+        var approvedByFirstname: String? = null,
 
         @SerializedName("approvedByLastname")
-        var approvedByLastname: String,
+        var approvedByLastname: String? = null,
 
         @SerializedName("activatedOnDate")
         var activatedOnDate: List<Int>,
 
         @SerializedName("activatedByUsername")
-        var activatedByUsername: String,
+        var activatedByUsername: String? = null,
 
         @SerializedName("activatedByFirstname")
-        var activatedByFirstname: String,
+        var activatedByFirstname: String? = null,
 
         @SerializedName("activatedByLastname")
-        var activatedByLastname: String,
+        var activatedByLastname: String? = null,
 
         @SerializedName("closedOnDate")
         var closedOnDate: List<Int>

--- a/app/src/main/java/org/mifos/mobile/models/client/Client.java
+++ b/app/src/main/java/org/mifos/mobile/models/client/Client.java
@@ -261,6 +261,10 @@ public class Client implements Parcelable {
         dest.writeString(this.officeName);
         dest.writeValue(this.staffId);
         dest.writeString(this.staffName);
+        dest.writeParcelable(this.timeline, flags);
+        dest.writeInt(this.imageId);
+        dest.writeByte((byte) (this.imagePresent ? 1 : 0));
+        dest.writeString(this.externalId);
     }
 
     public Client() {
@@ -285,7 +289,6 @@ public class Client implements Parcelable {
         this.staffId = (Integer) in.readValue(Integer.class.getClassLoader());
         this.staffName = in.readString();
         this.timeline = in.readParcelable(Timeline.class.getClassLoader());
-        this.fullname = in.readString();
         this.imageId = in.readInt();
         this.imagePresent = in.readByte() != 0;
         this.externalId = in.readString();

--- a/app/src/main/java/org/mifos/mobile/presenters/TransactionDetailsPresenter.java
+++ b/app/src/main/java/org/mifos/mobile/presenters/TransactionDetailsPresenter.java
@@ -1,0 +1,135 @@
+package org.mifos.mobile.presenters;
+
+
+import android.content.Context;
+import org.mifos.mobile.R;
+import org.mifos.mobile.api.DataManager;
+import org.mifos.mobile.injection.ApplicationContext;
+import org.mifos.mobile.models.Transaction;
+import org.mifos.mobile.models.accounts.savings.Transactions;
+import org.mifos.mobile.presenters.base.BasePresenter;
+import org.mifos.mobile.ui.views.TransactionDetailsView;
+import javax.inject.Inject;
+import io.reactivex.android.schedulers.AndroidSchedulers;
+import io.reactivex.disposables.CompositeDisposable;
+import io.reactivex.observers.DisposableObserver;
+import io.reactivex.schedulers.Schedulers;
+
+
+public class TransactionDetailsPresenter extends
+        BasePresenter<TransactionDetailsView> {
+
+    private final DataManager dataManager;
+    private CompositeDisposable compositeDisposables;
+
+    /**
+     * Initialises the TransactionDetailsPresenter by automatically injecting
+     * an instance of {@link DataManager} and {@link Context}.
+     * @param dataManager DataManager class that provides access to the data
+     *                    via the API.
+     * @param context     Context of the view attached to the presenter. In this case
+     *                    it is that of an {@link androidx.appcompat.app.AppCompatActivity}
+     */
+    @Inject
+    public TransactionDetailsPresenter(DataManager dataManager,
+                                            @ApplicationContext Context context) {
+        super(context);
+        this.dataManager = dataManager;
+        compositeDisposables = new CompositeDisposable();
+    }
+
+    @Override
+    public void attachView(TransactionDetailsView mvpView) {
+        super.attachView(mvpView);
+    }
+
+    @Override
+    public void detachView() {
+        super.detachView();
+        compositeDisposables.clear();
+    }
+
+    public void loadClientTransactionDetails(long transactionId) {
+        checkViewAttached();
+        getMvpView().showProgress();
+        compositeDisposables.add(dataManager.getClientTransaction(transactionId)
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribeOn(Schedulers.io())
+                .subscribeWith(new DisposableObserver<Transaction>() {
+                    @Override
+                    public void onComplete() {
+
+                    }
+                    @Override
+                    public void onError(Throwable e) {
+                        getMvpView().hideProgress();
+                        getMvpView().showErrorFetchingTransactionDetails(
+                                context.getString(R.string.error_transaction_details_loading));
+                    }
+
+                    @Override
+                    public void onNext(Transaction transaction) {
+                        getMvpView().hideProgress();
+                        getMvpView().showTransactionDetails(transaction);
+                    }
+                })
+        );
+    }
+
+    public void loadLoanAccountTransactionDetails(long loanId, long transactionId) {
+        checkViewAttached();
+        getMvpView().showProgress();
+        compositeDisposables.add(dataManager.getLoanAccountTransactionDetails(loanId,
+                transactionId)
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribeOn(Schedulers.io())
+                .subscribeWith(new DisposableObserver<Transaction>() {
+                    @Override
+                    public void onComplete() {
+
+                    }
+                    @Override
+                    public void onError(Throwable e) {
+                        getMvpView().hideProgress();
+                        getMvpView().showErrorFetchingTransactionDetails(
+                                context.getString(R.string.error_transaction_details_loading));
+                    }
+
+                    @Override
+                    public void onNext(Transaction transaction) {
+                        getMvpView().hideProgress();
+                        getMvpView().showTransactionDetails(transaction);
+                    }
+                })
+        );
+    }
+
+    public void loadSavingsAccountTransactionDetails(long accountId, long transactionId) {
+        checkViewAttached();
+        getMvpView().showProgress();
+        compositeDisposables.add(dataManager.getSavingAccountTransactionDetails(accountId,
+                transactionId)
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribeOn(Schedulers.io())
+                .subscribeWith(new DisposableObserver<Transactions>() {
+                    @Override
+                    public void onComplete() {
+
+                    }
+                    @Override
+                    public void onError(Throwable e) {
+                        getMvpView().hideProgress();
+                        getMvpView().showErrorFetchingTransactionDetails(
+                                context.getString(R.string.error_transaction_details_loading));
+                    }
+
+                    @Override
+                    public void onNext(Transactions transactions) {
+                        getMvpView().hideProgress();
+                        getMvpView().showSavingsAccountTransactionDetails(transactions);
+                    }
+                })
+        );
+    }
+
+}

--- a/app/src/main/java/org/mifos/mobile/ui/enums/TransactionType.java
+++ b/app/src/main/java/org/mifos/mobile/ui/enums/TransactionType.java
@@ -1,0 +1,7 @@
+package org.mifos.mobile.ui.enums;
+
+public enum TransactionType {
+    CLIENT,
+    SAVINGS,
+    LOAN
+}

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/LoanAccountTransactionFragment.java
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/LoanAccountTransactionFragment.java
@@ -19,10 +19,12 @@ import org.mifos.mobile.models.accounts.loan.LoanWithAssociations;
 import org.mifos.mobile.presenters.LoanAccountsTransactionPresenter;
 import org.mifos.mobile.ui.activities.base.BaseActivity;
 import org.mifos.mobile.ui.adapters.RecentTransactionListAdapter;
+import org.mifos.mobile.ui.enums.TransactionType;
 import org.mifos.mobile.ui.fragments.base.BaseFragment;
 import org.mifos.mobile.ui.views.LoanAccountsTransactionView;
 import org.mifos.mobile.utils.Constants;
 import org.mifos.mobile.utils.Network;
+import org.mifos.mobile.utils.RecyclerItemClickListener;
 
 import javax.inject.Inject;
 
@@ -38,7 +40,7 @@ import butterknife.OnClick;
  */
 
 public class LoanAccountTransactionFragment extends BaseFragment
-        implements LoanAccountsTransactionView {
+        implements LoanAccountsTransactionView, RecyclerItemClickListener.OnItemClickListener {
 
     @BindView(R.id.layout_error)
     View layoutError;
@@ -124,6 +126,8 @@ public class LoanAccountTransactionFragment extends BaseFragment
         rvLoanTransactions.setHasFixedSize(true);
         rvLoanTransactions.setLayoutManager(layoutManager);
         rvLoanTransactions.setAdapter(transactionsListAdapter);
+        rvLoanTransactions.addOnItemTouchListener(
+                new RecyclerItemClickListener(getActivity(), this));
     }
 
     /**
@@ -174,6 +178,20 @@ public class LoanAccountTransactionFragment extends BaseFragment
             Toast.makeText(getContext(), getString(R.string.internet_not_connected),
                     Toast.LENGTH_SHORT).show();
         }
+    }
+
+    @Override
+    public void onItemClick(View childView, int position) {
+        ((BaseActivity) getActivity()).replaceFragment(TransactionDetailsFragment
+                        .newInstance(loanId,
+                                loanWithAssociations.getTransactions().get(position).getId(),
+                                TransactionType.LOAN)
+                , true, R.id.container);
+    }
+
+    @Override
+    public void onItemLongPress(View childView, int position) {
+
     }
 
     @Override

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/RecentTransactionsFragment.java
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/RecentTransactionsFragment.java
@@ -14,12 +14,14 @@ import org.mifos.mobile.models.Transaction;
 import org.mifos.mobile.presenters.RecentTransactionsPresenter;
 import org.mifos.mobile.ui.activities.base.BaseActivity;
 import org.mifos.mobile.ui.adapters.RecentTransactionListAdapter;
+import org.mifos.mobile.ui.enums.TransactionType;
 import org.mifos.mobile.ui.fragments.base.BaseFragment;
 import org.mifos.mobile.ui.views.RecentTransactionsView;
 import org.mifos.mobile.utils.Constants;
 import org.mifos.mobile.utils.DividerItemDecoration;
 import org.mifos.mobile.utils.EndlessRecyclerViewScrollListener;
 import org.mifos.mobile.utils.Network;
+import org.mifos.mobile.utils.RecyclerItemClickListener;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,6 +41,7 @@ import butterknife.OnClick;
  * @since 09/08/16
  */
 public class RecentTransactionsFragment extends BaseFragment implements RecentTransactionsView,
+        RecyclerItemClickListener.OnItemClickListener,
         SwipeRefreshLayout.OnRefreshListener {
 
     @BindView(R.id.rv_recent_transactions)
@@ -123,6 +126,8 @@ public class RecentTransactionsFragment extends BaseFragment implements RecentTr
                 layoutManager.getOrientation()));
         recentTransactionsListAdapter.setTransactions(recentTransactionList);
         rvRecentTransactions.setAdapter(recentTransactionsListAdapter);
+        rvRecentTransactions.addOnItemTouchListener(
+                new RecyclerItemClickListener(getActivity(), this));
         rvRecentTransactions.addOnScrollListener(
                 new EndlessRecyclerViewScrollListener(layoutManager) {
                     @Override
@@ -224,6 +229,21 @@ public class RecentTransactionsFragment extends BaseFragment implements RecentTr
     @Override
     public void hideProgress() {
         showSwipeRefreshLayout(false);
+    }
+
+    @Override
+    public void onItemClick(View childView, int position) {
+        // created just to be passed to the constructor
+        long accountId = 0;
+        ((BaseActivity) getActivity()).replaceFragment(TransactionDetailsFragment
+                        .newInstance(accountId, recentTransactionList.get(position).getId(),
+                                TransactionType.CLIENT)
+                , true, R.id.container);
+    }
+
+    @Override
+    public void onItemLongPress(View childView, int position) {
+
     }
 
     @Override

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/SavingAccountsTransactionFragment.java
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/SavingAccountsTransactionFragment.java
@@ -32,6 +32,7 @@ import org.mifos.mobile.presenters.SavingAccountsTransactionPresenter;
 import org.mifos.mobile.ui.activities.base.BaseActivity;
 import org.mifos.mobile.ui.adapters.CheckBoxAdapter;
 import org.mifos.mobile.ui.adapters.SavingAccountsTransactionListAdapter;
+import org.mifos.mobile.ui.enums.TransactionType;
 import org.mifos.mobile.ui.fragments.base.BaseFragment;
 import org.mifos.mobile.ui.views.SavingAccountsTransactionView;
 import org.mifos.mobile.utils.Constants;
@@ -40,6 +41,7 @@ import org.mifos.mobile.utils.DatePick;
 import org.mifos.mobile.utils.MFDatePicker;
 import org.mifos.mobile.utils.MaterialDialog;
 import org.mifos.mobile.utils.Network;
+import org.mifos.mobile.utils.RecyclerItemClickListener;
 import org.mifos.mobile.utils.StatusUtils;
 import org.mifos.mobile.utils.Toaster;
 
@@ -58,6 +60,7 @@ import butterknife.OnClick;
 
 public class SavingAccountsTransactionFragment extends BaseFragment
         implements SavingAccountsTransactionView,
+        RecyclerItemClickListener.OnItemClickListener,
 //        RadioGroup.OnCheckedChangeListener,
         MFDatePicker.OnDatePickListener {
 
@@ -167,6 +170,8 @@ public class SavingAccountsTransactionFragment extends BaseFragment
         rvSavingAccountsTransaction.setHasFixedSize(true);
         rvSavingAccountsTransaction.setLayoutManager(layoutManager);
         rvSavingAccountsTransaction.setAdapter(transactionListAdapter);
+        rvSavingAccountsTransaction.addOnItemTouchListener(
+                new RecyclerItemClickListener(getActivity(), this));
 
 //        radioGroup.setOnCheckedChangeListener(this);
         mfDatePicker = MFDatePicker.newInstance(this, MFDatePicker.ALL_DAYS, active);
@@ -440,6 +445,19 @@ public class SavingAccountsTransactionFragment extends BaseFragment
                 .setNegativeButton(R.string.cancel)
                 .createMaterialDialog()
                 .show();
+    }
+
+    @Override
+    public void onItemClick(View childView, int position) {
+        ((BaseActivity) getActivity()).replaceFragment(TransactionDetailsFragment
+                        .newInstance(transactionsList.get(position).getAccountId(),
+                                transactionsList.get(position).getId(), TransactionType.SAVINGS)
+                , true, R.id.container);
+    }
+
+    @Override
+    public void onItemLongPress(View childView, int position) {
+
     }
 
     @Override

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/TransactionDetailsFragment.java
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/TransactionDetailsFragment.java
@@ -1,0 +1,237 @@
+package org.mifos.mobile.ui.fragments;
+
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import com.github.therajanmaurya.sweeterror.SweetUIErrorHandler;
+
+import org.mifos.mobile.R;
+import org.mifos.mobile.models.Transaction;
+import org.mifos.mobile.models.accounts.savings.PaymentDetailData;
+import org.mifos.mobile.models.accounts.savings.Transactions;
+import org.mifos.mobile.presenters.TransactionDetailsPresenter;
+import org.mifos.mobile.ui.activities.base.BaseActivity;
+import org.mifos.mobile.ui.enums.TransactionType;
+import org.mifos.mobile.ui.fragments.base.BaseFragment;
+import org.mifos.mobile.ui.views.TransactionDetailsView;
+import org.mifos.mobile.utils.Constants;
+import org.mifos.mobile.utils.CurrencyUtil;
+import org.mifos.mobile.utils.DateHelper;
+import org.mifos.mobile.utils.Network;
+
+import javax.inject.Inject;
+
+import androidx.annotation.Nullable;
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import butterknife.OnClick;
+
+public class TransactionDetailsFragment extends BaseFragment implements
+        TransactionDetailsView {
+
+    @BindView(R.id.ll_transaction)
+    LinearLayout transactionLayout;
+
+    @BindView(R.id.layout_error)
+    View layoutError;
+
+    @BindView(R.id.tv_transaction_id)
+    TextView tvTransactionId;
+
+    @BindView(R.id.tv_transaction_type)
+    TextView tvTransactionType;
+
+    @BindView(R.id.tv_transaction_date)
+    TextView tvTransactionDate;
+
+    @BindView(R.id.tv_transaction_currency)
+    TextView tvTransactionCurrency;
+
+    @BindView(R.id.tv_transaction_amount)
+    TextView tvTransactionAmount;
+
+    @BindView(R.id.tv_payment_type)
+    TextView tvPaymentType;
+
+    @BindView(R.id.tv_payment_acc_no)
+    TextView tvPaymentAccountNumber;
+
+    @BindView(R.id.tv_receipt_no)
+    TextView tvReceiptNumber;
+
+    @Inject
+    TransactionDetailsPresenter transactionDetailsPresenter;
+
+    private View rootView;
+    private SweetUIErrorHandler sweetUIErrorHandler;
+
+    private long transactionId;
+    private long accountId;
+    private TransactionType transactionType;
+
+    // for Client and Loan Account transactions
+    private Transaction transaction;
+
+    // for Savings Account transaction
+    private Transactions transactions;
+
+    public static TransactionDetailsFragment newInstance(long accountId, long transactionId,
+                                                         TransactionType transactionType) {
+        TransactionDetailsFragment fragment = new TransactionDetailsFragment();
+        Bundle args = new Bundle();
+        args.putLong(Constants.ACCOUNT_ID, accountId);
+        args.putLong(Constants.TRANSACTION_ID, transactionId);
+        args.putSerializable(Constants.TRANSACTION_TYPE, transactionType);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (getArguments() != null) {
+            accountId = getArguments().getLong(Constants.ACCOUNT_ID);
+            transactionId = getArguments().getLong(Constants.TRANSACTION_ID);
+            transactionType = (TransactionType) getArguments()
+                    .getSerializable(Constants.TRANSACTION_TYPE);
+        }
+    }
+
+
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container,
+                             @Nullable Bundle savedInstanceState) {
+        rootView = inflater.inflate(R.layout.fragment_transaction_details, container, false);
+        ((BaseActivity) getActivity()).getActivityComponent().inject(this);
+        setToolbarTitle(getString(R.string.transaction_details));
+        ButterKnife.bind(this, rootView);
+        transactionDetailsPresenter.attachView(this);
+        sweetUIErrorHandler = new SweetUIErrorHandler(getContext(), rootView);
+        if (savedInstanceState == null) {
+            loadTransactionDetails();
+        }
+
+        return rootView;
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        if (transactionType == TransactionType.SAVINGS) {
+            outState.putParcelable(Constants.TRANSACTION, transactions);
+        } else {
+            outState.putParcelable(Constants.TRANSACTION, transaction);
+        }
+    }
+
+    @Override
+    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+        if (savedInstanceState != null && transactionType == TransactionType.SAVINGS) {
+            showSavingsAccountTransactionDetails((Transactions) savedInstanceState.
+                    getParcelable(Constants.TRANSACTION));
+        } else if (savedInstanceState != null && transactionType != TransactionType.SAVINGS) {
+            showTransactionDetails((Transaction) savedInstanceState.
+                    getParcelable(Constants.TRANSACTION));
+        }
+    }
+
+    @Override
+    public void showSavingsAccountTransactionDetails(Transactions transactions) {
+        this.transactions = transactions;
+        String currencySymbol = transactions.getCurrency().getDisplaySymbol();
+        PaymentDetailData paymentDetailData = transactions.getPaymentDetailData();
+
+        tvTransactionId.setText(String.valueOf(transactions.getId()));
+        tvTransactionType.setText(transactions.getTransactionType().getValue());
+        tvTransactionDate.setText(DateHelper.getDateAsString(transactions.getDate()));
+        tvTransactionCurrency.setText(transactions.getCurrency().getName());
+        tvTransactionAmount.setText(getString(R.string.string_and_string,
+                currencySymbol, CurrencyUtil.formatCurrency(getActivity(),
+                        transactions.getAmount())));
+        tvPaymentType.setText(paymentDetailData.getPaymentType().getName());
+        tvPaymentAccountNumber.setText(paymentDetailData.getAccountNumber());
+        tvReceiptNumber.setText(paymentDetailData.getReceiptNumber());
+    }
+
+    @Override
+    public void showTransactionDetails(Transaction transaction) {
+        this.transaction = transaction;
+        String currencySymbol = transaction.getCurrency().getDisplaySymbol();
+
+        tvTransactionId.setText(String.valueOf(transaction.getId()));
+        tvTransactionType.setText(transaction.getType().getValue());
+        tvTransactionDate.setText(DateHelper.getDateAsString(transaction.getDate()));
+        tvTransactionCurrency.setText(transaction.getCurrency().getName());
+        tvTransactionAmount.setText(getString(R.string.string_and_string,
+                currencySymbol, CurrencyUtil.formatCurrency(getActivity(),
+                        transaction.getAmount())));
+    }
+
+    @Override
+    public void showErrorFetchingTransactionDetails(String message) {
+        if (!Network.isConnected(getContext())) {
+            sweetUIErrorHandler.showSweetNoInternetUI(transactionLayout, layoutError);
+            Toast.makeText(getContext(), getString(R.string.internet_not_connected),
+                    Toast.LENGTH_SHORT).show();
+        } else {
+            sweetUIErrorHandler.showSweetErrorUI(message, transactionLayout, layoutError);
+            Toast.makeText(getContext(), message, Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    private void loadTransactionDetails() {
+        switch (transactionType) {
+            case CLIENT:
+                transactionDetailsPresenter.loadClientTransactionDetails(transactionId);
+                break;
+            case LOAN:
+                transactionDetailsPresenter.loadLoanAccountTransactionDetails(accountId,
+                        transactionId);
+                break;
+            case SAVINGS:
+                transactionDetailsPresenter.loadSavingsAccountTransactionDetails(accountId,
+                        transactionId);
+                break;
+        }
+    }
+
+    @OnClick(R.id.btn_try_again)
+    void onRetry() {
+        if (!Network.isConnected(getContext())) {
+            Toast.makeText(getContext(), getString(R.string.internet_not_connected),
+                    Toast.LENGTH_SHORT).show();
+        } else {
+            sweetUIErrorHandler.hideSweetErrorLayoutUI(transactionLayout, layoutError);
+            loadTransactionDetails();
+        }
+    }
+
+    @Override
+    public void showProgress() {
+        transactionLayout.setVisibility(View.GONE);
+        showProgressBar();
+    }
+
+    @Override
+    public void hideProgress() {
+        transactionLayout.setVisibility(View.VISIBLE);
+        hideProgressBar();
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        hideProgressBar();
+        transactionDetailsPresenter.detachView();
+    }
+
+}

--- a/app/src/main/java/org/mifos/mobile/ui/views/TransactionDetailsView.java
+++ b/app/src/main/java/org/mifos/mobile/ui/views/TransactionDetailsView.java
@@ -1,0 +1,15 @@
+package org.mifos.mobile.ui.views;
+
+import org.mifos.mobile.models.Transaction;
+import org.mifos.mobile.models.accounts.savings.Transactions;
+import org.mifos.mobile.ui.views.base.MVPView;
+
+public interface TransactionDetailsView extends MVPView {
+
+    // used to show Client and Loan Account Transaction details
+    void showTransactionDetails(Transaction transaction);
+
+    void showSavingsAccountTransactionDetails(Transactions transactions);
+
+    void showErrorFetchingTransactionDetails(String message);
+}

--- a/app/src/main/java/org/mifos/mobile/utils/Constants.java
+++ b/app/src/main/java/org/mifos/mobile/utils/Constants.java
@@ -126,4 +126,10 @@ public class Constants {
     public static  final String OUTSTANDING_BALANCE = "outstanding_balance";
 
     public static final String LOAN_REPAYMENT = "loan_repayment";
+
+    public static final String TRANSACTION = "transaction";
+
+    public static final String TRANSACTION_ID = "transactionId";
+
+    public static final String TRANSACTION_TYPE = "transactionType";
 }

--- a/app/src/main/res/layout/fragment_transaction_details.xml
+++ b/app/src/main/res/layout/fragment_transaction_details.xml
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.core.widget.NestedScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:fillViewport="true"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent">
+
+    <LinearLayout
+        android:layout_height="match_parent"
+        android:layout_width="match_parent"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:id="@+id/ll_transaction"
+            android:layout_height="match_parent"
+            android:layout_width="match_parent"
+            android:orientation="vertical"
+            android:visibility="visible">
+
+            <androidx.cardview.widget.CardView
+                android:background="@color/white"
+                android:layout_height="wrap_content"
+                android:layout_width="match_parent">
+
+                <LinearLayout
+                    android:layout_height="wrap_content"
+                    android:layout_width="match_parent"
+                    android:orientation="vertical"
+                    android:padding="@dimen/default_padding">
+
+                    <TextView
+                        android:ellipsize="end"
+                        android:id="@+id/transaction_id_header"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/default_margin"
+                        android:layout_width="match_parent"
+                        android:text="@string/transaction_id"
+                        android:textAppearance="?android:textAppearanceMedium"
+                        android:textColor="@color/black"/>
+
+                    <TextView
+                        android:id="@+id/tv_transaction_id"
+                        android:layout_height="wrap_content"
+                        android:layout_width="match_parent"
+                        android:textAppearance="?android:textAppearanceSmall" />
+
+                    <TextView
+                        android:ellipsize="end"
+                        android:id="@+id/transaction_type_header"
+                        android:layout_height="wrap_content"
+                        android:layout_width="match_parent"
+                        android:lines="1"
+                        android:text="@string/transaction_type"
+                        android:textAppearance="?android:textAppearanceMedium"
+                        android:textColor="@color/black"/>
+
+                    <TextView
+                        android:id="@+id/tv_transaction_type"
+                        android:layout_height="match_parent"
+                        android:layout_width="match_parent"
+                        android:textAppearance="?android:textAppearanceSmall"
+                        android:visibility="visible"/>
+
+                    <TextView
+                        android:ellipsize="end"
+                        android:id="@+id/transaction_date_header"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/default_margin"
+                        android:layout_weight="1"
+                        android:layout_width="wrap_content"
+                        android:lines="1"
+                        android:text="@string/transaction_date"
+                        android:textAppearance="?android:textAppearanceMedium"
+                        android:textColor="@color/black"/>
+
+                    <TextView
+                        android:id="@+id/tv_transaction_date"
+                        android:layout_height="wrap_content"
+                        android:layout_width="match_parent"
+                        android:textAppearance="?android:textAppearanceSmall"/>
+
+                    <TextView
+                        android:ellipsize="end"
+                        android:id="@+id/tv_currency_header"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/default_margin"
+                        android:layout_weight="1"
+                        android:layout_width="wrap_content"
+                        android:lines="1"
+                        android:text="@string/currency"
+                        android:textAppearance="?android:textAppearanceMedium"
+                        android:textColor="@color/black"/>
+
+                    <TextView
+                        android:id="@+id/tv_transaction_currency"
+                        android:layout_height="wrap_content"
+                        android:layout_width="wrap_content"
+                        android:textAppearance="?android:textAppearanceSmall"/>
+
+                    <TextView
+                        android:ellipsize="end"
+                        android:id="@+id/amount_header"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/default_margin"
+                        android:layout_weight="1"
+                        android:layout_width="wrap_content"
+                        android:lines="1"
+                        android:text="@string/amount"
+                        android:textAppearance="?android:textAppearanceMedium"
+                        android:textColor="@color/black"/>
+
+                    <TextView
+                        android:id="@+id/tv_transaction_amount"
+                        android:layout_height="wrap_content"
+                        android:layout_width="wrap_content"
+                        android:textAppearance="?android:textAppearanceSmall"/>
+
+                </LinearLayout>
+
+            </androidx.cardview.widget.CardView>
+
+            <TextView
+                style="@style/Base.TextAppearance.AppCompat.Medium"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/margin_4dp"
+                android:layout_marginLeft="@dimen/default_margin"
+                android:layout_marginStart="@dimen/default_margin"
+                android:layout_marginTop="@dimen/default_padding"
+                android:layout_width="match_parent"
+                android:text="@string/payment_details"/>
+
+            <androidx.cardview.widget.CardView
+                android:background="@color/white"
+                android:layout_height="wrap_content"
+                android:layout_width="match_parent">
+
+                <LinearLayout
+                    android:layout_height="wrap_content"
+                    android:layout_width="match_parent"
+                    android:orientation="vertical"
+                    android:padding="@dimen/default_padding">
+
+                    <TextView
+                        android:ellipsize="end"
+                        android:id="@+id/payment_type_header"
+                        android:layout_height="wrap_content"
+                        android:layout_width="match_parent"
+                        android:text="@string/type"
+                        android:textAppearance="?android:textAppearanceMedium"
+                        android:textColor="@color/black"/>
+
+                    <TextView
+                        android:id="@+id/tv_payment_type"
+                        android:layout_height="wrap_content"
+                        android:layout_width="wrap_content"
+                        android:textAppearance="?android:textAppearanceSmall"/>
+
+                    <TextView
+                        android:ellipsize="end"
+                        android:id="@+id/payment_acc_no_header"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/default_margin"
+                        android:layout_width="wrap_content"
+                        android:text="@string/account_number"
+                        android:textAppearance="?android:textAppearanceMedium"
+                        android:textColor="@color/black"/>
+
+                    <TextView
+                        android:id="@+id/tv_payment_acc_no"
+                        android:layout_height="wrap_content"
+                        android:layout_width="wrap_content"
+                        android:textSize="@dimen/text_small"/>
+
+                    <TextView
+                        android:id="@+id/receipt_no_header"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/default_margin"
+                        android:layout_width="wrap_content"
+                        android:text="@string/receipt_number"
+                        android:textAppearance="?android:textAppearanceMedium"
+                        android:textColor="@color/black"/>
+                    <TextView
+                        android:id="@+id/tv_receipt_no"
+                        android:layout_height="wrap_content"
+                        android:layout_width="wrap_content"
+                        android:textAppearance="?android:textAppearanceSmall"/>
+
+                </LinearLayout>
+
+            </androidx.cardview.widget.CardView>
+
+        </LinearLayout>
+
+        <include
+            layout="@layout/layout_sweet_exception_handler"
+            android:id="@+id/layout_error"
+            android:visibility="gone"/>
+
+    </LinearLayout>
+
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -572,6 +572,13 @@
     <string name="savings_account_transaction">Savings Account Transaction</string>
     <string name="transaction_period">Transaction Period</string>
     <string name="transaction_type">Transaction Type</string>
+    <string name="transaction_details">Transaction Details</string>
+    <string name="transaction_id">Transaction ID</string>
+    <string name="transaction_date">Transaction Date</string>
+    <string name="payment_details">Payment Details</string>
+    <string name="type">Type</string>
+    <string name="receipt_number">Receipt Number</string>
+    <string name="error_transaction_details_loading">Error loading in transaction details</string>
 
     <string-array name="languages" translatable="false">
         <item>English</item>


### PR DESCRIPTION
Fixes #1364

**Summary**

In this pull request I have extended the back-end api  to display the details of the transactions  
  related to :-
* A savings account
* A loan account
* Client transaction

Screen Recording :-

* Savings Account Transaction Details
![GIF-200223_173331](https://user-images.githubusercontent.com/46667021/75111851-3d192d80-5664-11ea-8631-5c78c82b405c.gif)



* Loan Account Transaction Details
![GIF-200223_173421](https://user-images.githubusercontent.com/46667021/75111854-430f0e80-5664-11ea-819e-eb3118b40a54.gif)



* I have also added similar functionality for client transactions but because of some problem with the api I couldn't display it


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.