### PR TITLE
fix: #1694 Recycler view behaviour rectified

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/adapters/SavingAccountsTransactionListAdapter.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/adapters/SavingAccountsTransactionListAdapter.kt
@@ -57,6 +57,8 @@ class SavingAccountsTransactionListAdapter @Inject constructor() :
         if (paymentDetailData != null) {
             holder.tvTransactionDetailData?.visibility = View.VISIBLE
             holder.tvTransactionDetailData?.text = paymentDetailData.paymentType.name
+        } else {
+            holder.tvTransactionDetailData?.visibility = View.GONE
         }
         holder.tvTransactionDate?.text = getDateAsString(date)
         val color = getColor(transactionType)


### PR DESCRIPTION
## Issue Fix
 Fixes #1694

## Fixture Analysis.

When notifyDataSetChanged is called the recycler view mismatches the paymentDetailData because the visibility of tvTransactionDetailData is assumed to be gone. In adapter, we have to explicitly write visiblity=gone because of notifyDataSetChanged

For reference: https://stackoverflow.com/a/30082483

## Please Add Screenshots If there are any UI changes.

https://user-images.githubusercontent.com/50913976/104448718-85ff0b00-55c3-11eb-8be2-f373d9d8d6de.mp4

## Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.