### PR TITLE
feat: add show/hide visibility feature for total loan and saving amounts

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/fragments/HomeOldFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/HomeOldFragment.kt
@@ -269,39 +269,35 @@ class HomeOldFragment : BaseFragment(), HomeOldView, OnRefreshListener {
         }
     }
 
-    /**
-     * Toggles visibility of saving and loan total amounts on home,
-     * and updates the corresponding button icon.
-     */
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         ButterKnife.bind(this, view)
+        toggleVisibilityButton(
+            btn_saving_total_amount_visibility,
+            tv_saving_total_amount,
+            tv_saving_total_amount_hidden
+        )
+        toggleVisibilityButton(
+            btn_loan_amount_visibility,
+            tv_loan_total_amount,
+            tv_loan_total_amount_hidden
+        )
+    }
 
-        tv_saving_total_amount.visibility = View.GONE
-        tv_saving_total_amount_hidden.visibility = View.VISIBLE
-        tv_loan_total_amount.visibility = View.GONE
-        tv_loan_total_amount_hidden.visibility = View.VISIBLE
-
-        btn_saving_total_amount_visibility.setOnClickListener {
-            if (tv_saving_total_amount.visibility == View.VISIBLE) {
-                tv_saving_total_amount.visibility = View.GONE
-                tv_saving_total_amount_hidden.visibility = View.VISIBLE
-                btn_saving_total_amount_visibility.setImageResource(R.drawable.ic_visibility_24px)
+    private fun toggleVisibilityButton(
+        button: ImageButton,
+        visibleView: View,
+        hiddenView: View
+    ) {
+        button.setOnClickListener {
+            if (visibleView.visibility == View.VISIBLE) {
+                visibleView.visibility = View.GONE
+                hiddenView.visibility = View.VISIBLE
+                button.setImageResource(R.drawable.ic_visibility_24px)
             } else {
-                tv_saving_total_amount.visibility = View.VISIBLE
-                tv_saving_total_amount_hidden.visibility = View.GONE
-                btn_saving_total_amount_visibility.setImageResource(R.drawable.ic_visibility_off_24px)
-            }
-        }
-        btn_loan_amount_visibility.setOnClickListener {
-            if (tv_loan_total_amount.visibility == View.VISIBLE) {
-                tv_loan_total_amount.visibility = View.GONE
-                tv_loan_total_amount_hidden.visibility = View.VISIBLE
-                btn_loan_amount_visibility.setImageResource(R.drawable.ic_visibility_24px)
-            } else {
-                tv_loan_total_amount.visibility = View.VISIBLE
-                tv_loan_total_amount_hidden.visibility = View.GONE
-                btn_loan_amount_visibility.setImageResource(R.drawable.ic_visibility_off_24px)
+                visibleView.visibility = View.VISIBLE
+                hiddenView.visibility = View.GONE
+                button.setImageResource(R.drawable.ic_visibility_off_24px)
             }
         }
     }

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/HomeOldFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/HomeOldFragment.kt
@@ -9,24 +9,22 @@ import android.os.Build
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.*
+import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
-
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout.OnRefreshListener
-
 import butterknife.BindView
 import butterknife.ButterKnife
 import butterknife.OnClick
 import com.google.android.material.badge.BadgeDrawable
 import com.google.android.material.badge.BadgeUtils
 import com.google.android.material.imageview.ShapeableImageView
-
 import org.mifos.mobile.R
 import org.mifos.mobile.api.local.PreferencesHelper
 import org.mifos.mobile.models.client.Client
@@ -42,7 +40,6 @@ import org.mifos.mobile.ui.fragments.base.BaseFragment
 import org.mifos.mobile.ui.getThemeAttributeColor
 import org.mifos.mobile.ui.views.HomeOldView
 import org.mifos.mobile.utils.*
-
 import javax.inject.Inject
 
 /**
@@ -267,6 +264,48 @@ class HomeOldFragment : BaseFragment(), HomeOldView, OnRefreshListener {
                         .endConfig()
                         .buildRound(userName.substring(0, 1),requireContext().getThemeAttributeColor(R.attr.colorPrimary))
                 ivCircularUserImage?.setImageDrawable(drawable)
+            }
+        }
+    }
+
+    /**
+     * Toggles visibility of saving and loan total amounts on home,
+     * and updates the corresponding button icon.
+     */
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val savingAmountVisibilityButton: ImageButton = view.findViewById(R.id.btn_saving_total_amount_visibility)
+        val savingAmountVisible: TextView = view.findViewById(R.id.tv_saving_total_amount)
+        val savingAmountHidden: TextView = view.findViewById(R.id.tv_saving_total_amount_hidden)
+        val loanAmountVisibilityButton: ImageButton = view.findViewById(R.id.btn_loan_amount_visibility)
+        val loanAmountVisible: TextView = view.findViewById(R.id.tv_loan_total_amount)
+        val loanAmountHidden: TextView = view.findViewById(R.id.tv_loan_total_amount_hidden)
+
+        savingAmountVisible.visibility = View.GONE
+        savingAmountHidden.visibility = View.VISIBLE
+        loanAmountVisible.visibility = View.GONE
+        loanAmountHidden.visibility = View.VISIBLE
+
+        savingAmountVisibilityButton.setOnClickListener {
+            if (savingAmountVisible.visibility == View.VISIBLE) {
+                savingAmountVisible.visibility = View.GONE
+                savingAmountHidden.visibility = View.VISIBLE
+                savingAmountVisibilityButton.setImageResource(R.drawable.ic_visibility_24px)
+            } else {
+                savingAmountVisible.visibility = View.VISIBLE
+                savingAmountHidden.visibility = View.GONE
+                savingAmountVisibilityButton.setImageResource(R.drawable.ic_visibility_off_24px)
+            }
+        }
+        loanAmountVisibilityButton.setOnClickListener {
+            if (loanAmountVisible.visibility == View.VISIBLE) {
+                loanAmountVisible.visibility = View.GONE
+                loanAmountHidden.visibility = View.VISIBLE
+                loanAmountVisibilityButton.setImageResource(R.drawable.ic_visibility_24px)
+            } else {
+                loanAmountVisible.visibility = View.VISIBLE
+                loanAmountHidden.visibility = View.GONE
+                loanAmountVisibilityButton.setImageResource(R.drawable.ic_visibility_off_24px)
             }
         }
     }

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/HomeOldFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/HomeOldFragment.kt
@@ -25,6 +25,7 @@ import butterknife.OnClick
 import com.google.android.material.badge.BadgeDrawable
 import com.google.android.material.badge.BadgeUtils
 import com.google.android.material.imageview.ShapeableImageView
+import kotlinx.android.synthetic.main.fragment_home_old.*
 import org.mifos.mobile.R
 import org.mifos.mobile.api.local.PreferencesHelper
 import org.mifos.mobile.models.client.Client
@@ -274,38 +275,33 @@ class HomeOldFragment : BaseFragment(), HomeOldView, OnRefreshListener {
      */
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val savingAmountVisibilityButton: ImageButton = view.findViewById(R.id.btn_saving_total_amount_visibility)
-        val savingAmountVisible: TextView = view.findViewById(R.id.tv_saving_total_amount)
-        val savingAmountHidden: TextView = view.findViewById(R.id.tv_saving_total_amount_hidden)
-        val loanAmountVisibilityButton: ImageButton = view.findViewById(R.id.btn_loan_amount_visibility)
-        val loanAmountVisible: TextView = view.findViewById(R.id.tv_loan_total_amount)
-        val loanAmountHidden: TextView = view.findViewById(R.id.tv_loan_total_amount_hidden)
+        ButterKnife.bind(this, view)
 
-        savingAmountVisible.visibility = View.GONE
-        savingAmountHidden.visibility = View.VISIBLE
-        loanAmountVisible.visibility = View.GONE
-        loanAmountHidden.visibility = View.VISIBLE
+        tv_saving_total_amount.visibility = View.GONE
+        tv_saving_total_amount_hidden.visibility = View.VISIBLE
+        tv_loan_total_amount.visibility = View.GONE
+        tv_loan_total_amount_hidden.visibility = View.VISIBLE
 
-        savingAmountVisibilityButton.setOnClickListener {
-            if (savingAmountVisible.visibility == View.VISIBLE) {
-                savingAmountVisible.visibility = View.GONE
-                savingAmountHidden.visibility = View.VISIBLE
-                savingAmountVisibilityButton.setImageResource(R.drawable.ic_visibility_24px)
+        btn_saving_total_amount_visibility.setOnClickListener {
+            if (tv_saving_total_amount.visibility == View.VISIBLE) {
+                tv_saving_total_amount.visibility = View.GONE
+                tv_saving_total_amount_hidden.visibility = View.VISIBLE
+                btn_saving_total_amount_visibility.setImageResource(R.drawable.ic_visibility_24px)
             } else {
-                savingAmountVisible.visibility = View.VISIBLE
-                savingAmountHidden.visibility = View.GONE
-                savingAmountVisibilityButton.setImageResource(R.drawable.ic_visibility_off_24px)
+                tv_saving_total_amount.visibility = View.VISIBLE
+                tv_saving_total_amount_hidden.visibility = View.GONE
+                btn_saving_total_amount_visibility.setImageResource(R.drawable.ic_visibility_off_24px)
             }
         }
-        loanAmountVisibilityButton.setOnClickListener {
-            if (loanAmountVisible.visibility == View.VISIBLE) {
-                loanAmountVisible.visibility = View.GONE
-                loanAmountHidden.visibility = View.VISIBLE
-                loanAmountVisibilityButton.setImageResource(R.drawable.ic_visibility_24px)
+        btn_loan_amount_visibility.setOnClickListener {
+            if (tv_loan_total_amount.visibility == View.VISIBLE) {
+                tv_loan_total_amount.visibility = View.GONE
+                tv_loan_total_amount_hidden.visibility = View.VISIBLE
+                btn_loan_amount_visibility.setImageResource(R.drawable.ic_visibility_24px)
             } else {
-                loanAmountVisible.visibility = View.VISIBLE
-                loanAmountHidden.visibility = View.GONE
-                loanAmountVisibilityButton.setImageResource(R.drawable.ic_visibility_off_24px)
+                tv_loan_total_amount.visibility = View.VISIBLE
+                tv_loan_total_amount_hidden.visibility = View.GONE
+                btn_loan_amount_visibility.setImageResource(R.drawable.ic_visibility_off_24px)
             }
         }
     }

--- a/app/src/main/res/layout/fragment_home_old.xml
+++ b/app/src/main/res/layout/fragment_home_old.xml
@@ -91,14 +91,16 @@
                             tools:text="$ 1000"
                             style="@style/Mifos.DesignSystem.TextStyle.BodyLarger"
                             android:textColor="@color/deposit_green"
-                            android:text="-" />
+                            android:text="-"
+                            android:visibility="gone"/>
                         <TextView
                             android:id="@+id/tv_saving_total_amount_hidden"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:text="@string/hidden_amount"
                             style="@style/Mifos.DesignSystem.TextStyle.BodyLarger"
-                            android:textColor="@color/deposit_green" />
+                            android:textColor="@color/deposit_green"
+                            android:visibility="visible"/>
                         <ImageButton
                             android:id="@+id/btn_saving_total_amount_visibility"
                             android:layout_width="wrap_content"
@@ -131,14 +133,16 @@
                             android:layout_height="wrap_content"
                             android:textColor="@color/red"
                             style="@style/Mifos.DesignSystem.TextStyle.BodyLarger"
-                            android:text="-" />
+                            android:text="-"
+                            android:visibility="gone"/>
                         <TextView
                             android:id="@+id/tv_loan_total_amount_hidden"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:textColor="@color/red"
                             style="@style/Mifos.DesignSystem.TextStyle.BodyLarger"
-                            android:text="@string/hidden_amount" />
+                            android:text="@string/hidden_amount"
+                            android:visibility="visible"/>
                         <ImageButton
                             android:id="@+id/btn_loan_amount_visibility"
                             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/fragment_home_old.xml
+++ b/app/src/main/res/layout/fragment_home_old.xml
@@ -91,9 +91,24 @@
                             tools:text="$ 1000"
                             style="@style/Mifos.DesignSystem.TextStyle.BodyLarger"
                             android:textColor="@color/deposit_green"
-                            android:text="-"/>
+                            android:text="-" />
+                        <TextView
+                            android:id="@+id/tv_saving_total_amount_hidden"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/hidden_amount"
+                            style="@style/Mifos.DesignSystem.TextStyle.BodyLarger"
+                            android:textColor="@color/deposit_green" />
+                        <ImageButton
+                            android:id="@+id/btn_saving_total_amount_visibility"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:background="@null"
+                            android:contentDescription="@string/show_hide_total_saving_amount"
+                            android:paddingStart="6dp"
+                            android:src="@drawable/ic_visibility_24px"
+                            app:tint="@color/colorPrimary" />
                     </LinearLayout>
-
 
                     <LinearLayout
                         android:id="@+id/ll_total_loan"
@@ -105,18 +120,34 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             style="@style/Mifos.DesignSystem.TextStyle.Label"
-                            android:text="@string/total_loan"/>
+                            android:text="@string/total_loan" />
                         <View
                             android:layout_width="@dimen/width_0dp"
                             android:layout_height="@dimen/height_0dp"
-                            android:layout_weight="1"/>
+                            android:layout_weight="1" />
                         <TextView
                             android:id="@+id/tv_loan_total_amount"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:textColor="@color/red"
                             style="@style/Mifos.DesignSystem.TextStyle.BodyLarger"
-                            android:text="-"/>
+                            android:text="-" />
+                        <TextView
+                            android:id="@+id/tv_loan_total_amount_hidden"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:textColor="@color/red"
+                            style="@style/Mifos.DesignSystem.TextStyle.BodyLarger"
+                            android:text="@string/hidden_amount" />
+                        <ImageButton
+                            android:id="@+id/btn_loan_amount_visibility"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:background="@null"
+                            android:contentDescription="@string/show_hide_total_loan_amount"
+                            android:paddingStart="6dp"
+                            android:src="@drawable/ic_visibility_24px"
+                            app:tint="@color/colorPrimary" />
                     </LinearLayout>
 
                 </LinearLayout>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -298,6 +298,8 @@
     <string name="total_loan">إجمالي القرض</string>
     <string name="total_saving">مجموع المدخرات</string>
     <string name="accounts_overview">نظرة عامة على الحساب</string>
+    <string name="show_hide_total_loan_amount">إظهار أو إخفاء إجمالي مبلغ القرض</string>
+    <string name="hidden_amount">*****</string>
     <string name="survey">الدراسات الاستقصائية</string>
     <string name="activation_date">تفعيل التسجيل</string>
     <string name="groups">المجموعات</string>
@@ -440,4 +442,5 @@
     <string name="enter_base_url">أدخل عنوان URL الأساسي</string>
     <string name="enter_tenant">أدخل المستأجر</string>
     <string name="app_info">معلومات التطبيق</string>
+    <string name="show_hide_total_saving_amount">إظهار أو إخفاء إجمالي مبلغ التوفير</string>
 </resources>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -290,6 +290,8 @@
     <string name="total_loan">মোট ঋণ</string>
     <string name="total_saving">মোট সঞ্চয়</string>
     <string name="accounts_overview">অ্যাকাউন্ট ওভারভিউ</string>
+    <string name="show_hide_total_loan_amount">মোট ঋণের পরিমাণ দেখান বা লুকান</string>
+    <string name="hidden_amount">*****</string>
     <string name="survey">সার্ভের</string>
     <string name="activation_date">অ্যাক্টিভেশন তারিখ</string>
     <string name="groups">গ্রুপ</string>
@@ -427,4 +429,5 @@
     <string name="nine">৯</string>
     <string name="zero">০</string>
     <string name="app_info">অ্যাপের তথ্য</string>
+    <string name="show_hide_total_saving_amount">মোট সঞ্চয় পরিমাণ দেখান বা লুকান</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -290,6 +290,9 @@
     <string name="total_loan">Préstamo total</string>
     <string name="total_saving">Ahorro total</string>
     <string name="accounts_overview">Resumen de cuenta</string>
+    <string name="show_hide_total_saving_amount">Mostrar u ocultar la cantidad total de ahorro</string>
+    <string name="show_hide_total_loan_amount">Mostrar u ocultar el monto total del préstamo</string>
+    <string name="hidden_amount">*****</string>
     <string name="survey">Encuestas</string>
     <string name="activation_date">Fecha de activación</string>
     <string name="groups">Grupo</string>

--- a/app/src/main/res/values-fa-rAF/strings.xml
+++ b/app/src/main/res/values-fa-rAF/strings.xml
@@ -360,6 +360,9 @@
     <string name="submit_beneficiary">ارسال ذینفع</string>
     <string name="submit_loan">" ارسال قرض"</string>
     <string name="submitted">ارسال شده</string>
+    <string name="show_hide_total_saving_amount">نمایش یا پنهان کردن کل مبلغ پس انداز</string>
+    <string name="show_hide_total_loan_amount">نمایش یا پنهان کردن کل مبلغ وام</string>
+    <string name="hidden_amount">*****</string>
     <string name="survey">بررسی ها</string>
     <string name="tap_to_add_guarantor">برای افزودن ضمانت بر روی ضربه بزنید</string>
     <string name="tenant">مستاجر</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -289,6 +289,8 @@
     <string name="total_loan">Prêt total</string>
     <string name="total_saving">Total épargne</string>
     <string name="accounts_overview">Aperçu du compte</string>
+    <string name="show_hide_total_loan_amount">Afficher ou masquer le montant total du prêt</string>
+    <string name="hidden_amount">*****</string>
     <string name="survey">Enquêtes</string>
     <string name="activation_date">Date d\'activation</string>
     <string name="groups">Groupe</string>
@@ -414,4 +416,5 @@
     <string name="enter_base_url">Entrez l\'URL primaire</string>
     <string name="enter_tenant">Aller au locataire</string>
     <string name="app_info">Informations sur l\'application</string>
+    <string name="show_hide_total_saving_amount">Afficher ou masquer le montant total de l\'épargne</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -274,6 +274,9 @@
     <string name="total_loan">कुल ऋण</string>
     <string name="total_saving">कुल बचत</string>
     <string name="accounts_overview">खाता निरीक्षण</string>
+    <string name="show_hide_total_saving_amount">कुल बचत राशि दिखाएँ या छुपाएँ</string>
+    <string name="show_hide_total_loan_amount">कुल ऋण राशि दिखाएं या छुपाएं</string>
+    <string name="hidden_amount">*****</string>
     <string name="survey">सर्वेक्षण</string>
     <string name="first_name">पहला नाम</string>
     <string name="delete_beneficiary_confirmation">क्या आप वाकई इस लाभार्थी को हटाना चाहते हैं</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -290,6 +290,9 @@
     <string name="total_loan">Total pinjaman</string>
     <string name="total_saving">Penghematan total</string>
     <string name="accounts_overview">Ikhtisar akun</string>
+    <string name="show_hide_total_saving_amount">Tampilkan atau sembunyikan jumlah total tabungan</string>
+    <string name="show_hide_total_loan_amount">Tampilkan atau sembunyikan jumlah total pinjaman</string>
+    <string name="hidden_amount">*****</string>
     <string name="survey">Survei</string>
     <string name="activation_date">Tanggal aktivasi</string>
     <string name="groups">Kelompok</string>

--- a/app/src/main/res/values-km/strings.xml
+++ b/app/src/main/res/values-km/strings.xml
@@ -290,6 +290,9 @@
     <string name="total_loan">ឥណទានសរុប</string>
     <string name="total_saving">ការសន្សំសរុប</string>
     <string name="accounts_overview">ទិដ្ឋភាពគណនី</string>
+    <string name="show_hide_total_saving_amount">បង្ហាញ ឬលាក់ចំនួនទឹកប្រាក់សន្សំសរុប</string>
+    <string name="show_hide_total_loan_amount">បង្ហាញ ឬលាក់ចំនួនប្រាក់កម្ចីសរុប</string>
+    <string name="hidden_amount">*****</string>
     <string name="survey">ការស្ទង់មតិ</string>
     <string name="activation_date">កាលបរិច្ឆេទសកម្ម</string>
     <string name="groups">ក្រុម</string>

--- a/app/src/main/res/values-kn/strings.xml
+++ b/app/src/main/res/values-kn/strings.xml
@@ -290,6 +290,9 @@
     <string name="total_loan">ಒಟ್ಟು ಸಾಲ</string>
     <string name="total_saving">ಒಟ್ಟು ಉಳಿತಾಯ</string>
     <string name="accounts_overview">ಖಾತೆ ಅವಲೋಕನ</string>
+    <string name="show_hide_total_saving_amount">ಒಟ್ಟು ಉಳಿತಾಯದ ಮೊತ್ತವನ್ನು ತೋರಿಸಿ ಅಥವಾ ಮರೆಮಾಡಿ</string>
+    <string name="show_hide_total_loan_amount">ಒಟ್ಟು ಸಾಲದ ಮೊತ್ತವನ್ನು ತೋರಿಸಿ ಅಥವಾ ಮರೆಮಾಡಿ</string>
+    <string name="hidden_amount">*****</string>
     <string name="survey">ಸಮೀಕ್ಷೆಗಳು</string>
     <string name="activation_date">ಸಕ್ರಿಯಗೊಳಿಸುವ ದಿನಾಂಕ</string>
     <string name="groups">ಗುಂಪು</string>

--- a/app/src/main/res/values-my/strings.xml
+++ b/app/src/main/res/values-my/strings.xml
@@ -296,6 +296,8 @@
     <string name="total_loan">စုစုပေါင်းချေးငွေ</string>
     <string name="total_saving">စုစုပေါင်းချွေတာသုံးစွဲ</string>
     <string name="accounts_overview">အကောင့်ခြုံငုံသုံးသပ်ချက်</string>
+    <string name="show_hide_total_loan_amount">စုစုပေါင်းချေးငွေပမာဏကို ပြပါ သို့မဟုတ် ဝှက်ပါ။</string>
+    <string name="hidden_amount">*****</string>
     <string name="survey">စစ်တမ်းများ</string>
     <string name="activation_date">activation နေ့စွဲ</string>
     <string name="groups">အဖွဲ့များ</string>
@@ -438,5 +440,6 @@
     <string name="enter_base_url">အဆိုပါအခြေစိုက်စခန်း URL ကိုရိုက်ထည့်ပါ</string>
     <string name="enter_tenant">ဥယျာဉ်စောင့် Enter</string>
     <string name="app_info">အက်ပ်အချက်အလက်</string>
+    <string name="show_hide_total_saving_amount">စုစုပေါင်းချွေတာသည့်ပမာဏကို ပြပါ သို့မဟုတ် ဝှက်ပါ။</string>
 
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -290,6 +290,9 @@
     <string name="total_loan">Łączna pożyczka</string>
     <string name="total_saving">Całkowite oszczędności</string>
     <string name="accounts_overview">Przegląd konta</string>
+    <string name="show_hide_total_saving_amount">Pokaż lub ukryj całkowitą kwotę oszczędności</string>
+    <string name="show_hide_total_loan_amount">Pokaż lub ukryj całkowitą kwotę pożyczki</string>
+    <string name="hidden_amount">*****</string>
     <string name="survey">Ankiety</string>
     <string name="activation_date">Data aktywacji</string>
     <string name="groups">Grupy</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -312,6 +312,9 @@
     <string name="total_loan">Empréstimo Total</string>
     <string name="total_saving">Poupança Total</string>
     <string name="accounts_overview">Visão Global da Conta</string>
+    <string name="show_hide_total_saving_amount">Mostrar ou ocultar o valor total economizado</string>
+    <string name="show_hide_total_loan_amount">Mostrar ou ocultar o valor total do empréstimo</string>
+    <string name="hidden_amount">*****</string>
     <string name="survey">Sondagens</string>
     <string name="activation_date">Data de Ativação</string>
     <string name="groups">Grupos</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -290,6 +290,9 @@
     <string name="total_loan">Общий кредит</string>
     <string name="total_saving">Общая экономия</string>
     <string name="accounts_overview">Обзор учетной записи</string>
+    <string name="show_hide_total_saving_amount">Mostrar ou ocultar o valor total economizado</string>
+    <string name="show_hide_total_loan_amount">Показать или скрыть общую сумму кредита</string>
+    <string name="hidden_amount">*****</string>
     <string name="survey">Обзоры</string>
     <string name="activation_date">Дата активации</string>
     <string name="groups">Группа</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -290,6 +290,9 @@
     <string name="total_loan">Jumla ya mkopo</string>
     <string name="total_saving">Uhifadhi wa jumla</string>
     <string name="accounts_overview">Maelezo ya Akaunti</string>
+    <string name="show_hide_total_saving_amount">Onyesha au ufiche jumla ya kiasi kilichohifadhiwa</string>
+    <string name="show_hide_total_loan_amount">Onyesha au ufiche jumla ya kiasi cha mkopo</string>
+    <string name="hidden_amount">*****</string>
     <string name="survey">Surveys</string>
     <string name="activation_date">Tarehe ya uanzishaji</string>
     <string name="groups">Kundi</string>

--- a/app/src/main/res/values-te/strings.xml
+++ b/app/src/main/res/values-te/strings.xml
@@ -292,6 +292,9 @@
     <string name="total_loan">మొత్తం రుణ</string>
     <string name="total_saving">మొత్తం పొదుపు</string>
     <string name="accounts_overview">ఖాతా సారాంశం</string>
+    <string name="show_hide_total_saving_amount">మొత్తం పొదుపు మొత్తాన్ని చూపండి లేదా దాచండి</string>
+    <string name="show_hide_total_loan_amount">మొత్తం లోన్ మొత్తాన్ని చూపండి లేదా దాచండి</string>
+    <string name="hidden_amount">*****</string>
     <string name="survey">సర్వేలు</string>
     <string name="activation_date">ఆక్టివేషన్ తేదీ</string>
     <string name="groups">గుంపులు</string>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -295,6 +295,9 @@
     <string name="total_loan">کل قرض</string>
     <string name="total_saving">کل بچت</string>
     <string name="accounts_overview">اکاؤنٹ کا جائزہ</string>
+    <string name="show_hide_total_saving_amount">بچت کی کل رقم دکھائیں یا چھپائیں۔</string>
+    <string name="show_hide_total_loan_amount">قرض کی کل رقم دکھائیں یا چھپائیں۔</string>
+    <string name="hidden_amount">*****</string>
     <string name="survey">سروے</string>
     <string name="activation_date">چالو کرنے کی تاریخ</string>
     <string name="groups">گروپ</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -346,6 +346,9 @@
     <string name="total_loan">Total Loan</string>
     <string name="total_saving">Total Savings</string>
     <string name="accounts_overview">Account Overview</string>
+    <string name="show_hide_total_saving_amount">Show or hide the total saving amount</string>
+    <string name="show_hide_total_loan_amount">Show or hide the total loan amount</string>
+    <string name="hidden_amount">*****</string>
     <string name="survey">Surveys</string>
     <string name="activation_date">Activation Date</string>
     <string name="groups">Groups</string>


### PR DESCRIPTION
Fixes #2003

**Summary**
Added a single-tap icon button to the app's dashboard that enables the user to display or hide loan and savings amounts by masking them.

**Screenshots**
<img src="https://user-images.githubusercontent.com/65452331/225789794-c974eae3-9e5d-4ef1-8f66-ee63816a698f.jpg" width="45%"></img> <img src="https://user-images.githubusercontent.com/65452331/225789812-d861c440-228f-40f8-a4d8-b20906e3790a.jpg" width="45%"></img> 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.