### PR TITLE
The mobile radio button of verification mode is not aligned on the registration page.

### DIFF
--- a/app/src/main/res/layout/fragment_registration.xml
+++ b/app/src/main/res/layout/fragment_registration.xml
@@ -141,15 +141,14 @@
 
         <TextView
             android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:text="@string/verification_mode"/>
 
         <RadioGroup
             android:id="@+id/rg_verification_mode"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
+            android:layout_marginStart="@dimen/layout_padding_16dp"
             android:orientation="horizontal">
 
             <RadioButton


### PR DESCRIPTION
Fixes #Issue_Number

The mobile radio button of verification mode is not aligned on the registration page, so I made some UI changes. The screenshots below will show the changes, the first screenshot is of registration page  before I made the changes and as you can see the mobile radio button is not aligned with the rest of the buttons, so I made the changes to the layout and you can see that in the second picture.
![before](https://user-images.githubusercontent.com/89389741/209472562-11cd2936-9250-4705-93b4-0b637b352e07.jpeg)
![after](https://user-images.githubusercontent.com/89389741/209472565-c651db3f-5886-469f-806c-92a74e9cd53b.jpeg)
