### PR TITLE
Fix#1417 Message Dispalyed on No Transactions

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/fragments/SavingAccountsTransactionFragment.java
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/SavingAccountsTransactionFragment.java
@@ -188,12 +188,9 @@ public class SavingAccountsTransactionFragment extends BaseFragment
 
         if (transactionsList != null && !transactionsList.isEmpty()) {
             transactionListAdapter.setContext(getContext());
-            transactionListAdapter.
-                    setSavingAccountsTransactionList(transactionsList);
+            transactionListAdapter.setSavingAccountsTransactionList(transactionsList);
         } else {
-            sweetUIErrorHandler.showSweetEmptyUI(getString(R.string.transactions),
-                    R.drawable.ic_compare_arrows_black_24dp, rvSavingAccountsTransaction,
-                    layoutError);
+            showEmptyTransactions();
         }
     }
 
@@ -227,9 +224,18 @@ public class SavingAccountsTransactionFragment extends BaseFragment
      */
     @Override
     public void showFilteredList(List<Transactions> list) {
-        Toaster.show(rootView, getString(R.string.filtered));
-        transactionListAdapter.
-                setSavingAccountsTransactionList(list);
+        if (list.size() != 0) {
+            Toaster.show(rootView, getString(R.string.filtered));
+            transactionListAdapter.setSavingAccountsTransactionList(list);
+        } else {
+            showEmptyTransactions();
+        }
+    }
+
+    @Override
+    public void showEmptyTransactions() {
+        sweetUIErrorHandler.showSweetEmptyUI(getString(R.string.transactions),
+                R.drawable.ic_compare_arrows_black_24dp, rvSavingAccountsTransaction, layoutError);
     }
 
     /**

--- a/app/src/main/java/org/mifos/mobile/ui/views/SavingAccountsTransactionView.java
+++ b/app/src/main/java/org/mifos/mobile/ui/views/SavingAccountsTransactionView.java
@@ -20,4 +20,6 @@ public interface SavingAccountsTransactionView extends MVPView {
 
     void showFilteredList(List<Transactions> list);
 
+    void showEmptyTransactions();
+
 }


### PR DESCRIPTION
Fixes #1417 

On Filter, if there are no transactions, a message is displayed.

Please Add Screenshots If there are any UI changes.
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/39809059/76731653-f068d400-6783-11ea-9b32-8e8539585cb3.gif)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.