### PR TITLE
migrating lower navigation drawer features from butterknife to viewbinding

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -76,6 +76,10 @@ android {
     androidExtensions {
         experimental = true
     }
+
+    buildFeatures {
+        viewBinding = true
+    }
 }
 
 dependencies {

--- a/app/src/main/java/org/mifos/mobile/ui/activities/AboutUsActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/AboutUsActivity.kt
@@ -3,6 +3,7 @@ package org.mifos.mobile.ui.activities
 import android.os.Bundle
 
 import org.mifos.mobile.R
+import org.mifos.mobile.databinding.ActivityContainerBinding
 import org.mifos.mobile.ui.activities.base.BaseActivity
 import org.mifos.mobile.ui.fragments.AboutUsFragment
 
@@ -11,10 +12,13 @@ import org.mifos.mobile.ui.fragments.AboutUsFragment
  * On 11/03/19.
  */
 class AboutUsActivity : BaseActivity() {
+    private lateinit var binding : ActivityContainerBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_container)
+        binding = ActivityContainerBinding.inflate(layoutInflater)
+        val view = binding.root
+        setContentView(view)
         setToolbarTitle(getString(R.string.about_us))
         showBackButton()
         replaceFragment(AboutUsFragment.newInstance(), false, R.id.container)

--- a/app/src/main/java/org/mifos/mobile/ui/activities/AboutUsActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/AboutUsActivity.kt
@@ -17,8 +17,7 @@ class AboutUsActivity : BaseActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityContainerBinding.inflate(layoutInflater)
-        val view = binding.root
-        setContentView(view)
+        setContentView(binding.root)
         setToolbarTitle(getString(R.string.about_us))
         showBackButton()
         replaceFragment(AboutUsFragment.newInstance(), false, R.id.container)

--- a/app/src/main/java/org/mifos/mobile/ui/activities/HelpActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/HelpActivity.kt
@@ -3,6 +3,7 @@ package org.mifos.mobile.ui.activities
 import android.os.Bundle
 
 import org.mifos.mobile.R
+import org.mifos.mobile.databinding.ActivityContainerBinding
 import org.mifos.mobile.ui.activities.base.BaseActivity
 import org.mifos.mobile.ui.fragments.HelpFragment
 
@@ -11,10 +12,13 @@ import org.mifos.mobile.ui.fragments.HelpFragment
  * On 11/03/19.
  */
 class HelpActivity : BaseActivity() {
+    private lateinit var binding : ActivityContainerBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_container)
+        binding = ActivityContainerBinding.inflate(layoutInflater)
+        val view = binding.root
+        setContentView(view)
         setToolbarTitle(getString(R.string.help))
         showBackButton()
         replaceFragment(HelpFragment.newInstance(), false, R.id.container)

--- a/app/src/main/java/org/mifos/mobile/ui/activities/HelpActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/HelpActivity.kt
@@ -17,8 +17,7 @@ class HelpActivity : BaseActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityContainerBinding.inflate(layoutInflater)
-        val view = binding.root
-        setContentView(view)
+        setContentView(binding.root)
         setToolbarTitle(getString(R.string.help))
         showBackButton()
         replaceFragment(HelpFragment.newInstance(), false, R.id.container)

--- a/app/src/main/java/org/mifos/mobile/ui/activities/PrivacyPolicyActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/PrivacyPolicyActivity.kt
@@ -23,8 +23,7 @@ class PrivacyPolicyActivity : BaseActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityPrivacyPolicyBinding.inflate(layoutInflater)
-        val view = binding.root
-        setContentView(view)
+        setContentView(binding.root)
         setToolbarTitle(getString(R.string.privacy_policy))
         showBackButton()
 

--- a/app/src/main/java/org/mifos/mobile/ui/activities/PrivacyPolicyActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/PrivacyPolicyActivity.kt
@@ -7,12 +7,10 @@ import android.os.Bundle
 import android.view.View
 import android.webkit.WebView
 import android.webkit.WebViewClient
-import android.widget.ProgressBar
 
-import butterknife.BindView
-import butterknife.ButterKnife
 
 import org.mifos.mobile.R
+import org.mifos.mobile.databinding.ActivityPrivacyPolicyBinding
 import org.mifos.mobile.ui.activities.base.BaseActivity
 
 /**
@@ -20,39 +18,33 @@ import org.mifos.mobile.ui.activities.base.BaseActivity
  * On 11/03/19.
  */
 class PrivacyPolicyActivity : BaseActivity() {
-
-    @JvmField
-    @BindView(R.id.webView)
-    var webView: WebView? = null
-
-    @JvmField
-    @BindView(R.id.progress_bar)
-    var progressBar: ProgressBar? = null
+    private lateinit var binding : ActivityPrivacyPolicyBinding
     private var showOrHideWebViewInitialUse = "show"
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_privacy_policy)
-        ButterKnife.bind(this)
+        binding = ActivityPrivacyPolicyBinding.inflate(layoutInflater)
+        val view = binding.root
+        setContentView(view)
         setToolbarTitle(getString(R.string.privacy_policy))
         showBackButton()
 
         // Force links and redirects to open in the WebView instead of in a browser
-        webView?.webViewClient = WebViewClient()
+        binding.webView.webViewClient = WebViewClient()
 
         // Enable Javascript
-        val webSettings = webView?.settings
-        webSettings?.javaScriptEnabled = true
+        val webSettings = binding.webView.settings
+        webSettings.javaScriptEnabled = true
 
         // REMOTE RESOURCE
-        webView?.settings?.domStorageEnabled = true
-        webView?.overScrollMode = WebView.OVER_SCROLL_NEVER
-        webView?.loadUrl(getString(R.string.privacy_policy_host_url))
-        webView?.webViewClient = MyWebViewClient()
+        binding.webView.settings.domStorageEnabled = true
+        binding.webView.overScrollMode = WebView.OVER_SCROLL_NEVER
+        binding.webView.loadUrl(getString(R.string.privacy_policy_host_url))
+        binding.webView.webViewClient = MyWebViewClient()
     }
 
     override fun onBackPressed() {
-        if (webView?.canGoBack() == true) {
-            webView?.goBack()
+        if (binding.webView.canGoBack()) {
+            binding.webView.goBack()
         } else {
             super.onBackPressed()
         }
@@ -71,13 +63,13 @@ class PrivacyPolicyActivity : BaseActivity() {
         override fun onPageStarted(view: WebView, url: String, favicon: Bitmap?) {
             // only make it invisible the FIRST time the app is run
             if (showOrHideWebViewInitialUse == "show") {
-                webView?.visibility = View.INVISIBLE
+                binding.webView.visibility = View.INVISIBLE
             }
         }
 
         override fun onPageFinished(view: WebView, url: String) {
             showOrHideWebViewInitialUse = "hide"
-            progressBar?.visibility = View.GONE
+            binding.progressBar.visibility = View.GONE
             view.visibility = View.VISIBLE
             super.onPageFinished(view, url)
         }

--- a/app/src/main/java/org/mifos/mobile/ui/activities/SettingsActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/SettingsActivity.kt
@@ -6,16 +6,19 @@ import android.os.Bundle
 import androidx.core.app.ActivityCompat
 
 import org.mifos.mobile.R
+import org.mifos.mobile.databinding.ActivitySettingsBinding
 import org.mifos.mobile.ui.activities.base.BaseActivity
 import org.mifos.mobile.ui.fragments.SettingsFragment
 import org.mifos.mobile.utils.Constants
 
 class SettingsActivity : BaseActivity() {
-
+    private lateinit var binding : ActivitySettingsBinding
     private var hasSettingsChanged = false
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_settings)
+        binding = ActivitySettingsBinding.inflate(layoutInflater)
+        val view = binding.root
+        setContentView(view)
         setToolbarTitle(getString(R.string.settings))
         showBackButton()
         replaceFragment(SettingsFragment.newInstance(), false, R.id.container)

--- a/app/src/main/java/org/mifos/mobile/ui/activities/SettingsActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/SettingsActivity.kt
@@ -17,8 +17,7 @@ class SettingsActivity : BaseActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivitySettingsBinding.inflate(layoutInflater)
-        val view = binding.root
-        setContentView(view)
+        setContentView(binding.root)
         setToolbarTitle(getString(R.string.settings))
         showBackButton()
         replaceFragment(SettingsFragment.newInstance(), false, R.id.container)

--- a/app/src/main/java/org/mifos/mobile/ui/activities/base/BaseActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/base/BaseActivity.kt
@@ -5,6 +5,7 @@ import android.app.Activity
 import android.app.ProgressDialog
 import android.content.Context
 import android.view.MenuItem
+import android.view.View
 import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
 import androidx.appcompat.widget.Toolbar
@@ -51,6 +52,15 @@ open class BaseActivity : BasePassCodeActivity(), BaseActivityCallback {
     private var progress: ProgressDialog? = null
     override fun setContentView(layoutResID: Int) {
         super.setContentView(layoutResID)
+        toolbar = findViewById(R.id.toolbar)
+        if (toolbar != null) {
+            setSupportActionBar(toolbar)
+            setToolbarElevation()
+        }
+    }
+
+    override fun setContentView(view: View?) {
+        super.setContentView(view)
         toolbar = findViewById(R.id.toolbar)
         if (toolbar != null) {
             setSupportActionBar(toolbar)

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/AboutUsFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/AboutUsFragment.kt
@@ -6,16 +6,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 
-import butterknife.BindView
-import butterknife.ButterKnife
-import butterknife.OnClick
 
 import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
 
 import org.mifos.mobile.BuildConfig
 import org.mifos.mobile.R
+import org.mifos.mobile.databinding.FragmentAboutUsBinding
 import org.mifos.mobile.ui.activities.PrivacyPolicyActivity
 import org.mifos.mobile.ui.fragments.base.BaseFragment
 import java.util.*
@@ -25,54 +22,66 @@ import java.util.*
 ~See https://github.com/openMF/self-service-app/blob/master/LICENSE.md
 */
 class AboutUsFragment : BaseFragment() {
+    private var _binding : FragmentAboutUsBinding? = null
+    private val binding get() = _binding!!
+
     private val licenseLink = "https://github.com/openMF/mifos-mobile/blob/development/LICENSE.md"
     private val sourceCodeLink = "https://github.com/openMF/mifos-mobile"
     private val websiteLink = "https://openmf.github.io/mobileapps.github.io/"
-
-    @kotlin.jvm.JvmField
-    @BindView(R.id.app_version)
-    var tvAppVersion: TextView? = null
-
-
-    @kotlin.jvm.JvmField
-    @BindView(R.id.tv_copy_right)
-    var tvCopyRight: TextView? = null
-
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val rootView = inflater.inflate(R.layout.fragment_about_us, container, false)
-        ButterKnife.bind(this, rootView!!)
+        _binding = FragmentAboutUsBinding.inflate(inflater, container, false)
+        val rootView = binding.root
         setToolbarTitle(getString(R.string.about_us))
-        tvAppVersion?.text = BuildConfig.VERSION_NAME
-        tvCopyRight?.text = getString(R.string.copy_right_mifos, Calendar.getInstance()[Calendar.YEAR].toString())
+        binding.appVersion.text = BuildConfig.VERSION_NAME
+        binding.tvCopyRight.text = getString(R.string.copy_right_mifos, Calendar.getInstance()[Calendar.YEAR].toString())
         return rootView
     }
 
-    @OnClick(R.id.about_website_container)
-    fun showWebsite(){
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.aboutWebsiteContainer.setOnClickListener {
+            showWebsite()
+        }
+
+        binding.aboutLicensesContainer.setOnClickListener {
+            showOpenSourceLicenses()
+        }
+
+        binding.aboutPrivacyPolicyContainer.setOnClickListener {
+            showPrivacyPolicy()
+        }
+
+        binding.aboutSourcesContainer.setOnClickListener {
+            showSourceCode()
+        }
+
+        binding.selfLicenseContainer.setOnClickListener {
+            showSelfLicense()
+        }
+    }
+
+    private fun showWebsite(){
         startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(websiteLink)))
     }
 
-    @OnClick(R.id.about_licenses_container)
-    fun showOpenSourceLicenses() {
+    private fun showOpenSourceLicenses() {
         startActivity(Intent(activity, OssLicensesMenuActivity::class.java))
     }
 
-    @OnClick(R.id.about_privacy_policy_container)
-    fun showPrivacyPolicy() {
+    private fun showPrivacyPolicy() {
         startActivity(Intent(activity, PrivacyPolicyActivity::class.java))
     }
 
-    @OnClick(R.id.about_sources_container)
-    fun showSourceCode() {
+    private fun showSourceCode() {
         startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(sourceCodeLink)))
     }
 
-    @OnClick(R.id.self_license_container)
-    fun showSelfLicense() {
+    private fun showSelfLicense() {
         startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(licenseLink)))
     }
 
@@ -84,5 +93,10 @@ class AboutUsFragment : BaseFragment() {
             fragment.arguments = args
             return fragment
         }
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
     }
 }

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/HelpFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/HelpFragment.kt
@@ -7,15 +7,12 @@ import android.net.Uri
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.*
-import android.widget.Button
 import android.widget.Toast
 import androidx.appcompat.widget.SearchView
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
-import butterknife.BindView
-import butterknife.ButterKnife
 import com.github.therajanmaurya.sweeterror.SweetUIErrorHandler
 import org.mifos.mobile.R
+import org.mifos.mobile.databinding.FragmentHelpBinding
 import org.mifos.mobile.models.FAQ
 import org.mifos.mobile.presenters.HelpPresenter
 import org.mifos.mobile.ui.activities.base.BaseActivity
@@ -32,14 +29,8 @@ import javax.inject.Inject
 ~See https://github.com/openMF/self-service-app/blob/master/LICENSE.md
 */
 class HelpFragment : BaseFragment(), HelpView {
-    @kotlin.jvm.JvmField
-    @BindView(R.id.rv_faq)
-    var rvFaq: RecyclerView? = null
-
-
-    @kotlin.jvm.JvmField
-    @BindView(R.id.layout_error)
-    var layoutError: View? = null
+    private var _binding : FragmentHelpBinding? = null
+    private val binding get() = _binding!!
 
     @kotlin.jvm.JvmField
     @Inject
@@ -48,16 +39,15 @@ class HelpFragment : BaseFragment(), HelpView {
     @kotlin.jvm.JvmField
     @Inject
     var presenter: HelpPresenter? = null
-    private var rootView: View? = null
     private var faqArrayList: ArrayList<FAQ?>? = null
     private lateinit var sweetUIErrorHandler: SweetUIErrorHandler
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View? {
-        rootView = inflater.inflate(R.layout.fragment_help, container, false)
+        _binding = FragmentHelpBinding.inflate(inflater, container, false)
+        val rootView = binding.root
         setHasOptionsMenu(true)
         (activity as BaseActivity?)?.activityComponent?.inject(this)
-        ButterKnife.bind(this, rootView!!)
         presenter?.attachView(this)
         setToolbarTitle(getString(R.string.help))
         sweetUIErrorHandler = SweetUIErrorHandler(activity, rootView)
@@ -84,15 +74,15 @@ class HelpFragment : BaseFragment(), HelpView {
     private fun showUserInterface() {
         val layoutManager = LinearLayoutManager(activity)
         layoutManager.orientation = LinearLayoutManager.VERTICAL
-        rvFaq?.layoutManager = layoutManager
-        rvFaq?.addItemDecoration(DividerItemDecoration(activity,
+        binding.rvFaq.layoutManager = layoutManager
+        binding.rvFaq.addItemDecoration(DividerItemDecoration(activity,
                 layoutManager.orientation))
-        rootView?.findViewById<Button>(R.id.call_button)?.setOnClickListener {
+        binding.callButton.setOnClickListener {
             val intent = Intent(Intent.ACTION_DIAL)
             intent.data = Uri.parse("tel:" + getString(R.string.help_line_number))
             startActivity(intent)
         }
-        rootView?.findViewById<Button>(R.id.mail_button)?.setOnClickListener {
+        binding.mailButton.setOnClickListener {
             val intent = Intent(Intent.ACTION_SENDTO).apply {
                 data = Uri.parse("mailto:")
                 putExtra(Intent.EXTRA_EMAIL, arrayOf(getString(R.string.contact_email)) )
@@ -105,14 +95,14 @@ class HelpFragment : BaseFragment(), HelpView {
                 Toast.makeText(requireContext(), getString(R.string.no_app_to_support_action),Toast.LENGTH_SHORT).show();
             }
         }
-        rootView?.findViewById<Button>(R.id.locations_button)?.setOnClickListener {
+        binding.locationsButton.setOnClickListener {
             (activity as BaseActivity?)?.replaceFragment(LocationsFragment.newInstance(),true, R.id.container)
         }
     }
 
     override fun showFaq(faqArrayList: ArrayList<FAQ?>?) {
         faqAdapter?.setFaqArrayList(faqArrayList)
-        rvFaq?.adapter = faqAdapter
+        binding.rvFaq.adapter = faqAdapter
         this.faqArrayList = faqArrayList
     }
 
@@ -131,7 +121,7 @@ class HelpFragment : BaseFragment(), HelpView {
                 val filteredFAQList = presenter?.filterList(faqArrayList, newText)
                 filteredFAQList?.let {
                     if (it.isNotEmpty()) {
-                        sweetUIErrorHandler.hideSweetErrorLayoutUI(rvFaq, layoutError)
+                        sweetUIErrorHandler.hideSweetErrorLayoutUI(binding.rvFaq, binding.layoutError.clErrorLayout)
                         faqAdapter?.updateList(it)
                     } else {
                         showEmptyFAQUI()
@@ -144,7 +134,7 @@ class HelpFragment : BaseFragment(), HelpView {
 
     private fun showEmptyFAQUI() {
         sweetUIErrorHandler.showSweetEmptyUI(getString(R.string.questions),
-                R.drawable.ic_help_black_24dp, rvFaq, layoutError)
+                R.drawable.ic_help_black_24dp, binding.rvFaq, binding.layoutError.clErrorLayout)
     }
 
     override fun showProgress() {
@@ -163,5 +153,10 @@ class HelpFragment : BaseFragment(), HelpView {
             fragment.arguments = args
             return fragment
         }
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
     }
 }

--- a/app/src/main/res/layout/error_layout.xml
+++ b/app/src/main/res/layout/error_layout.xml
@@ -3,6 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/cl_error_layout"
     android:layout_height="match_parent"
     android:layout_width="match_parent">
 

--- a/app/src/main/res/layout/fragment_help.xml
+++ b/app/src/main/res/layout/fragment_help.xml
@@ -27,8 +27,8 @@
         android:layout_width="match_parent"/>
 
     <include
-        layout="@layout/error_layout"
         android:id="@+id/layout_error"
+        layout="@layout/error_layout"
         android:visibility="gone" />
     <LinearLayout
         android:id="@+id/toggleButton"


### PR DESCRIPTION
fixes #2142 

migrating following files which fall under the lower navigation drawer ->

activities(4)
	AboutUs, Help, PrivacyPolicy, Settings
fragments(2)
	AboutUsFragment, HelpFragment

videos after the change, 

Light Theme -> 

https://github.com/openMF/mifos-mobile/assets/59947871/ded1a17c-e9ea-4188-87ad-2e59e391f3bf


Dark Theme -> 

https://github.com/openMF/mifos-mobile/assets/59947871/80af76c6-2cb1-45d4-b40b-53151049729c


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.