### PR TITLE
fix:restore the language set before logout 

### DIFF
--- a/app/src/main/java/org/mifos/mobile/api/local/PreferencesHelper.kt
+++ b/app/src/main/java/org/mifos/mobile/api/local/PreferencesHelper.kt
@@ -25,7 +25,7 @@ class PreferencesHelper @Inject constructor(@ApplicationContext context: Context
         //prevent deletion of url and tenant
         if (sharedPreferences != null)
             for ((key) in sharedPreferences.all) {
-                if (!(key == BASE_URL || key == TENANT)) {
+                if (!(key == BASE_URL || key == TENANT||key== LANGUAGE_TYPE)) {
                     editor?.remove(key)
                 }
             }
@@ -52,7 +52,7 @@ class PreferencesHelper @Inject constructor(@ApplicationContext context: Context
         return sharedPreferences?.getString(preferenceKey, preferenceDefaultValue)
     }
 
-    private fun putString(preferenceKey: String?, preferenceValue: String?) {
+    fun putString(preferenceKey: String?, preferenceValue: String?) {
         sharedPreferences?.edit()?.putString(preferenceKey, preferenceValue)?.apply()
     }
 
@@ -110,7 +110,11 @@ class PreferencesHelper @Inject constructor(@ApplicationContext context: Context
         set(officeName) {
             putString(OFFICE_NAME, officeName)
         }
-
+    var language_type:String?
+        get()=getString(LANGUAGE_TYPE,"en")
+        set(language_type){
+            putString(LANGUAGE_TYPE,language_type)
+        }
     fun setOverviewState(state: Boolean) {
         putBoolean(OVERVIEW_STATE, state)
     }
@@ -170,6 +174,7 @@ class PreferencesHelper @Inject constructor(@ApplicationContext context: Context
         private const val PROFILE_IMAGE = "preferences_profile_image"
         const val CLIENT_NAME = "client_name"
         private const val APPLICATION_THEME = "application_theme"
+        private const val LANGUAGE_TYPE="language_type"
     }
 
 

--- a/app/src/main/java/org/mifos/mobile/ui/activities/LoginActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/LoginActivity.kt
@@ -1,6 +1,9 @@
 package org.mifos.mobile.ui.activities
 
+import android.content.Context
 import android.content.Intent
+import android.content.SharedPreferences
+import android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.widget.LinearLayout
@@ -15,13 +18,16 @@ import butterknife.OnClick
 import com.google.android.material.textfield.TextInputLayout
 
 import org.mifos.mobile.R
+import org.mifos.mobile.api.local.PreferencesHelper
 import org.mifos.mobile.models.payload.LoginPayload
 import org.mifos.mobile.presenters.LoginPresenter
 import org.mifos.mobile.ui.activities.base.BaseActivity
 import org.mifos.mobile.ui.views.LoginView
 import org.mifos.mobile.utils.Constants
+import org.mifos.mobile.utils.LanguageHelper
 import org.mifos.mobile.utils.Network
 import org.mifos.mobile.utils.Toaster
+import java.util.*
 
 import javax.inject.Inject
 
@@ -51,8 +57,14 @@ class LoginActivity : BaseActivity(), LoginView {
     @BindView(R.id.ll_login)
     var llLogin: LinearLayout? = null
 
+    @JvmField
+    @Inject
+    var preferencesHelper: PreferencesHelper? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        preferencesHelper?.language_type?.let { language(it) }
+        println("The language is ${preferencesHelper?.language_type?.let { language(it) }}")
         activityComponent?.inject(this)
         setContentView(R.layout.activity_login)
         ButterKnife.bind(this)
@@ -151,5 +163,16 @@ class LoginActivity : BaseActivity(), LoginView {
         intent.putExtra(Constants.INTIAL_LOGIN, true)
         startActivity(intent)
         finish()
+    }
+
+    fun language(lang : String){
+        val config = resources.configuration
+        val locale = Locale(lang)
+        Locale.setDefault(locale)
+        config.setLocale(locale)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+            createConfigurationContext(config)
+        resources.updateConfiguration(config, resources.displayMetrics)
     }
 }

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/SettingsFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/SettingsFragment.kt
@@ -1,5 +1,6 @@
 package org.mifos.mobile.ui.fragments
 
+import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener
@@ -21,6 +22,7 @@ import org.mifos.mobile.utils.ConfigurationDialogFragmentCompat
 import org.mifos.mobile.utils.ConfigurationPreference
 import org.mifos.mobile.utils.Constants
 import org.mifos.mobile.utils.LanguageHelper
+import javax.inject.Inject
 
 /**
  * Created by dilpreet on 02/10/17.
@@ -30,11 +32,14 @@ class SettingsFragment : PreferenceFragmentCompat(), OnSharedPreferenceChangeLis
     private val prefsHelper by lazy { PreferencesHelper(requireContext().applicationContext) }
     var preference: android.preference.Preference? = null
 
+    @JvmField
+    @Inject
+    var preferencesHelper: PreferencesHelper? = null
+
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.settings_preference)
         findPreference(getString(R.string.theme_type)).setOnPreferenceClickListener {
             val previouslySelectedTheme = prefsHelper.appTheme
-
             MaterialAlertDialogBuilder(requireContext())
                 .setTitle(getString(R.string.change_app_theme))
                 .setSingleChoiceItems(resources.getStringArray(R.array.themes), previouslySelectedTheme) { dialog, selectedTheme ->
@@ -109,6 +114,7 @@ class SettingsFragment : PreferenceFragmentCompat(), OnSharedPreferenceChangeLis
         val preference = findPreference(s)
         if (preference is ListPreference) {
             LanguageHelper.setLocale(context, preference.value)
+            preferencesHelper?.language_type=preference.value
             val intent = Intent(activity, activity?.javaClass)
             intent.putExtra(Constants.HAS_SETTINGS_CHANGED, true)
             startActivity(intent)


### PR DESCRIPTION
Fixes #1997 

The video demonstrates the fix 
https://user-images.githubusercontent.com/90026952/225747968-2653cd48-3ac1-42af-83c8-283df6471fd2.mp4

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.