### PR TITLE
fix #1944 - Replace jcenter with mavenCentral

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ allprojects {
     repositories {
         google()
         jcenter()
+        mavenCentral()
         maven { url "https://www.jitpack.io" }
     }
 }


### PR DESCRIPTION
We cannot completely remove jcenter() as some of the dependencies such as **"com.isseiaoki:simplecropview:1.1.8"** works only with jcenter(). So adding mavenCentral for those dependencies whose latest implementations works with mavenCentral.

Fixes #1944 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.