### PR TITLE
fix #1408 : fixing EditText error message on the login screen

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/activities/LoginActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/LoginActivity.kt
@@ -11,8 +11,10 @@ import androidx.appcompat.widget.AppCompatButton
 import butterknife.BindView
 import butterknife.ButterKnife
 import butterknife.OnClick
+import butterknife.OnTouch
 
 import com.google.android.material.textfield.TextInputLayout
+import kotlinx.android.synthetic.main.activity_login.*
 
 import org.mifos.mobile.R
 import org.mifos.mobile.models.payload.LoginPayload
@@ -57,6 +59,15 @@ class LoginActivity : BaseActivity(), LoginView {
         setContentView(R.layout.activity_login)
         ButterKnife.bind(this)
         loginPresenter?.attachView(this)
+    }
+
+    @OnTouch(R.id.et_username, R.id.et_password)
+    fun onTouch(v : View): Boolean {
+        when(v.id) {
+            R.id.et_username -> loginPresenter?.mvpView?.clearUsernameError()
+            R.id.et_password -> loginPresenter?.mvpView?.clearPasswordError()
+        }
+        return false
     }
 
     /**


### PR DESCRIPTION
Fixes #1408 

The error message is displayed in case of an error(eg : user left username/ or password blank and pressed login) But the error should go away when the user tries to input the username/ password again.

1. adding onTouch listener to both et_password and et_username, so when the user touches on these to input username/ or password clearUsernameError(), or clearPasswordError() is called and the error is dismissed.

2. tested on my pixel 2 and the fix runs smooth and fine.



Please Add Screenshots If there are any UI changes.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.