### PR TITLE
feat: Add UI Tests for Login flow with Espresso

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,6 +68,9 @@ android {
     androidExtensions {
         experimental = true
     }
+    testOptions {
+        animationsDisabled = true
+    }
 }
 
 dependencies {
@@ -139,6 +142,9 @@ dependencies {
 
     //TableView
     implementation "com.evrencoskun.library:tableview:$rootProject.tableViewVersion"
+
+    //Espresso Idling Resource
+    implementation "androidx.test.espresso:espresso-idling-resource:$rootProject.espressoVersion"
 
     // Unit tests dependencies
     testImplementation "junit:junit:$rootProject.jUnitVersion"

--- a/app/src/androidTest/java/org/mifos/mobile/ui/activities/LoginSetPasscodeTest.kt
+++ b/app/src/androidTest/java/org/mifos/mobile/ui/activities/LoginSetPasscodeTest.kt
@@ -1,0 +1,192 @@
+package org.mifos.mobile.ui.activities
+
+import android.view.View
+import android.view.ViewGroup
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.IdlingRegistry
+import androidx.test.espresso.ViewInteraction
+import androidx.test.espresso.action.ViewActions.*
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.filters.LargeTest
+import androidx.test.rule.ActivityTestRule
+import androidx.test.rule.GrantPermissionRule
+import androidx.test.runner.AndroidJUnit4
+
+import org.hamcrest.Description
+import org.hamcrest.Matcher
+import org.hamcrest.Matchers.`is`
+import org.hamcrest.Matchers.allOf
+import org.hamcrest.TypeSafeMatcher
+
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mifos.mobile.R
+import org.mifos.mobile.utils.EspressoIdlingResouce
+
+/**
+ * UI Testing for Login using Espresso
+ *
+ * @author Ashwin Ramakrishnan
+ * @since 22/08/2020
+ */
+
+@LargeTest
+@RunWith(AndroidJUnit4::class)
+class LoginSetPasscodeTest {
+
+    @Rule
+    @JvmField
+    var mActivityTestRule = ActivityTestRule(SplashActivity::class.java)
+
+    @Rule
+    @JvmField
+    val grantPermissionRule: GrantPermissionRule =
+        GrantPermissionRule.grant(android.Manifest.permission.READ_PHONE_STATE)
+
+    @Before
+    fun registerIdlingResource() {
+        IdlingRegistry.getInstance().register(EspressoIdlingResouce.countingIdlingResource)
+    }
+
+    @After
+    fun unregisterIdlingResource() {
+        IdlingRegistry.getInstance().unregister(EspressoIdlingResouce.countingIdlingResource)
+    }
+
+    @Test
+    fun loginSetPasscodeTest() {
+        val usernameEditText = onView(
+            allOf(
+                childAtPosition(
+                    childAtPosition(
+                        withId(R.id.til_username),
+                        0
+                    ),
+                    0
+                )
+            )
+        )
+
+        val passwordEditText = onView(
+            allOf(
+                childAtPosition(
+                    childAtPosition(
+                        withId(R.id.til_password),
+                        0
+                    ),
+                    0
+                )
+            )
+        )
+
+        val showPasswordToggle = onView(
+            allOf(
+                withId(R.id.text_input_password_toggle), withContentDescription("Show password"),
+                childAtPosition(
+                    childAtPosition(
+                        withId(R.id.til_password),
+                        0
+                    ),
+                    1
+                )
+            )
+        )
+
+        val loginButton = onView(
+            allOf(
+                withId(R.id.btn_login), withText("Login"),
+                childAtPosition(
+                    allOf(
+                        withId(R.id.ll_login),
+                        childAtPosition(
+                            withClassName(`is`("androidx.core.widget.NestedScrollView")),
+                            0
+                        )
+                    ),
+                    3
+                )
+            )
+        )
+
+        val zeroButtonPasscode = onView(
+            allOf(
+                withId(R.id.btn_zero), withText("0"),
+                childAtPosition(
+                    childAtPosition(
+                        withClassName(`is`("android.widget.TableLayout")),
+                        3
+                    ),
+                    1
+                )
+            )
+        )
+
+        val passcodeLayout: ViewInteraction = onView(withId(R.id.cl_rootview))
+
+        val passcodeVisibilityButton = onView(
+            allOf(
+                withId(R.id.iv_visibility),
+                childAtPosition(
+                    childAtPosition(
+                        withClassName(`is`("android.widget.LinearLayout")),
+                        3
+                    ),
+                    1
+                )
+            )
+        )
+
+        val proceedButton = onView(allOf(withId(R.id.btn_save), withText("Proceed")))
+
+        val appCompatButton12 = onView(allOf(withId(R.id.btn_save), withText("Save")))
+
+        //Test actions
+
+        usernameEditText.perform(click(), replaceText("ashwinr"), closeSoftKeyboard())
+
+        passwordEditText.perform(click(), replaceText("password"), closeSoftKeyboard())
+
+        for (i in 1..2) showPasswordToggle.perform(click())
+
+        loginButton.perform(click())
+
+        passcodeLayout.check(matches(isDisplayed()))
+
+        passcodeVisibilityButton.perform(click())
+
+        passcodeLayout.perform(swipeUp()) //To make the lower part of the screen visible in smaller devices
+
+        for (i in 1..4) zeroButtonPasscode.perform(click()) // Inputs passcode as 0000
+
+        proceedButton.perform(click())
+
+        passcodeLayout.perform(swipeUp()) //To make the lower part of the screen visible in smaller devices
+
+        for (i in 1..4) zeroButtonPasscode.perform(click()) // Inputs passcode as 0000
+
+        appCompatButton12.perform(click())
+    }
+
+    private fun childAtPosition(
+        parentMatcher: Matcher<View>, position: Int
+    ): Matcher<View> {
+
+        return object : TypeSafeMatcher<View>() {
+            override fun describeTo(description: Description) {
+                description.appendText("Child at position $position in parent ")
+                parentMatcher.describeTo(description)
+            }
+
+            public override fun matchesSafely(view: View): Boolean {
+                val parent = view.parent
+                return parent is ViewGroup && parentMatcher.matches(parent)
+                        && view == parent.getChildAt(position)
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/mifos/mobile/ui/activities/LoginActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/LoginActivity.kt
@@ -20,6 +20,7 @@ import org.mifos.mobile.presenters.LoginPresenter
 import org.mifos.mobile.ui.activities.base.BaseActivity
 import org.mifos.mobile.ui.views.LoginView
 import org.mifos.mobile.utils.Constants
+import org.mifos.mobile.utils.EspressoIdlingResouce
 import org.mifos.mobile.utils.Network
 import org.mifos.mobile.utils.Toaster
 
@@ -88,6 +89,7 @@ class LoginActivity : BaseActivity(), LoginView {
      * Starts [PassCodeActivity]
      */
     override fun showPassCodeActivity() {
+        EspressoIdlingResouce.decrement()
         showToast(getString(R.string.toast_welcome, userName))
         startPassCodeActivity()
     }
@@ -98,6 +100,7 @@ class LoginActivity : BaseActivity(), LoginView {
      * @param errorMessage Error message that tells the user about the problem.
      */
     override fun showMessage(errorMessage: String?) {
+        EspressoIdlingResouce.decrement()
         showToast(errorMessage!!, Toast.LENGTH_LONG)
         llLogin?.visibility = View.VISIBLE
     }
@@ -127,6 +130,7 @@ class LoginActivity : BaseActivity(), LoginView {
         val username = tilUsername?.editText?.editableText.toString()
         val password = tilPassword?.editText?.editableText.toString()
         if (Network.isConnected(this)) {
+            EspressoIdlingResouce.increment()
             val payload = LoginPayload()
             payload.username = username
             payload.password = password

--- a/app/src/main/java/org/mifos/mobile/utils/EspressoIdlingResouce.kt
+++ b/app/src/main/java/org/mifos/mobile/utils/EspressoIdlingResouce.kt
@@ -1,0 +1,29 @@
+package org.mifos.mobile.utils
+
+import androidx.test.espresso.idling.CountingIdlingResource
+
+/**
+ * Used for handling async operations in the app for UI testing using Espresso
+ * https://developer.android.com/training/testing/espresso/idling-resource
+ *
+ * @author Ashwin Ramakrishnan
+ * @since 21/08/2020
+ */
+
+object EspressoIdlingResouce {
+
+    private const val RESOURCE = "GLOBAL"
+
+    @JvmField
+    val countingIdlingResource = CountingIdlingResource(RESOURCE)
+
+    fun increment() {
+        countingIdlingResource.increment()
+    }
+
+    fun decrement() {
+        if (!countingIdlingResource.isIdleNow) {
+            countingIdlingResource.decrement()
+        }
+    }
+}


### PR DESCRIPTION
Uses the espresso library to perform UI tests for complete login flow
<p align="center"><img src="https://user-images.githubusercontent.com/20596763/91065420-0f7e6280-e64e-11ea-8bc9-6aa4f1689ae6.gif" width = 300/>
</p>
</br>


Steps implemented:
- Enter username: _ashwinr_
- Enter password: _password_
- Tap password visibility toggle twice
- Press login button
- Wait for login request to complete (Uses `CountingIdlingResource`)
- Checks if passcode activity layout is properly loaded and displayed
- Tap password visibility toggle 
- Perform swipe up action to make the digit _0_ and _proceed_ buttons visible in smaller devices (Required for Travis CI to pass)
- Tap digit _0_ four times (To input passcode as 0000)
- Press proceed button
- Perform passcode input again
- Press save button

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.