### PR TITLE
Fix #2097 and #2098 . Resolved RepaymentScheduleScreen Crash and Dark…

### DIFF
--- a/app/src/main/res/layout/cell_loan_repayment_schedule.xml
+++ b/app/src/main/res/layout/cell_loan_repayment_schedule.xml
@@ -22,6 +22,7 @@
         android:gravity="center"
         android:maxLines="1"
         android:visibility="visible"
-        tools:text="Cell Data"/>
+        tools:text="Cell Data"
+        android:textColor="@color/black"/>
 
 </LinearLayout>

--- a/app/src/main/res/layout/column_header_loan_repayment_schedule.xml
+++ b/app/src/main/res/layout/column_header_loan_repayment_schedule.xml
@@ -21,7 +21,8 @@
         android:layout_weight="4"
         android:gravity="center"
         style="@style/Mifos.DesignSystem.TextStyle.Body"
-        tools:text="Header Data"/>
+        tools:text="Header Data"
+        android:textColor="@color/black"/>
 
 
     <View

--- a/app/src/main/res/layout/fragment_loan_repayment_schedule.xml
+++ b/app/src/main/res/layout/fragment_loan_repayment_schedule.xml
@@ -38,8 +38,7 @@
                         android:layout_weight="1"
                         android:layout_width="wrap_content"
                         android:text="@string/account_number"
-                        android:textAppearance="@style/Base.TextAppearance.AppCompat.Medium"
-                        android:textColor="@color/black"/>
+                        android:textAppearance="@style/Base.TextAppearance.AppCompat.Medium" />
                     <TextView
                         android:gravity="start"
                         android:id="@+id/tv_account_number"
@@ -59,7 +58,7 @@
                         android:layout_width="wrap_content"
                         android:text="@string/disbursement_date"
                         android:textAppearance="@style/Base.TextAppearance.AppCompat.Medium"
-                        android:textColor="@color/black"/>
+                        />
                     <TextView
                         android:gravity="start"
                         android:id="@+id/tv_disbursement_date"
@@ -79,7 +78,7 @@
                         android:layout_width="wrap_content"
                         android:text="@string/no_of_payments"
                         android:textAppearance="@style/Base.TextAppearance.AppCompat.Medium"
-                        android:textColor="@color/black"/>
+                        />
                     <TextView
                         android:gravity="start"
                         android:id="@+id/tv_number_of_payments"
@@ -104,7 +103,8 @@
             android:layout_marginStart="@dimen/default_margin"
             app:selected_color="?attr/colorPrimary"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"/>
+            android:layout_height="wrap_content"
+            />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/row_header_loan_repayment_schedule.xml
+++ b/app/src/main/res/layout/row_header_loan_repayment_schedule.xml
@@ -25,10 +25,12 @@
             android:gravity="center"
             android:maxLines="1"
             style="@style/Mifos.DesignSystem.TextStyle.Body"
-            tools:text="Row Data"/>
+            tools:text="Row Data"
+            android:textColor="@color/black"/>
     </LinearLayout>
 
 
     <View
-        style="@style/Mifos.DesignSystem.Components.VerticalSpacer"/>
+        style="@style/Mifos.DesignSystem.Components.VerticalSpacer"
+        android:layout_width="wrap_content"/>
 </RelativeLayout>


### PR DESCRIPTION
Resolved RepaymentScheduleScreen Crash and Dark Mode Text Readability.

Fixes #2097 and #2098 

![RepaymentScheduleScreen in Dark Mode](https://user-images.githubusercontent.com/73953395/236993683-14aef232-aaf1-45c3-b097-3f0a3a391ddd.png)
![RepaymentScheduleScreen in Light Mode](https://user-images.githubusercontent.com/73953395/236993700-884bc8f7-6275-4a6a-bf48-07e7cf04548f.png)
