### PR TITLE
fix #1499: dismiss soft keyboard on background tap

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/activities/LoginActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/LoginActivity.kt
@@ -1,19 +1,18 @@
 package org.mifos.mobile.ui.activities
 
+import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
 import android.widget.LinearLayout
 import android.widget.Toast
-
 import androidx.appcompat.widget.AppCompatButton
-
 import butterknife.BindView
 import butterknife.ButterKnife
 import butterknife.OnClick
-
 import com.google.android.material.textfield.TextInputLayout
-
 import org.mifos.mobile.R
 import org.mifos.mobile.models.payload.LoginPayload
 import org.mifos.mobile.presenters.LoginPresenter
@@ -22,7 +21,7 @@ import org.mifos.mobile.ui.views.LoginView
 import org.mifos.mobile.utils.Constants
 import org.mifos.mobile.utils.Network
 import org.mifos.mobile.utils.Toaster
-
+import org.mifos.mobile.utils.Utils
 import javax.inject.Inject
 
 /**
@@ -58,6 +57,7 @@ class LoginActivity : BaseActivity(), LoginView {
         setContentView(R.layout.activity_login)
         ButterKnife.bind(this)
         loginPresenter?.attachView(this)
+        dismissKeyboardOnBackgroundTap(findViewById(R.id.ll_background))
     }
 
     /**
@@ -155,5 +155,25 @@ class LoginActivity : BaseActivity(), LoginView {
         intent.putExtra(Constants.INTIAL_LOGIN, true)
         startActivity(intent)
         finish()
+    }
+
+    //Method to setup ui to dismiss soft keyboard on background tap
+    private fun dismissKeyboardOnBackgroundTap(view: View) {
+
+        // Set up touch listener for non-text box views to hide keyboard.
+        if (view !is TextInputLayout) {
+            view.setOnTouchListener { v, event ->
+                Utils.hideSoftKeyboard(this@LoginActivity)
+                false
+            }
+        }
+
+        //If a layout container, iterate over children and seed recursion.
+        if (view is ViewGroup) {
+            for (i in 0 until view.childCount) {
+                val innerView = view.getChildAt(i)
+                dismissKeyboardOnBackgroundTap(innerView)
+            }
+        }
     }
 }

--- a/app/src/main/java/org/mifos/mobile/utils/Utils.kt
+++ b/app/src/main/java/org/mifos/mobile/utils/Utils.kt
@@ -1,5 +1,6 @@
 package org.mifos.mobile.utils
 
+import android.app.Activity
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.PorterDuff
@@ -9,8 +10,10 @@ import android.graphics.drawable.LayerDrawable
 import android.net.Uri
 import android.util.Log
 import android.view.Menu
+import android.view.inputmethod.InputMethodManager
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
+import com.mifos.mobile.passcode.BasePassCodeActivity
 import org.mifos.mobile.R
 import java.io.File
 import java.io.FileOutputStream
@@ -76,5 +79,13 @@ object Utils {
                     str.length) + " ")
         }
         return builder.toString()
+    }
+
+    fun hideSoftKeyboard(activity: Activity) {
+        val inputMethodManager: InputMethodManager = activity.getSystemService(
+                BasePassCodeActivity.INPUT_METHOD_SERVICE) as InputMethodManager
+        inputMethodManager.hideSoftInputFromWindow(
+                activity.currentFocus.windowToken, 0)
+
     }
 }

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -5,7 +5,8 @@
     android:background="@color/white"
     android:layout_height="match_parent"
     android:layout_width="match_parent"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:id="@+id/ll_background">
 
     <androidx.core.widget.NestedScrollView
         android:fitsSystemWindows="true"


### PR DESCRIPTION
Fixes #1499 

Here is the GIF showing output behaviour when tapped on bankground.
<img src="https://user-images.githubusercontent.com/63469151/101877530-25d80c00-3bb4-11eb-8140-06fbd2dcaa0f.gif" width="270" height="538">

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.