### PR TITLE
fix : fixed the logic of comparator function that's used to sort notifications

### DIFF
--- a/app/src/main/java/org/mifos/mobile/utils/NotificationComparator.kt
+++ b/app/src/main/java/org/mifos/mobile/utils/NotificationComparator.kt
@@ -7,11 +7,11 @@ import java.util.*
  * Created by dilpreet on 14/9/17.
  */
 class NotificationComparator : Comparator<MifosNotification> {
-    override fun compare(mifosNotification1: MifosNotification, mifosNotification2: MifosNotification): Int {
+    override fun compare(firstNotification: MifosNotification, secondNotification: MifosNotification): Int {
         return when {
             // comparator function logic to sort notifications in the descending order of their timeStamp :
-            mifosNotification2.timeStamp < mifosNotification1.timeStamp -> -1
-            mifosNotification1.timeStamp < mifosNotification2.timeStamp -> 1
+            firstNotification.timeStamp > secondNotification.timeStamp -> -1
+            firstNotification.timeStamp < secondNotification.timeStamp -> 1
             else -> 0
         }
     }

--- a/app/src/main/java/org/mifos/mobile/utils/NotificationComparator.kt
+++ b/app/src/main/java/org/mifos/mobile/utils/NotificationComparator.kt
@@ -9,8 +9,9 @@ import java.util.*
 class NotificationComparator : Comparator<MifosNotification> {
     override fun compare(mifosNotification1: MifosNotification, mifosNotification2: MifosNotification): Int {
         return when {
+            // comparator function logic to sort notifications in the descending order of their timeStamp :
             mifosNotification2.timeStamp < mifosNotification1.timeStamp -> -1
-            mifosNotification1.timeStamp > mifosNotification2.timeStamp -> 1
+            mifosNotification1.timeStamp < mifosNotification2.timeStamp -> 1
             else -> 0
         }
     }


### PR DESCRIPTION
Fixes #2000 


Fixed the logic of comparator function that used to sort nofications(desc order) on the basis of their timestamps.

The comparator function that is called in DatabaseHelper.kt to sort the notifications in Descending order of their timestamp is incorrect and doesn't provide the right comparator function logic to sort objects in descending order. According to online java/kotlin documentation a comparator function should provide return values for all three cases.

1. updated the comparator function to provide return values for all three conditions(a > b ,a < b and a == b), where a and b are timestamps of any two notifications that are being compared.


Please Add Screenshots If there are any UI changes.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.