### PR TITLE
refactor: Removal of deprecated Kotlin-Android-Extensions Gradle Plugin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ apply from: '../config/quality/quality.gradle'
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    
+
     defaultConfig {
         applicationId "org.mifos.mobile"
         minSdkVersion rootProject.ext.minSdkVersion
@@ -44,7 +44,7 @@ android {
         }
     }
 
-    buildFeatures{
+    buildFeatures {
         viewBinding true
     }
 
@@ -117,7 +117,7 @@ dependencies {
     //Dagger dependencies
     kapt "com.google.dagger:dagger-compiler:$rootProject.daggerVersion"
     implementation "com.google.dagger:dagger:$rootProject.daggerVersion"
-    compileOnly 'javax.annotation:jsr250-api:1.0' 
+    compileOnly 'javax.annotation:jsr250-api:1.0'
     compileOnly 'com.github.pengrad:jdk9-deps:1.0'  //Required by Dagger2
 
     //Butter Knife

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'com.android.application'
 apply plugin: 'com.google.firebase.crashlytics'
 apply plugin: 'com.google.android.gms.oss-licenses-plugin'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
+apply plugin: 'kotlin-parcelize'
 
 apply from: '../config/quality/quality.gradle'
 
@@ -44,6 +44,10 @@ android {
         }
     }
 
+    buildFeatures{
+        viewBinding true
+    }
+
 
     sourceSets {
         def commonTestDir = 'src/commonTest/java'
@@ -71,10 +75,6 @@ android {
     lintOptions {
         abortOnError false
         disable 'InvalidPackage'
-    }
-
-    androidExtensions {
-        experimental = true
     }
 }
 

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/ReviewLoanApplicationFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/ReviewLoanApplicationFragment.kt
@@ -100,38 +100,40 @@ class ReviewLoanApplicationFragment : BaseFragment() {
 
     }
 
-    private fun setUpViews(): Unit = with(binding) {
-        tvLoanProduct.text = viewModel.getLoanProduct()
-        tvLoanPurpose.text = viewModel.getLoanPurpose()
-        tvPrincipalAmount.text = viewModel.getPrincipal().toString()
-        tvExpectedDisbursementDate.text = viewModel.getDisbursementDate()
-        tvSubmissionDate.text = viewModel.getSubmissionDate()
-        tvCurrency.text = viewModel.getCurrency()
-        tvNewLoanApplication.text = viewModel.getLoanName()
-        tvAccountNumber.text = viewModel.getAccountNo()
+    private fun setUpViews(){
+        binding.apply {
+            tvLoanProduct.text = viewModel.getLoanProduct()
+            tvLoanPurpose.text = viewModel.getLoanPurpose()
+            tvPrincipalAmount.text = viewModel.getPrincipal().toString()
+            tvExpectedDisbursementDate.text = viewModel.getDisbursementDate()
+            tvSubmissionDate.text = viewModel.getSubmissionDate()
+            tvCurrency.text = viewModel.getCurrency()
+            tvNewLoanApplication.text = viewModel.getLoanName()
+            tvAccountNumber.text = viewModel.getAccountNo()
 
-        btnLoanSubmit.setOnClickListener {
-            showProgress()
-            viewModel.submitLoan()
-                ?.observeOn(AndroidSchedulers.mainThread())
-                ?.subscribeOn(Schedulers.io())
-                ?.subscribeWith(object : DisposableObserver<ResponseBody>() {
-                    override fun onComplete() {
-                    }
+            btnLoanSubmit.setOnClickListener {
+                showProgress()
+                viewModel.submitLoan()
+                    ?.observeOn(AndroidSchedulers.mainThread())
+                    ?.subscribeOn(Schedulers.io())
+                    ?.subscribeWith(object : DisposableObserver<ResponseBody>() {
+                        override fun onComplete() {
+                        }
 
-                    override fun onNext(t: ResponseBody) {
-                        hideProgress()
-                        if (viewModel.getLoanState() == LoanState.CREATE)
-                            showLoanAccountCreatedSuccessfully()
-                        else
-                            showLoanAccountUpdatedSuccessfully()
-                    }
+                        override fun onNext(t: ResponseBody) {
+                            hideProgress()
+                            if (viewModel.getLoanState() == LoanState.CREATE)
+                                showLoanAccountCreatedSuccessfully()
+                            else
+                                showLoanAccountUpdatedSuccessfully()
+                        }
 
-                    override fun onError(e: Throwable) {
-                        hideProgress()
-                        showError(MFErrorParser.errorMessage(e))
-                    }
-                })
+                        override fun onError(e: Throwable) {
+                            hideProgress()
+                            showError(MFErrorParser.errorMessage(e))
+                        }
+                    })
+            }
         }
     }
 
@@ -140,17 +142,17 @@ class ReviewLoanApplicationFragment : BaseFragment() {
         activity?.supportFragmentManager?.popBackStack()
     }
 
-    fun showError(message: String?): Unit = with(binding) {
-        val isConnected = Network.isConnected(activity)
-        if (!isConnected) {
+    fun showError(message: String?) {
+        if (!Network.isConnected(activity)) {
             Toaster.show(rootView, message)
-            return@with
+            return
         }
-        llError.ivStatus.setImageResource(R.drawable.ic_error_black_24dp)
-        llError.tvStatus.text = getString(R.string.internet_not_connected)
-        llAddLoan.visibility = View.GONE
-        llError.root.visibility = View.VISIBLE
-
+        binding.apply {
+            llError.ivStatus.setImageResource(R.drawable.ic_error_black_24dp)
+            llError.tvStatus.text = getString(R.string.internet_not_connected)
+            llAddLoan.visibility = View.GONE
+            llError.root.visibility = View.VISIBLE
+        }
     }
 
     fun showProgress() {
@@ -166,5 +168,10 @@ class ReviewLoanApplicationFragment : BaseFragment() {
     fun showLoanAccountCreatedSuccessfully() {
         Toaster.show(rootView, R.string.loan_application_submitted_successfully)
         activity?.supportFragmentManager?.popBackStack()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/ReviewLoanApplicationFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/ReviewLoanApplicationFragment.kt
@@ -31,8 +31,12 @@ class ReviewLoanApplicationFragment : BaseFragment() {
         const val LOAN_STATE = "loan_state"
         const val LOAN_ID = "loan_id"
 
-        fun newInstance(loanState: LoanState, loansPayload: LoansPayload, loanName: String, accountNo: String)
-                : ReviewLoanApplicationFragment {
+        fun newInstance(
+            loanState: LoanState,
+            loansPayload: LoansPayload,
+            loanName: String,
+            accountNo: String
+        ): ReviewLoanApplicationFragment {
             val fragment = ReviewLoanApplicationFragment()
             val args = Bundle().apply {
                 putSerializable(LOAN_STATE, loanState)
@@ -44,8 +48,13 @@ class ReviewLoanApplicationFragment : BaseFragment() {
             return fragment
         }
 
-        fun newInstance(loanState: LoanState?, loansPayload: LoansPayload?, loanId: Long?, loanName: String?, accountNo: String?)
-                : ReviewLoanApplicationFragment {
+        fun newInstance(
+            loanState: LoanState?,
+            loansPayload: LoansPayload?,
+            loanId: Long?,
+            loanName: String?,
+            accountNo: String?
+        ): ReviewLoanApplicationFragment {
             val fragment = ReviewLoanApplicationFragment()
             val args = Bundle().apply {
                 putSerializable(LOAN_STATE, loanState)
@@ -70,25 +79,31 @@ class ReviewLoanApplicationFragment : BaseFragment() {
     private val binding
         get() = _binding!!
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
-                              savedInstanceState: Bundle?): View? {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
         rootView = inflater.inflate(R.layout.fragment_review_loan_application, container, false)
         (activity as BaseActivity).activityComponent?.inject(this)
-        viewModel = ViewModelProviders.of(this, viewModelFactory).get(ReviewLoanApplicationViewModel::class.java)
+        viewModel = ViewModelProviders.of(this, viewModelFactory)
+            .get(ReviewLoanApplicationViewModel::class.java)
         val loanState = arguments?.getSerializable(LOAN_STATE) as LoanState
         if (loanState == LoanState.CREATE) {
             viewModel.insertData(
-                    loanState,
-                    arguments?.getParcelable(LOANS_PAYLOAD)!!,
-                    arguments?.getString(LOAN_NAME)!!,
-                    arguments?.getString(ACCOUNT_NO)!!)
+                loanState,
+                arguments?.getParcelable(LOANS_PAYLOAD)!!,
+                arguments?.getString(LOAN_NAME)!!,
+                arguments?.getString(ACCOUNT_NO)!!
+            )
         } else {
             viewModel.insertData(
-                    loanState,
-                    arguments?.getLong(LOAN_ID)!!,
-                    arguments?.getParcelable(LOANS_PAYLOAD)!!,
-                    arguments?.getString(LOAN_NAME)!!,
-                    arguments?.getString(ACCOUNT_NO)!!)
+                loanState,
+                arguments?.getLong(LOAN_ID)!!,
+                arguments?.getParcelable(LOANS_PAYLOAD)!!,
+                arguments?.getString(LOAN_NAME)!!,
+                arguments?.getString(ACCOUNT_NO)!!
+            )
         }
         return rootView
     }
@@ -100,7 +115,7 @@ class ReviewLoanApplicationFragment : BaseFragment() {
 
     }
 
-    private fun setUpViews(){
+    private fun setUpViews() {
         binding.apply {
             tvLoanProduct.text = viewModel.getLoanProduct()
             tvLoanPurpose.text = viewModel.getLoanPurpose()
@@ -147,12 +162,12 @@ class ReviewLoanApplicationFragment : BaseFragment() {
             Toaster.show(rootView, message)
             return
         }
-        binding.apply {
-            llError.ivStatus.setImageResource(R.drawable.ic_error_black_24dp)
-            llError.tvStatus.text = getString(R.string.internet_not_connected)
-            llAddLoan.visibility = View.GONE
-            llError.root.visibility = View.VISIBLE
+        binding.llError.apply {
+            ivStatus.setImageResource(R.drawable.ic_error_black_24dp)
+            tvStatus.text = getString(R.string.internet_not_connected)
+            root.visibility = View.VISIBLE
         }
+        binding.llAddLoan.visibility = View.GONE
     }
 
     fun showProgress() {


### PR DESCRIPTION
Removed Kotlin-Android-Extensions and introduced ViewBinding.
ViewBinding had to be added in order to replace the long deprecated Kotlin-Synthetics included in Kotlin-Android-Extensions.
ViewBinding is the preferred way over Kotlin-Synthetics.
Kotlin Parcelize plugin had to be added in order to use Parcelization which was included in Kotlin-Android-Extensions.


Fixes #1953 

Please Add Screenshots If there are any UI changes.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.