### PR TITLE
Fixes #1333: User detail opens on clicking header view

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/activities/HomeActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/HomeActivity.kt
@@ -221,6 +221,7 @@ class HomeActivity : BaseActivity(), UserDetailsView, NavigationView.OnNavigatio
         ivTextDrawableUserProfilePicture = ButterKnife.findById(headerView, R.id.iv_user_image)
         ivTextDrawableUserProfilePicture?.setOnClickListener(this)
         ivCircularUserProfilePicture?.setOnClickListener(this)
+        headerView.setOnClickListener(this)
     }
 
     /**


### PR DESCRIPTION
Fixes #1333 
Now on clicking anywhere in header User Details Section opens.

https://user-images.githubusercontent.com/70195106/103025220-5be39b80-4577-11eb-95e8-9b60c2354afb.mp4

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.