### PR TITLE
fix #1316: Fix incorrect icon on fetch profile error

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/fragments/UserProfileFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/UserProfileFragment.kt
@@ -256,7 +256,7 @@ class UserProfileFragment : BaseFragment(), UserDetailsView {
     override fun showError(message: String?) {
         Toaster.show(rootView, message)
         sweetUIErrorHandler?.showSweetCustomErrorUI(getString(R.string.error_fetching_user_profile),
-                R.drawable.ic_assignment_turned_in_black_24dp, appBarLayout,
+                R.drawable.ic_error_black_24dp, appBarLayout,
                 layoutError)
         fabEdit?.visibility = View.GONE
     }


### PR DESCRIPTION
Fixes #1316 

Screenshots:

1. **Old icon:**

<img src="https://user-images.githubusercontent.com/55937724/101328415-fa90ac80-3895-11eb-8565-de23ddd22e3b.png" width="350" />

2. **New icon:**

<img src="https://user-images.githubusercontent.com/55937724/102262162-af7f3500-3f38-11eb-9c41-5e1acb3e0399.png" width="350" height="800">


- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.