### PR TITLE
Fix: GuarantorApi was not getting created in BaseApiManager Class

### DIFF
--- a/app/src/main/java/org/mifos/mobile/api/BaseApiManager.kt
+++ b/app/src/main/java/org/mifos/mobile/api/BaseApiManager.kt
@@ -37,7 +37,7 @@ class BaseApiManager @Inject constructor(preferencesHelper: PreferencesHelper) {
     val userDetailsService: UserDetailsService?
         get() = Companion.userDetailsService
     val guarantorApi: GuarantorService?
-        get() = Companion.field
+        get() = Companion.guarantorApi
 
     companion object {
         private val field: GuarantorService? = null

--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,8 @@ task clean(type: Delete) {
 ext {
     // Sdk and tools
     minSdkVersion = 22
-    targetSdkVersion = 31
-    compileSdkVersion = 31
+    targetSdkVersion = 33
+    compileSdkVersion = 33
 
     // App dependencies
     supportLibraryVersion = '1.4.2'

--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,8 @@ task clean(type: Delete) {
 ext {
     // Sdk and tools
     minSdkVersion = 22
-    targetSdkVersion = 33
-    compileSdkVersion = 33
+    targetSdkVersion = 31
+    compileSdkVersion = 31
 
     // App dependencies
     supportLibraryVersion = '1.4.2'


### PR DESCRIPTION
In BaseApiManager class guarantorApi was not getting called correctly instead  a different field was getting called, which wasn't creating the guatrantorApi. So I made a change, which make sure it create guarantorApi.


- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.