### PR TITLE
Fixes #1721: Saving Account Transfer error fixed

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/fragments/SavingsMakeTransferFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/SavingsMakeTransferFragment.kt
@@ -342,13 +342,27 @@ class SavingsMakeTransferFragment : BaseFragment(), SavingsMakeTransferMvpView, 
      */
     @OnClick(R.id.btn_pay_to)
     fun payToSelected() {
-        pvOne?.setCurrentCompleted()
-        pvTwo?.setCurrentActive()
-        btnPayTo?.visibility = View.GONE
-        tvSelectPayFrom?.visibility = View.GONE
-        btnPayFrom?.visibility = View.VISIBLE
-        spPayFrom?.visibility = View.VISIBLE
-        spPayTo?.isEnabled = false
+        if(arguments?.getString(Constants.TRANSFER_TYPE) == "transfer_pay_from"){
+            if (payTo == payFrom) {
+                showToaster(getString(R.string.error_same_account_transfer))
+                return
+            }
+            pvOne?.setCurrentCompleted()
+            btnPayTo?.visibility = View.GONE
+            tvSelectPayFrom?.visibility = View.GONE
+            spPayTo?.isEnabled = false
+            pvThree?.setCurrentActive()
+            etAmount?.visibility = View.VISIBLE
+            btnAmount?.visibility = View.VISIBLE
+        } else{
+            pvOne?.setCurrentCompleted()
+            btnPayTo?.visibility = View.GONE
+            tvSelectPayFrom?.visibility = View.GONE
+            spPayTo?.isEnabled = false
+            pvTwo?.setCurrentActive()
+            btnPayFrom?.visibility = View.VISIBLE
+            spPayFrom?.visibility = View.VISIBLE
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #1721 
Now if account is same in step 1 of Transfer, user is stopped there, and if not it directly goes to step 2, or else for deposit and other use acts as normal.

https://user-images.githubusercontent.com/70195106/107982537-3bb9e100-6fea-11eb-95e3-77d44dbbdc1d.mp4


- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.