### PR TITLE
fix #2103 : dismiss soft keyboard on background tap

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/activities/LoanApplicationActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/LoanApplicationActivity.kt
@@ -1,6 +1,10 @@
 package org.mifos.mobile.ui.activities
 
 import android.os.Bundle
+import android.view.View
+import android.view.ViewGroup
+import android.widget.EditText
+import kotlinx.android.synthetic.main.activity_loan_application.*
 
 import org.mifos.mobile.R
 import org.mifos.mobile.ui.activities.base.BaseActivity
@@ -17,5 +21,22 @@ class LoanApplicationActivity : BaseActivity() {
                     R.id.container)
         }
         showBackButton()
+
+        dismissSoftKeyboardOnBkgTap(cl_background)
+    }
+
+    private fun dismissSoftKeyboardOnBkgTap(view: View) {
+        if (view !is EditText) {
+            view.setOnTouchListener { view, event ->
+                hideKeyboard(this@LoanApplicationActivity)
+                false
+            }
+        }
+        if (view is ViewGroup) {
+            for (i in 0 until view.childCount) {
+                val innerView = view.getChildAt(i)
+                dismissSoftKeyboardOnBkgTap(innerView)
+            }
+        }
     }
 }

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/LoanApplicationFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/LoanApplicationFragment.kt
@@ -176,11 +176,17 @@ class LoanApplicationFragment : BaseFragment(), LoanApplicationMvpView {
             savedInstanceState: Bundle?
     ): View? {
         rootView = inflater.inflate(R.layout.fragment_add_loan_application, container, false)
-        ButterKnife.bind(this, rootView!!)
+        val rootView = this.rootView
+        if (rootView != null) {
+            ButterKnife.bind(this, rootView)
+        }
         loanApplicationPresenter?.attachView(this)
         showUserInterface()
         if (savedInstanceState == null) {
             loadLoanTemplate()
+        }
+        if(rootView != null) {
+            dismissSoftKeyboardOnBkgTap(rootView)
         }
         return rootView
     }
@@ -497,6 +503,21 @@ class LoanApplicationFragment : BaseFragment(), LoanApplicationMvpView {
         super.onDestroyView()
         hideProgressBar()
         loanApplicationPresenter?.detachView()
+    }
+
+    private fun dismissSoftKeyboardOnBkgTap(view: View) {
+        if (view !is EditText) {
+            view.setOnTouchListener { view, event ->
+                BaseActivity.hideKeyboard(requireContext())
+                false
+            }
+        }
+        if (view is ViewGroup) {
+            for (i in 0 until view.childCount) {
+                val innerView = view.getChildAt(i)
+                dismissSoftKeyboardOnBkgTap(innerView)
+            }
+        }
     }
 
     companion object {

--- a/app/src/main/res/layout/activity_loan_application.xml
+++ b/app/src/main/res/layout/activity_loan_application.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout
+    android:id="@+id/cl_background"
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:fitsSystemWindows="true"
     android:layout_height="match_parent"


### PR DESCRIPTION
Fixes #2103 

1. dismissSoftKeyboardOnBackgroundTap() takes root view as input and assigns each view which is not an EditText with a Listener, if a tap is registered, softkeyboard is dismissed.
2. surrounded rootView with mandatory safe null checks
3. tested on pixel 2, fix runs smooth.

 

Attached screen recording below : 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.

after the fix : 

https://user-images.githubusercontent.com/59947871/233266935-fa5dc15d-ac60-4067-9083-322acde20c41.mp4

