### PR TITLE
chore: Update branch policy in README.md for Kotlin conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ For pull request guidelines please click <a href="https://github.com/openMF/mifo
 
 We have the following branches :
 
+ * **gsoc#2020**
+	 The app is currently being converted to Kotlin for enabling multiplatform development in the future. Kotlin version of the app is currently pushed in this branch. Any further development shall be pushed to this branch until the conversion is reviewed and merged into development branch.
+	  
  * **development**
      All the contributions should be pushed to this branch. If you're making a contribution,
      you are supposed to make a pull request to _development_.


### PR DESCRIPTION
Updated branch policy to instruct developers work on top of the [gsoc#2020](https://github.com/openMF/mifos-mobile/tree/gsoc%232020) branch which contains the Kotlin version of the app. 

- [x] If you have multiple commits please combine them into one commit by squashing them.