### PR TITLE
fix- Changed title on back button pressed

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/fragments/SettingsFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/SettingsFragment.kt
@@ -25,6 +25,7 @@ class SettingsFragment : PreferenceFragmentCompat(), OnSharedPreferenceChangeLis
 
     override fun onResume() {
         super.onResume()
+        activity?.title = getString(R.string.settings)
         preferenceScreen.sharedPreferences.registerOnSharedPreferenceChangeListener(this)
     }
 


### PR DESCRIPTION
Fixes #1392 
Settings ToolbarTitle changed on BackButton Pressed from Change Password 

**Screenshots**
![ezgif-3-42bb9c5a8e1d](https://user-images.githubusercontent.com/39809059/76301558-76989c80-62e4-11ea-96a8-0ab0592d8460.gif)

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.