### PR TITLE
Fix - #1394 View Gurantor - Recycler View Fills the screen

### DIFF
--- a/app/src/main/res/layout/fragment_guarantor_list.xml
+++ b/app/src/main/res/layout/fragment_guarantor_list.xml
@@ -13,7 +13,7 @@
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_guarantors"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:layout_width="match_parent"/>
 
     </LinearLayout>


### PR DESCRIPTION
Fixes #1394 

**Screenshots :**

<img width="30%" src="https://user-images.githubusercontent.com/39809059/76729737-d88f5100-677f-11ea-99c5-9f2d99b43563.jpg">

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.