### PR TITLE
fix #1354 : making TableView width cover entire screen width.

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/adapters/LoanRepaymentScheduleAdapter.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/adapters/LoanRepaymentScheduleAdapter.kt
@@ -3,6 +3,7 @@ package org.mifos.mobile.ui.adapters
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.LinearLayout
 import android.widget.TextView
 import butterknife.BindView
 import butterknife.ButterKnife
@@ -24,6 +25,7 @@ class LoanRepaymentScheduleAdapter @Inject internal constructor() :
         AbstractTableAdapter<ColumnHeader?, RowHeader?, Cell?>() {
 
     private var currency: String? = ""
+    private var columnWidth : Double = 0.0
     fun setCurrency(currency: String?) {
         this.currency = currency
     }
@@ -32,6 +34,10 @@ class LoanRepaymentScheduleAdapter @Inject internal constructor() :
         @JvmField
         @BindView(R.id.cell_data)
         var tvCell: TextView? = null
+
+        @JvmField
+        @BindView(R.id.cell_container)
+        var llCellContainer : LinearLayout? = null
 
         init {
             ButterKnife.bind(this, v)
@@ -77,12 +83,18 @@ class LoanRepaymentScheduleAdapter @Inject internal constructor() :
             }
             else -> viewHolder.tvCell?.text = ""
         }
+        viewHolder.llCellContainer?.layoutParams?.width = columnWidth.toInt()
+        viewHolder.tvCell?.requestLayout()
     }
 
     internal inner class ColumnHeaderViewHolder(itemView: View) : AbstractViewHolder(itemView) {
         @JvmField
         @BindView(R.id.column_header_textView)
         var tvColumnHeader: TextView? = null
+
+        @JvmField
+        @BindView(R.id.column_header_container)
+        var llColumnHeaderContainer : LinearLayout? = null
 
         init {
             ButterKnife.bind(this, itemView)
@@ -106,6 +118,9 @@ class LoanRepaymentScheduleAdapter @Inject internal constructor() :
         // Get the holder to update cell item text
         val columnHeaderViewHolder = holder as ColumnHeaderViewHolder
         columnHeaderViewHolder.tvColumnHeader?.text = data.toString()
+
+        columnHeaderViewHolder.llColumnHeaderContainer?.layoutParams?.width = columnWidth.toInt()
+        columnHeaderViewHolder.tvColumnHeader?.requestLayout()
     }
 
     internal inner class RowHeaderViewHolder(itemView: View) : AbstractViewHolder(itemView) {
@@ -161,5 +176,9 @@ class LoanRepaymentScheduleAdapter @Inject internal constructor() :
         // then you should fill this method to be able create different
         // type of CellViewHolder on "onCreateCellViewHolder"
         return 0
+    }
+
+    fun setColumnWidth(columnWidth : Double) {
+        this.columnWidth = columnWidth
     }
 }

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/LoanRepaymentScheduleFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/LoanRepaymentScheduleFragment.kt
@@ -1,5 +1,6 @@
 package org.mifos.mobile.ui.fragments
 
+import android.content.res.Configuration
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.LayoutInflater
@@ -106,7 +107,17 @@ class LoanRepaymentScheduleFragment : BaseFragment(), LoanRepaymentScheduleMvpVi
      * Initializes the layout
      */
     override fun showUserInterface() {
+        val columnWidth : Double
+        tvRepaymentSchedule?.setHasFixedWidth(true)
+        val orientation = resources.configuration.orientation
+        tvRepaymentSchedule?.layoutParams?.width = resources.displayMetrics.widthPixels
         tvRepaymentSchedule?.setAdapter(loanRepaymentScheduleAdapter)
+        if(orientation == Configuration.ORIENTATION_PORTRAIT) {
+            columnWidth = 2 * (resources.displayMetrics.widthPixels / 7.2);
+        } else {
+            columnWidth = 2 * (resources.displayMetrics.widthPixels / 6.6);
+        }
+        loanRepaymentScheduleAdapter?.setColumnWidth(columnWidth)
     }
 
     override fun showProgress() {
@@ -195,6 +206,11 @@ class LoanRepaymentScheduleFragment : BaseFragment(), LoanRepaymentScheduleMvpVi
         super.onDestroyView()
         hideProgressBar()
         loanRepaymentSchedulePresenter?.detachView()
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        showUserInterface()
     }
 
     companion object {

--- a/app/src/main/java/org/mifos/mobile/utils/DateHelper.kt
+++ b/app/src/main/java/org/mifos/mobile/utils/DateHelper.kt
@@ -37,7 +37,7 @@ object DateHelper {
      */
     fun getDateAsString(integersOfDate: List<Int?>?): String {
         val stringBuilder = StringBuilder()
-        if (integersOfDate != null) {
+        if (integersOfDate != null && integersOfDate.size >= 3) {
             stringBuilder.append(integersOfDate[2])
                     .append(' ')
                     .append(getMonthName(integersOfDate[1]))

--- a/app/src/main/res/layout/cell_loan_repayment_schedule.xml
+++ b/app/src/main/res/layout/cell_loan_repayment_schedule.xml
@@ -8,7 +8,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
+    android:layout_height="@dimen/cell_height"
     android:gravity="center"
     android:orientation="vertical"
     android:padding="@dimen/Mifos.DesignSystem.Spacing.CardInnerPadding">

--- a/app/src/main/res/layout/row_header_loan_repayment_schedule.xml
+++ b/app/src/main/res/layout/row_header_loan_repayment_schedule.xml
@@ -30,5 +30,6 @@
 
 
     <View
+        android:layout_width="wrap_content"
         style="@style/Mifos.DesignSystem.Components.VerticalSpacer"/>
 </RelativeLayout>


### PR DESCRIPTION
Fixes #1354

TableView width now covers the entire screen width, UI looks much cleaner and sharp.

1. modified height of each cell to default_cell_height, so as to match the height of row header cell(screenshot below)
2. added a check in DateHelper.kt so as to avoid app crash from indexOutOfBoundsException(Logcat screen below)
3. added layout_width constraint to the View in row_header_loan_repayment_schedule.xml, because the app was crashing when layout_inflator was trying to inflate this View. #2097 
4. fixed TableView width to cover entire screen.(video below)
5. extensively tested on pixel 2

 
Please Add Screenshots If there are any UI changes.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.

before fix, table height didn't catchup with row header height(due to cell_height != row_header_cell_height)
<img width="358" alt="Screenshot 2023-04-09 at 22 42 26" src="https://user-images.githubusercontent.com/59947871/230788047-2e55ee31-3cac-4a5c-8273-8ead06da2f40.png">

before fix, indexOutOfBoundsException
<img width="1273" alt="Screenshot 2023-04-09 at 22 40 40" src="https://user-images.githubusercontent.com/59947871/230788113-50e0b3c4-9665-4b48-b62e-753a071dc2c1.png">

after fix : 

https://user-images.githubusercontent.com/59947871/230788158-0e496a5f-91d8-4a64-9b24-8b4841fcd36e.mp4

after fix : orientation change ->


https://user-images.githubusercontent.com/59947871/230833296-cf28e390-2a18-4b77-b7b5-3b39a7017057.mp4


