### PR TITLE
RepaymentScheduleScreen Crash and Dark Mode Text Readability Fixed #2098 and #2097

### DIFF
--- a/app/src/main/res/layout/cell_loan_repayment_schedule.xml
+++ b/app/src/main/res/layout/cell_loan_repayment_schedule.xml
@@ -22,6 +22,7 @@
         android:gravity="center"
         android:maxLines="1"
         android:visibility="visible"
-        tools:text="Cell Data"/>
+        tools:text="Cell Data"
+        android:textColor="@color/black"/>
 
 </LinearLayout>

--- a/app/src/main/res/layout/column_header_loan_repayment_schedule.xml
+++ b/app/src/main/res/layout/column_header_loan_repayment_schedule.xml
@@ -21,7 +21,8 @@
         android:layout_weight="4"
         android:gravity="center"
         style="@style/Mifos.DesignSystem.TextStyle.Body"
-        tools:text="Header Data"/>
+        tools:text="Header Data"
+        android:textColor="@color/black"/>
 
 
     <View

--- a/app/src/main/res/layout/fragment_loan_repayment_schedule.xml
+++ b/app/src/main/res/layout/fragment_loan_repayment_schedule.xml
@@ -39,7 +39,7 @@
                         android:layout_width="wrap_content"
                         android:text="@string/account_number"
                         android:textAppearance="@style/Base.TextAppearance.AppCompat.Medium"
-                        android:textColor="@color/black"/>
+                        />
                     <TextView
                         android:gravity="start"
                         android:id="@+id/tv_account_number"
@@ -59,7 +59,7 @@
                         android:layout_width="wrap_content"
                         android:text="@string/disbursement_date"
                         android:textAppearance="@style/Base.TextAppearance.AppCompat.Medium"
-                        android:textColor="@color/black"/>
+                        />
                     <TextView
                         android:gravity="start"
                         android:id="@+id/tv_disbursement_date"
@@ -79,7 +79,7 @@
                         android:layout_width="wrap_content"
                         android:text="@string/no_of_payments"
                         android:textAppearance="@style/Base.TextAppearance.AppCompat.Medium"
-                        android:textColor="@color/black"/>
+                        />
                     <TextView
                         android:gravity="start"
                         android:id="@+id/tv_number_of_payments"

--- a/app/src/main/res/layout/row_header_loan_repayment_schedule.xml
+++ b/app/src/main/res/layout/row_header_loan_repayment_schedule.xml
@@ -25,10 +25,12 @@
             android:gravity="center"
             android:maxLines="1"
             style="@style/Mifos.DesignSystem.TextStyle.Body"
-            tools:text="Row Data"/>
+            tools:text="Row Data"
+            android:textColor="@color/black"/>
     </LinearLayout>
 
 
     <View
-        style="@style/Mifos.DesignSystem.Components.VerticalSpacer"/>
+        style="@style/Mifos.DesignSystem.Components.VerticalSpacer"
+        android:layout_width="wrap_content"/>
 </RelativeLayout>


### PR DESCRIPTION
Fixes #2098 and #2097 . Fixed the RepaymentScheduleScreen Crash Problem and Dark Mode Text Readability also. Attached the Screenshots below.

![RepaymentScheduleScreen in Dark Mode](https://user-images.githubusercontent.com/73953395/237002664-80b1b484-ed2e-46b8-b1f5-431aff70b452.png)
![RepaymentScheduleScreen in Light Mode](https://user-images.githubusercontent.com/73953395/237002641-813a5a14-b9fb-4d5f-b481-ae1f1da9a341.png)
