### PR TITLE
fix#1460 - Message screen shown when no questions are returned

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/fragments/HelpFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/HelpFragment.kt
@@ -12,6 +12,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import butterknife.BindView
 import butterknife.ButterKnife
+import com.github.therajanmaurya.sweeterror.SweetUIErrorHandler
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import org.mifos.mobile.R
 import org.mifos.mobile.models.FAQ
@@ -38,6 +39,10 @@ import javax.inject.Inject
     var bnvHelp: BottomNavigationView? = null
 
     @kotlin.jvm.JvmField
+    @BindView(R.id.layout_error)
+    var layoutError: View? = null
+
+    @kotlin.jvm.JvmField
     @Inject
     var faqAdapter: FAQAdapter? = null
 
@@ -46,6 +51,8 @@ import javax.inject.Inject
     var presenter: HelpPresenter? = null
     private var rootView: View? = null
     private var faqArrayList: ArrayList<FAQ?>? = null
+    private lateinit var sweetUIErrorHandler: SweetUIErrorHandler
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View? {
         rootView = inflater.inflate(R.layout.fragment_help, container, false)
@@ -54,6 +61,7 @@ import javax.inject.Inject
         ButterKnife.bind(this, rootView!!)
         presenter?.attachView(this)
         setToolbarTitle(getString(R.string.help))
+        sweetUIErrorHandler = SweetUIErrorHandler(activity, rootView)
         showUserInterface()
         if (savedInstanceState == null) {
             presenter?.loadFaq()
@@ -121,10 +129,23 @@ import javax.inject.Inject
             }
 
             override fun onQueryTextChange(newText: String): Boolean {
-                faqAdapter?.updateList(presenter?.filterList(faqArrayList, newText))
+                val filteredFAQList = presenter?.filterList(faqArrayList, newText)
+                filteredFAQList?.let {
+                    if (it.isNotEmpty()) {
+                        sweetUIErrorHandler.hideSweetErrorLayoutUI(rvFaq, layoutError)
+                        faqAdapter?.updateList(it)
+                    } else {
+                        showEmptyFAQUI()
+                    }
+                } ?: showEmptyFAQUI()
                 return false
             }
         })
+    }
+
+    private fun showEmptyFAQUI() {
+        sweetUIErrorHandler.showSweetEmptyUI(getString(R.string.questions),
+                R.drawable.ic_help_black_24dp, rvFaq, layoutError)
     }
 
     override fun showProgress() {

--- a/app/src/main/res/layout/fragment_help.xml
+++ b/app/src/main/res/layout/fragment_help.xml
@@ -33,6 +33,11 @@
         android:layout_weight="1"
         android:layout_width="match_parent"/>
 
+    <include
+        layout="@layout/layout_sweet_exception_handler"
+        android:id="@+id/layout_error"
+        android:visibility="gone" />
+
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bnv_help"
         android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -572,6 +572,7 @@
     <string name="savings_account_transaction">Savings Account Transaction</string>
     <string name="transaction_period">Transaction Period</string>
     <string name="transaction_type">Transaction Type</string>
+    <string name="questions">Questions</string>
 
     <string-array name="languages" translatable="false">
         <item>English</item>


### PR DESCRIPTION
Fixes #1460 

**Screenshot:**
<img src="https://user-images.githubusercontent.com/46667021/80243207-66663200-8684-11ea-831e-d76ae6019635.jpeg" height="400" width="250" />

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.