### PR TITLE
fix #2089 : fixed back button in the settings

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/activities/SettingsActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/SettingsActivity.kt
@@ -27,8 +27,8 @@ class SettingsActivity : BaseActivity() {
 
     override fun onBackPressed() {
         if (supportFragmentManager.backStackEntryCount == 0) {
+            super.onBackPressed()
             if (hasSettingsChanged) {
-                super.onBackPressed()
                 ActivityCompat.finishAffinity(this)
                 startActivity(Intent(this, HomeActivity::class.java))
             }


### PR DESCRIPTION
Fixes #2089

super.onBackPressed() should be outside the condition : if(hasSettingsChanged) ... so that it could provide the default functionality even when the settings aren't changed.

 

Please Add Screenshots If there are any UI changes.


https://user-images.githubusercontent.com/59947871/230304391-93964573-498a-4795-b7a6-3d43e2096f76.mp4



Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.