### PR TITLE
Fixed fatal IndexOutOfBoundsException in LoanApplicationFragment.kt

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/fragments/LoanApplicationFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/LoanApplicationFragment.kt
@@ -497,7 +497,8 @@ class LoanApplicationFragment : BaseFragment(), LoanApplicationMvpView, OnDatePi
                             LoanState.UPDATE)
                 }
             }
-            R.id.sp_loan_purpose -> purposeId = loanTemplate?.loanPurposeOptions?.get(position)?.id
+
+            R.id.sp_loan_purpose -> purposeId = loanTemplate?.loanPurposeOptions?.getOrNull(position)?.id;
         }
     }
 


### PR DESCRIPTION
Fixes: fatal IndexOutOfBoundsException in LoanApplicationFragment.kt

How to produce this error:
Apply for Loan > REVIEW > SUBMIT LOAN > go back

LOG::
```
2021-01-12 21:07:20.071 16818-16818/org.mifos.mobile E/AndroidRuntime: FATAL EXCEPTION: main
    Process: org.mifos.mobile, PID: 16818
    java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
        at java.util.ArrayList.get(ArrayList.java:437)
        at org.mifos.mobile.ui.fragments.LoanApplicationFragment.onItemSelected(LoanApplicationFragment.kt:501)
        at android.widget.AdapterView.fireOnSelected(AdapterView.java:944)
        at android.widget.AdapterView.dispatchOnItemSelected(AdapterView.java:933)
        at android.widget.AdapterView.selectionChanged(AdapterView.java:922)
        at android.widget.AdapterView.checkSelectionChanged(AdapterView.java:1105)
        at android.widget.AdapterView.handleDataChanged(AdapterView.java:1081)
        at android.widget.AbsSpinner.onMeasure(AbsSpinner.java:191)
        at android.widget.Spinner.onMeasure(Spinner.java:602)
        at androidx.appcompat.widget.AppCompatSpinner.onMeasure(AppCompatSpinner.java:421)
        at android.view.View.measure(View.java:23200)
        at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:6753)
        at android.widget.LinearLayout.measureChildBeforeLayout(LinearLayout.java:1535)
        at android.widget.LinearLayout.measureVertical(LinearLayout.java:825)
        at android.widget.LinearLayout.onMeasure(LinearLayout.java:704)
        at android.view.View.measure(View.java:23200)
        at androidx.core.widget.NestedScrollView.measureChildWithMargins(NestedScrollView.java:1502)
        at android.widget.FrameLayout.onMeasure(FrameLayout.java:185)
        at androidx.core.widget.NestedScrollView.onMeasure(NestedScrollView.java:556)
        at android.view.View.measure(View.java:23200)
        at android.widget.RelativeLayout.measureChildHorizontal(RelativeLayout.java:715)
        at android.widget.RelativeLayout.onMeasure(RelativeLayout.java:461)
        at android.view.View.measure(View.java:23200)
        at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:6753)
        at android.widget.FrameLayout.onMeasure(FrameLayout.java:185)
        at android.view.View.measure(View.java:23200)
        at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:6753)
        at android.widget.LinearLayout.measureChildBeforeLayout(LinearLayout.java:1535)
        at android.widget.LinearLayout.measureVertical(LinearLayout.java:825)
        at android.widget.LinearLayout.onMeasure(LinearLayout.java:704)
        at android.view.View.measure(View.java:23200)
        at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:6753)
        at androidx.coordinatorlayout.widget.CoordinatorLayout.onMeasureChild(CoordinatorLayout.java:733)
        at androidx.coordinatorlayout.widget.CoordinatorLayout.onMeasure(CoordinatorLayout.java:805)
        at android.view.View.measure(View.java:23200)
        at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:6753)
        at android.widget.FrameLayout.onMeasure(FrameLayout.java:185)
        at androidx.appcompat.widget.ContentFrameLayout.onMeasure(ContentFrameLayout.java:143)
        at android.view.View.measure(View.java:23200)
        at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:6753)
        at android.widget.LinearLayout.measureChildBeforeLayout(LinearLayout.java:1535)
        at android.widget.LinearLayout.measureVertical(LinearLayout.java:825)
        at android.widget.LinearLayout.onMeasure(LinearLayout.java:704)
        at android.view.View.measure(View.java:23200)
        at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:6753)
        at android.widget.FrameLayout.onMeasure(FrameLayout.java:185)
        at android.view.View.measure(View.java:23200)
        at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:6753)
        at android.widget.LinearLayout.measureChildBeforeLayout(LinearLayout.java:1535)
        at android.widget.LinearLayout.measureVertical(LinearLayout.java:825)
        at android.widget.LinearLayout.onMeasure(LinearLayout.java:704)
        at android.view.View.measure(View.java:23200)
        at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:6753)
        at android.widget.FrameLayout.onMeasure(FrameLayout.java:185)
        at com.android.internal.policy.DecorView.onMeasure(DecorView.java:720)
        at android.view.View.measure(View.java:23200)
        at android.view.ViewRootImpl.performMeasure(ViewRootImpl.java:2796)
2021-01-12 21:07:24.639 16904-16904/org.mifos.mobile E/AndroidRuntime: FATAL EXCEPTION: main
    Process: org.mifos.mobile, PID: 16904
    java.lang.RuntimeException: Unable to start activity ComponentInfo{org.mifos.mobile/org.mifos.mobile.ui.activities.HomeActivity}: android.os.BadParcelableException: Parcelable protocol requires a Parcelable.Creator object called CREATOR on class org.mifos.mobile.models.client.Client
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2946)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3081)
        at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:78)
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:108)
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:68)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1831)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loop(Looper.java:201)
        at android.app.ActivityThread.main(ActivityThread.java:6823)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:547)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:873)
     Caused by: android.os.BadParcelableException: Parcelable protocol requires a Parcelable.Creator object called CREATOR on class org.mifos.mobile.models.client.Client
        at android.os.Parcel.readParcelableCreator(Parcel.java:2851)
        at android.os.Parcel.readParcelable(Parcel.java:2768)
        at android.os.Parcel.readValue(Parcel.java:2671)
        at android.os.Parcel.readArrayMapInternal(Parcel.java:3045)
        at android.os.BaseBundle.initializeFromParcelLocked(BaseBundle.java:288)
        at android.os.BaseBundle.unparcel(BaseBundle.java:232)
        at android.os.BaseBundle.getBoolean(BaseBundle.java:903)
        at android.app.Activity.restoreHasCurrentPermissionRequest(Activity.java:7576)
        at android.app.Activity.performCreate(Activity.java:7218)
        at android.app.Activity.performCreate(Activity.java:7213)
        at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1272)
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2926)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3081) 
        at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:78) 
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:108) 
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:68) 
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1831) 
        at android.os.Handler.dispatchMessage(Handler.java:106) 
        at android.os.Looper.loop(Looper.java:201) 
        at android.app.ActivityThread.main(ActivityThread.java:6823) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:547) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:873) 

```
