### PR TITLE
fix-#1439 Account Number field for user registration also accepts alphabetical letters

### DIFF
--- a/app/src/main/res/layout/fragment_registration.xml
+++ b/app/src/main/res/layout/fragment_registration.xml
@@ -13,7 +13,7 @@
 
         <EditText android:hint="@string/account_number"
                   android:id="@+id/et_account_number"
-                  android:inputType="number"
+                  android:inputType="text"
                   android:layout_height="wrap_content"
                   android:layout_width="match_parent"/>
     </com.google.android.material.textfield.TextInputLayout>


### PR DESCRIPTION
Account Number field for self-service user registration also accepts alphabetical letters.

Fixes #1439 

Screenshots  :

<img width="30%" src="https://user-images.githubusercontent.com/39809059/77253845-3097ed00-6c83-11ea-9635-6316cde6ee66.jpg">

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.