### PR TITLE
Fix-1434 Added dividers in Saving Account Transaction RecyclerView

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/fragments/SavingAccountsTransactionFragment.java
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/SavingAccountsTransactionFragment.java
@@ -37,6 +37,7 @@ import org.mifos.mobile.ui.views.SavingAccountsTransactionView;
 import org.mifos.mobile.utils.Constants;
 import org.mifos.mobile.utils.DateHelper;
 import org.mifos.mobile.utils.DatePick;
+import org.mifos.mobile.utils.DividerItemDecoration;
 import org.mifos.mobile.utils.MFDatePicker;
 import org.mifos.mobile.utils.MaterialDialog;
 import org.mifos.mobile.utils.Network;
@@ -166,6 +167,8 @@ public class SavingAccountsTransactionFragment extends BaseFragment
         layoutManager.setOrientation(LinearLayoutManager.VERTICAL);
         rvSavingAccountsTransaction.setHasFixedSize(true);
         rvSavingAccountsTransaction.setLayoutManager(layoutManager);
+        rvSavingAccountsTransaction.addItemDecoration(new DividerItemDecoration(getActivity(),
+                layoutManager.getOrientation()));
         rvSavingAccountsTransaction.setAdapter(transactionListAdapter);
 
 //        radioGroup.setOnCheckedChangeListener(this);

--- a/app/src/main/res/layout/row_saving_account_transaction.xml
+++ b/app/src/main/res/layout/row_saving_account_transaction.xml
@@ -35,7 +35,7 @@
             android:layout_height="wrap_content"
             android:layout_width="match_parent"
             android:text="@string/small_text"
-            android:textAppearance="@style/Base.TextAppearance.AppCompat.Medium"
+            android:textAppearance="@style/Base.TextAppearance.AppCompat.Small"
             android:textColor="@color/gray_dark"/>
 
         <TextView
@@ -43,7 +43,7 @@
             android:layout_height="wrap_content"
             android:layout_width="match_parent"
             android:text="@string/small_text"
-            android:textAppearance="@style/Base.TextAppearance.AppCompat.Medium"
+            android:textAppearance="@style/Base.TextAppearance.AppCompat.Small"
             android:textColor="@color/gray_dark"
             android:visibility="gone"/>
 


### PR DESCRIPTION
Fixes #1434  

- Added dividers in Saving Account Transaction RecyclerView

**Screenshots:**

![Screenshot_20200318_214803](https://user-images.githubusercontent.com/39809059/76983702-dd145f00-6963-11ea-9aef-f3f2b1d3ba72.jpg)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.