### PR TITLE
fix: Nullable View receiver in HomeFragment & HomeOldFragment

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/fragments/HomeFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/HomeFragment.kt
@@ -104,8 +104,8 @@ class HomeFragment : BaseFragment(), HomeView, OnRefreshListener {
         inflater.inflate(R.menu.menu_main, menu)
         val menuItem = menu.findItem(R.id.menu_notifications)
         val count = menuItem.actionView
-        tvNotificationCount = count.findViewById(R.id.tv_notification_indicator)
-        count.setOnClickListener {
+        tvNotificationCount = count?.findViewById(R.id.tv_notification_indicator)
+        count?.setOnClickListener {
             (activity as BaseActivity?)?.replaceFragment(NotificationFragment.newInstance(),
                     true, R.id.container)
         }

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/HomeOldFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/HomeOldFragment.kt
@@ -130,9 +130,9 @@ class HomeOldFragment : BaseFragment(), HomeOldView, OnRefreshListener {
         inflater.inflate(R.menu.menu_main, menu)
         val menuItem = menu.findItem(R.id.menu_notifications)
         val count = menuItem.actionView
-        tvNotificationCount = count.findViewById(R.id.tv_notification_indicator)
+        tvNotificationCount = count?.findViewById(R.id.tv_notification_indicator)
         presenter?.unreadNotificationsCount
-        count.setOnClickListener { startActivity(Intent(context, NotificationActivity::class.java)) }
+        count?.setOnClickListener { startActivity(Intent(context, NotificationActivity::class.java)) }
         super.onCreateOptionsMenu(menu, inflater)
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,8 @@ task clean(type: Delete) {
 ext {
     // Sdk and tools
     minSdkVersion = 22
-    targetSdkVersion = 31
-    compileSdkVersion = 31
+    targetSdkVersion = 33
+    compileSdkVersion = 33
 
     // App dependencies
     supportLibraryVersion = '1.4.2'


### PR DESCRIPTION
Fixes #1956 

I used safe call operator to make sure code executes only if `count` is not null.
This also fixes #1945 as the original issue is due to updated SDK version

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.