### PR TITLE
fix #2118 : typo in README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Before you begin, you should have already downloaded the Android Studio SDK and 
 
 3. Click on 'Open an existing Android Studio project'
 
-4. Browse to the directory where you cloned the mobile-mobile repo and click OK.
+4. Browse to the directory where you cloned the mifos-mobile repo and click OK.
 
 5. Let Android Studio import the project.
 


### PR DESCRIPTION
Fixes #2118 

The Typo in the line number 4 of Build Codes Has been fixed

Screenshot 
![Screen shot](https://user-images.githubusercontent.com/87092955/233832771-93b398d1-a140-42a8-9c4c-f9646b00beee.png)

