### PR TITLE
Fixes #1689: Removed Contact Us from SavingAccountsTransactionFragment.kt

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/fragments/SavingAccountsTransactionFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/SavingAccountsTransactionFragment.kt
@@ -198,16 +198,6 @@ class SavingAccountsTransactionFragment : BaseFragment(), SavingAccountsTransact
                 R.drawable.ic_compare_arrows_black_24dp, rvSavingAccountsTransaction, layoutError)
     }
 
-    /**
-     * Opens up Phone Dialer
-     */
-    @OnClick(R.id.tv_help_line_number)
-    fun dialHelpLineNumber() {
-        val intent = Intent(Intent.ACTION_DIAL)
-        intent.data = Uri.parse("tel:" + getString(R.string.help_line_number))
-        startActivity(intent)
-    }
-
     private fun startDatePick() {
         datePick = DatePick.START
         mfDatePicker?.show(activity?.supportFragmentManager, Constants.DFRAG_DATE_PICKER)

--- a/app/src/main/res/layout/fragment_saving_account_transactions.xml
+++ b/app/src/main/res/layout/fragment_saving_account_transactions.xml
@@ -15,33 +15,8 @@
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rv_saving_accounts_transaction"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
+            android:layout_height="match_parent"
             android:layout_width="match_parent"/>
-
-        <LinearLayout
-            android:layout_height="wrap_content"
-            android:layout_width="match_parent"
-            android:orientation="horizontal"
-            android:padding="10dp">
-
-            <TextView
-                android:layout_height="wrap_content"
-                android:layout_width="wrap_content"
-                android:text="@string/need_help"/>
-
-            <TextView
-                android:clickable="true"
-                android:focusable="true"
-                android:id="@+id/tv_help_line_number"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="@dimen/default_margin"
-                android:layout_marginStart="@dimen/default_margin"
-                android:layout_width="wrap_content"
-                android:text="@string/help_line_number"
-                android:textColor="@color/blue"/>
-
-        </LinearLayout>
 
     </LinearLayout>
 


### PR DESCRIPTION
Fixes #1689
Removed Contact Us layout from SavingAccountsTransactionFragment.kt

<img width="333" src="https://user-images.githubusercontent.com/70195106/104349240-aded6080-5528-11eb-8312-6c79fd2c1844.jpeg">

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.