### PR TITLE
Fixes_#1641: Alignment of circular imageView in User Details fixed

### DIFF
--- a/app/src/main/res/layout/fragment_user_profile.xml
+++ b/app/src/main/res/layout/fragment_user_profile.xml
@@ -29,7 +29,7 @@
                 tools:src="@drawable/mifos_logo"/>
 
             <LinearLayout
-                android:gravity="bottom"
+                android:gravity="center_vertical"
                 android:layout_height="match_parent"
                 android:layout_margin="@dimen/margin_32dp"
                 android:layout_width="150dp"


### PR DESCRIPTION
Fixes #1641 
Alignment of imageview has be set to `center_vetical` along with "10dp" `margin_top`
<img alt="ss" width="333" src="https://user-images.githubusercontent.com/70195106/103026775-9dc21100-457a-11eb-9db9-3d7b703804a4.jpeg">

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.