### PR TITLE
fix#1663 - Back Button Press from Update Password handled

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/fragments/UpdatePasswordFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/UpdatePasswordFragment.kt
@@ -107,7 +107,8 @@ import javax.inject.Inject
     override fun showPasswordUpdatedSuccessfully() {
         Toast.makeText(context, getString(R.string.string_changed_successfully,
                 getString(R.string.password)), Toast.LENGTH_SHORT).show()
-        startActivity(Intent(context, SettingsActivity::class.java))
+        (activity as BaseActivity).clearFragmentBackStack()
+        (activity as BaseActivity).replaceFragment(SettingsFragment.newInstance(), true, R.id.container)
     }
 
     override fun showProgress() {


### PR DESCRIPTION
## Fixes #1663 

On Back Button Press from Settings after password update goes to Home Activity


https://user-images.githubusercontent.com/39809059/103340296-b7e37e00-4aa9-11eb-88e7-20f80cd6c123.mp4


- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.