### PR TITLE
fix #2102 : making soft keyboard dismiss on background tap

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/activities/RegistrationActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/RegistrationActivity.kt
@@ -2,6 +2,10 @@ package org.mifos.mobile.ui.activities
 
 import android.content.DialogInterface
 import android.os.Bundle
+import android.view.View
+import android.view.ViewGroup
+import android.widget.EditText
+import kotlinx.android.synthetic.main.activity_registration.*
 
 import org.mifos.mobile.R
 import org.mifos.mobile.ui.activities.base.BaseActivity
@@ -14,6 +18,23 @@ class RegistrationActivity : BaseActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_registration)
         replaceFragment(RegistrationFragment.newInstance(), false, R.id.container)
+
+        dismissSoftKeyboardOnBackgroundTap(nsv_background)
+    }
+
+    private fun dismissSoftKeyboardOnBackgroundTap(view: View) {
+        if (view !is EditText) {
+            view.setOnTouchListener { view, event ->
+                hideKeyboard(this@RegistrationActivity)
+                false
+            }
+        }
+        if (view is ViewGroup) {
+            for (i in 0 until view.childCount) {
+                val innerView = view.getChildAt(i)
+                dismissSoftKeyboardOnBackgroundTap(innerView)
+            }
+        }
     }
 
     override fun onBackPressed() {

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/RegistrationFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/RegistrationFragment.kt
@@ -111,7 +111,25 @@ class RegistrationFragment : BaseFragment(), RegistrationView {
             }
             override fun afterTextChanged(editable: Editable) {}
         })
+        if (rootView != null) {
+            dismissSoftKeyboardOnBackgroundTap(rootView)
+        }
         return rootView
+    }
+
+    private fun dismissSoftKeyboardOnBackgroundTap(view: View) {
+        if (view !is EditText) {
+            view.setOnTouchListener { view, event ->
+                BaseActivity.hideKeyboard(requireContext())
+                false
+            }
+        }
+        if (view is ViewGroup) {
+            for (i in 0 until view.childCount) {
+                val innerView = view.getChildAt(i)
+                dismissSoftKeyboardOnBackgroundTap(innerView)
+            }
+        }
     }
 
     private fun updatePasswordStrengthView(password: String) {

--- a/app/src/main/res/layout/activity_registration.xml
+++ b/app/src/main/res/layout/activity_registration.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/nsv_background"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:background="@android:color/white"
     android:layout_height="match_parent"


### PR DESCRIPTION
Fixes #2102 

dismissSoftKeyboardOnBackgroundTap() takes root view as input and assigns each view which is not an EditText with a Listener, if a tap is registered, softkeyboard is dismissed.

tested on pixel 2, fix runs smooth.


Please Add Screenshots If there are any UI changes.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.


https://user-images.githubusercontent.com/59947871/233178363-076523dd-de65-4ad6-a39f-161a99f33b6d.mp4