### PR TITLE
fix #2064 : fixing spelling mistake in permission material dialog box.

### DIFF
--- a/app/src/main/java/org/mifos/mobile/utils/CheckSelfPermissionAndRequest.kt
+++ b/app/src/main/java/org/mifos/mobile/utils/CheckSelfPermissionAndRequest.kt
@@ -42,7 +42,7 @@ object CheckSelfPermissionAndRequest {
      * button and next time App ask for permission, It will show a Material Dialog and there
      * will be a message to tell the user that you have denied the permission before, So do
      * you want to give this permission to app or not, If yes then click on Re-Try dialog button
-     * and if not then click on Dialog button "I'M Sure", to not to give this permission to the
+     * and if not then click on Dialog button "I'm Sure", to not to give this permission to the
      * app.
      *
      *

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -414,7 +414,7 @@
     <string name="dialog_action_cancel">Cancel</string>
     <string name="dialog_action_back">Back</string>
     <string name="dialog_permission_denied">Permission Denied</string>
-    <string name="dialog_action_i_am_sure">I\'M Sure</string>
+    <string name="dialog_action_i_am_sure">I\'m Sure</string>
     <string name="dialog_action_re_try">Retry</string>
     <string name="dialog_action_app_settings">App Settings</string>
     <string name="dialog_message_camera_permission_denied_prompt">Without camera permission you will


### PR DESCRIPTION
Fixes #2064 

Fixed a spelling error that appears in the permission material dialog box.

### After the fix : 

<img width="249" alt="Screenshot 2023-03-26 at 10 11 38" src="https://user-images.githubusercontent.com/59947871/227756025-73a7eeec-eab7-4329-a474-16e46f65d8fc.png">

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.