### PR TITLE
Fix #1646: Fix confirmation dialog for forgot passcode option

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/activities/PassCodeActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/PassCodeActivity.kt
@@ -47,17 +47,19 @@ class PassCodeActivity : MifosPassCodeActivity() {
     }
 
     override fun startLoginActivity() {
+        val i = Intent(this@PassCodeActivity,
+                LoginActivity::class.java)
+        i.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        startActivity(i)
+        finish()
+    }
+
+    override fun forgotPassCode(v: View?) {
         MaterialDialog.Builder().init(this@PassCodeActivity)
                 .setCancelable(false)
                 .setMessage(R.string.login_using_password_confirmation)
                 .setPositiveButton(getString(R.string.logout),
-                        DialogInterface.OnClickListener { _, _ ->
-                            val i = Intent(this@PassCodeActivity,
-                                    LoginActivity::class.java)
-                            i.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-                            startActivity(i)
-                            finish()
-                        })
+                        DialogInterface.OnClickListener { _, _ -> startLoginActivity() })
                 .setNegativeButton(getString(R.string.cancel),
                         DialogInterface.OnClickListener { dialog, _ -> dialog.dismiss() })
                 .createMaterialDialog()


### PR DESCRIPTION
Made changes to show a confirmation dialog on selecting “Forgot passcode, log in manually” option instead of directly logging out the user. User is logged out when “Logout” in the confirmation dialog is selected and selecting “Cancel” dismisses the dialog without any action.

Overrode the function` forgotPassCode()` in `PassCodeActivity` to display confirmation dialog. The user is logged out and login activity is launched ( `startLoginActivity()` is called) after the user selects "Logout" in the confirmation dialog.

Fixes #1646 

Please Add Screenshots If there are any UI changes.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.