### PR TITLE
fix#1395 - fragment doesn't reload onbackpressed

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/fragments/LoanAccountsDetailFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/LoanAccountsDetailFragment.kt
@@ -96,8 +96,10 @@ class LoanAccountsDetailFragment : BaseFragment(), LoanAccountsDetailView {
         ButterKnife.bind(this, rootView!!)
         loanAccountDetailsPresenter?.attachView(this)
         sweetUIErrorHandler = SweetUIErrorHandler(activity, rootView)
-        if (savedInstanceState == null) {
+        if (savedInstanceState == null && this.loanWithAssociations == null) {
             loanAccountDetailsPresenter?.loadLoanAccountDetails(loanId)
+        } else {
+            showLoanAccountsDetail(this.loanWithAssociations)
         }
         return rootView
     }

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/SavingAccountsDetailFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/SavingAccountsDetailFragment.kt
@@ -115,8 +115,10 @@ class SavingAccountsDetailFragment : BaseFragment(), SavingAccountsDetailView {
         ButterKnife.bind(this, rootView!!)
         savingAccountsDetailPresenter?.attachView(this)
         sweetUIErrorHandler = SweetUIErrorHandler(context, rootView)
-        if (savedInstanceState == null) {
+        if (savedInstanceState == null && this.savingsWithAssociations == null) {
             savingAccountsDetailPresenter?.loadSavingsWithAssociations(savingsId)
+        } else {
+            showSavingAccountsDetail(this.savingsWithAssociations)
         }
         setHasOptionsMenu(true)
         return rootView


### PR DESCRIPTION
Fixes #1395 

### Description
Since `addToBackStack` saves the current state of fragment so we can use the instance variable values directly instead of fetching the data again

Please Add Screenshots If there are any UI changes.

![GIF-200309_113057](https://user-images.githubusercontent.com/46667021/76186935-e9791900-61f9-11ea-9d49-dd23bc0cf4ee.gif)


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.