### PR TITLE
fix : making on-screen/soft keyboard dismiss on background tap

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/activities/LoginActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/LoginActivity.kt
@@ -20,7 +20,6 @@ import org.mifos.mobile.ui.views.LoginView
 import org.mifos.mobile.utils.Constants
 import org.mifos.mobile.utils.Network
 import org.mifos.mobile.utils.Toaster
-import org.mifos.mobile.utils.Utils.hideSoftKeyboard
 import javax.inject.Inject
 
 
@@ -61,16 +60,13 @@ class LoginActivity : BaseActivity(), LoginView {
 
     private fun dismissSoftKeyboardOnBkgTap(view: View) {
 
-        // If this individual view doesn't include an EditText
         if (view !is EditText) {
             view.setOnTouchListener { view, event ->
-                hideSoftKeyboard(this@LoginActivity)
+                hideKeyboard(this@LoginActivity)
                 false
             }
         }
 
-        //If it's a ViewGroup(or layout container), iterate over all its child views and
-        // recursively call dismissSoftKeyboardOnBkgTap() for each individual view.
         if (view is ViewGroup) {
             for (i in 0 until view.childCount) {
                 val innerView = view.getChildAt(i)

--- a/app/src/main/java/org/mifos/mobile/ui/activities/LoginActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/LoginActivity.kt
@@ -12,6 +12,7 @@ import butterknife.BindView
 import butterknife.ButterKnife
 import butterknife.OnClick
 import com.google.android.material.textfield.TextInputLayout
+import kotlinx.android.synthetic.main.activity_login.*
 import org.mifos.mobile.R
 import org.mifos.mobile.models.payload.LoginPayload
 import org.mifos.mobile.presenters.LoginPresenter
@@ -55,18 +56,16 @@ class LoginActivity : BaseActivity(), LoginView {
         setContentView(R.layout.activity_login)
         ButterKnife.bind(this)
         loginPresenter?.attachView(this)
-        dismissSoftKeyboardOnBkgTap(findViewById(R.id.nsv_bkg))
+        dismissSoftKeyboardOnBkgTap(nsv_background)
     }
 
     private fun dismissSoftKeyboardOnBkgTap(view: View) {
-
         if (view !is EditText) {
             view.setOnTouchListener { view, event ->
                 hideKeyboard(this@LoginActivity)
                 false
             }
         }
-
         if (view is ViewGroup) {
             for (i in 0 until view.childCount) {
                 val innerView = view.getChildAt(i)

--- a/app/src/main/java/org/mifos/mobile/ui/activities/LoginActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/LoginActivity.kt
@@ -3,17 +3,15 @@ package org.mifos.mobile.ui.activities
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import android.view.ViewGroup
+import android.widget.EditText
 import android.widget.LinearLayout
 import android.widget.Toast
-
 import androidx.appcompat.widget.AppCompatButton
-
 import butterknife.BindView
 import butterknife.ButterKnife
 import butterknife.OnClick
-
 import com.google.android.material.textfield.TextInputLayout
-
 import org.mifos.mobile.R
 import org.mifos.mobile.models.payload.LoginPayload
 import org.mifos.mobile.presenters.LoginPresenter
@@ -22,8 +20,9 @@ import org.mifos.mobile.ui.views.LoginView
 import org.mifos.mobile.utils.Constants
 import org.mifos.mobile.utils.Network
 import org.mifos.mobile.utils.Toaster
-
+import org.mifos.mobile.utils.Utils.hideSoftKeyboard
 import javax.inject.Inject
+
 
 /**
  * @author Vishwajeet
@@ -57,6 +56,27 @@ class LoginActivity : BaseActivity(), LoginView {
         setContentView(R.layout.activity_login)
         ButterKnife.bind(this)
         loginPresenter?.attachView(this)
+        dismissSoftKeyboardOnBkgTap(findViewById(R.id.nsv_bkg))
+    }
+
+    private fun dismissSoftKeyboardOnBkgTap(view: View) {
+
+        // If this individual view doesn't include an EditText
+        if (view !is EditText) {
+            view.setOnTouchListener { view, event ->
+                hideSoftKeyboard(this@LoginActivity)
+                false
+            }
+        }
+
+        //If it's a ViewGroup(or layout container), iterate over all its child views and
+        // recursively call dismissSoftKeyboardOnBkgTap() for each individual view.
+        if (view is ViewGroup) {
+            for (i in 0 until view.childCount) {
+                val innerView = view.getChildAt(i)
+                dismissSoftKeyboardOnBkgTap(innerView)
+            }
+        }
     }
 
     /**

--- a/app/src/main/java/org/mifos/mobile/utils/Utils.kt
+++ b/app/src/main/java/org/mifos/mobile/utils/Utils.kt
@@ -1,6 +1,5 @@
 package org.mifos.mobile.utils
 
-import android.app.Activity
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.PorterDuff
@@ -10,12 +9,9 @@ import android.graphics.drawable.LayerDrawable
 import android.net.Uri
 import android.util.Log
 import android.view.Menu
-import android.view.inputmethod.InputMethodManager
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
-import com.mifos.mobile.passcode.BasePassCodeActivity
 import org.mifos.mobile.R
-import org.mifos.mobile.ui.activities.LoginActivity
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException

--- a/app/src/main/java/org/mifos/mobile/utils/Utils.kt
+++ b/app/src/main/java/org/mifos/mobile/utils/Utils.kt
@@ -1,5 +1,6 @@
 package org.mifos.mobile.utils
 
+import android.app.Activity
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.PorterDuff
@@ -9,9 +10,12 @@ import android.graphics.drawable.LayerDrawable
 import android.net.Uri
 import android.util.Log
 import android.view.Menu
+import android.view.inputmethod.InputMethodManager
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
+import com.mifos.mobile.passcode.BasePassCodeActivity
 import org.mifos.mobile.R
+import org.mifos.mobile.ui.activities.LoginActivity
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -76,5 +80,12 @@ object Utils {
                     str.length) + " ")
         }
         return builder.toString()
+    }
+
+    fun hideSoftKeyboard(activity: Activity) {
+        val inputMethodManager: InputMethodManager = activity.getSystemService(
+            Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        inputMethodManager.hideSoftInputFromWindow(
+            activity.currentFocus?.windowToken, 0)
     }
 }

--- a/app/src/main/java/org/mifos/mobile/utils/Utils.kt
+++ b/app/src/main/java/org/mifos/mobile/utils/Utils.kt
@@ -81,11 +81,4 @@ object Utils {
         }
         return builder.toString()
     }
-
-    fun hideSoftKeyboard(activity: Activity) {
-        val inputMethodManager: InputMethodManager = activity.getSystemService(
-            Context.INPUT_METHOD_SERVICE) as InputMethodManager
-        inputMethodManager.hideSoftInputFromWindow(
-            activity.currentFocus?.windowToken, 0)
-    }
 }

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -3,7 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:fitsSystemWindows="true"
-    android:id="@+id/nsv_bkg"
+    android:id="@+id/nsv_background"
     android:layout_height="match_parent"
     android:layout_width="match_parent">
 

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -3,6 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:fitsSystemWindows="true"
+    android:id="@+id/nsv_bkg"
     android:layout_height="match_parent"
     android:layout_width="match_parent">
 


### PR DESCRIPTION

Fixes #1499 

To enhance the user flow, added the ability to dismiss the soft keyboard or on-screen keyboard by tapping on the background or anywhere other than an EditText.

1. dismissSoftKeyboardOnBkgTap() takes View/ViewGroup as an input and then individually checks all its child Views/ViewGroups to find a View that doesn't include EditText.

2. when such a view is found and a tap is made on such a view, it's passed to hideSoftKeyboard() Utils function that by using Input Method Manager hides the soft keyboard.

3. tested on pixel 2(api 33), the fix works smoothly.



https://user-images.githubusercontent.com/59947871/226180530-0580d102-6e02-41d0-b924-9cf536055348.mp4




Please Add Screenshots If there are any UI changes.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.