### PR TITLE
fix : added apk support for arm64-v8a android architecture.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,7 @@ android {
         vectorDrawables.useSupportLibrary = true
 
         ndk {
-            abiFilters "armeabi-v7a", "x86", "x86_64"
+            abiFilters "armeabi-v7a", "x86", "x86_64", "arm64-v8a"
         }
 
         multiDexEnabled true


### PR DESCRIPTION

Fixes #1995 

Added application apk support for arm64-v8a android architecture, application now supports more devices(newer).

Current application apk didn't support the newer arm64-v8a android architecture, which is much recent and newer. According to the latest guidelines it's also required to be supported as it is a newer version of armeabi-v7a.

1. in build.gradle(app) -> abiFilters add "arm64-v8a" android architecture.
2. tested in my local device(armeabi-v7a) and pixel 2(arm64-v8a), application runs & installs succesfully.


Please Add Screenshots If there are any UI changes.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.