### PR TITLE
Fixes #1073: Toast message in Recent Transactions fixed

### DIFF
--- a/app/src/main/java/org/mifos/mobile/presenters/RecentTransactionsPresenter.kt
+++ b/app/src/main/java/org/mifos/mobile/presenters/RecentTransactionsPresenter.kt
@@ -81,9 +81,6 @@ class RecentTransactionsPresenter @Inject constructor(
                                     ?.showLoadMoreRecentTransactions(transactions.pageItems)
                         } else if (transactions.pageItems.isNotEmpty()) {
                             mvpView?.showRecentTransactions(transactions.pageItems)
-                        } else {
-                            mvpView?.showMessage(
-                                    context?.getString(R.string.no_more_transactions_available))
                         }
                     }
                 })?.let {

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/RecentTransactionsFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/RecentTransactionsFragment.kt
@@ -28,6 +28,7 @@ import org.mifos.mobile.utils.Constants
 import org.mifos.mobile.utils.DividerItemDecoration
 import org.mifos.mobile.utils.EndlessRecyclerViewScrollListener
 import org.mifos.mobile.utils.Network.isConnected
+import org.mifos.mobile.utils.Toaster
 
 import javax.inject.Inject
 
@@ -111,6 +112,14 @@ class RecentTransactionsFragment : BaseFragment(), RecentTransactionsView, OnRef
                 object : EndlessRecyclerViewScrollListener(layoutManager) {
                     override fun onLoadMore(page: Int, totalItemsCount: Int, view: RecyclerView?) {
                         recentTransactionsPresenter?.loadRecentTransactions(true, totalItemsCount)
+                    }
+
+                    override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
+                        super.onScrollStateChanged(recyclerView, newState)
+                        if (!recyclerView.canScrollVertically(1) &&
+                                newState == RecyclerView.SCROLL_STATE_IDLE) {
+                            Toaster.show(rootView, R.string.no_more_transactions_available)
+                        }
                     }
                 })
         swipeTransactionContainer?.setColorSchemeColors(*activity!!


### PR DESCRIPTION
Fixes #1073 
Now message is shown only when user scrolls for more items.

![GIF-201217_111940 1](https://user-images.githubusercontent.com/70195106/102449436-4263c080-405a-11eb-88bc-d39e9b1ee7a8.gif)

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.