### PR TITLE
Fixes_#1492: No warning message when going back from register account fixed

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/activities/RegistrationActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/RegistrationActivity.kt
@@ -1,10 +1,12 @@
 package org.mifos.mobile.ui.activities
 
+import android.content.DialogInterface
 import android.os.Bundle
 
 import org.mifos.mobile.R
 import org.mifos.mobile.ui.activities.base.BaseActivity
 import org.mifos.mobile.ui.fragments.RegistrationFragment
+import org.mifos.mobile.utils.MaterialDialog
 
 class RegistrationActivity : BaseActivity() {
 
@@ -12,5 +14,17 @@ class RegistrationActivity : BaseActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_registration)
         replaceFragment(RegistrationFragment.newInstance(), false, R.id.container)
+    }
+
+    override fun onBackPressed() {
+        MaterialDialog.Builder().init(this)
+                .setTitle(getString(R.string.dialog_cancel_registration_title))
+                .setMessage(getString(R.string.dialog_cancel_registration_message))
+                .setPositiveButton(getString(R.string.cancel),
+                        DialogInterface.OnClickListener { _, _ -> super.onBackPressed() })
+                .setNegativeButton(R.string.continue_str,
+                        DialogInterface.OnClickListener { dialog, _ -> dialog.dismiss() })
+                .createMaterialDialog()
+                .show()
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -573,6 +573,9 @@
     <string name="transaction_period">Transaction Period</string>
     <string name="transaction_type">Transaction Type</string>
 
+    <string name="dialog_cancel_registration_message">Do you want to cancel registering New Account ?</string>
+    <string name="dialog_cancel_registration_title">Cancel Registration</string>
+
     <string-array name="languages" translatable="false">
         <item>English</item>
         <item>हिंदी</item>


### PR DESCRIPTION
Fixes #1492
Now if user presses back buuton while creating new account, warning dialog pops up for confirmation to user. It saves data from accidental backpress.

https://user-images.githubusercontent.com/70195106/102694795-51f52c00-4249-11eb-85ab-f066976ba473.mp4

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.