### PR TITLE
#1487-feat: Display toast for logout status

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/activities/HomeActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/HomeActivity.kt
@@ -182,6 +182,9 @@ class HomeActivity : BaseActivity(), UserDetailsView, NavigationView.OnNavigatio
                             i.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
                             startActivity(i)
                             finish()
+                            Toast.makeText(this,
+                                    R.string.logged_out_successfully, Toast.LENGTH_SHORT)
+                                    .show();
                         })
                 .setNegativeButton(getString(R.string.cancel),
                         DialogInterface.OnClickListener { _, _ -> setNavigationViewSelectedItem(R.id.item_home) })

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -573,6 +573,7 @@
     <string name="transaction_period">Transaction Period</string>
     <string name="transaction_type">Transaction Type</string>
     <string name="questions">Questions</string>
+    <string name="logged_out_successfully">Logged out successfully</string>
 
     <string-array name="languages" translatable="false">
         <item>English</item>


### PR DESCRIPTION
Fixes #1487 

**Screenshots:**
<img height="700" width="300" src="https://user-images.githubusercontent.com/55937724/101274570-50e1ea80-37c5-11eb-8b03-a7e6c509d86b.png" />

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.