### PR TITLE
fix : migrated activities from butterknife to viewbinding

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -76,6 +76,10 @@ android {
     androidExtensions {
         experimental = true
     }
+
+    buildFeatures {
+        viewBinding = true
+    }
 }
 
 dependencies {

--- a/app/src/main/java/org/mifos/mobile/ui/activities/AccountOverviewActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/AccountOverviewActivity.kt
@@ -3,8 +3,10 @@ package org.mifos.mobile.ui.activities
 import android.os.Bundle
 
 import org.mifos.mobile.R
+import org.mifos.mobile.databinding.ActivityContainerBinding
 import org.mifos.mobile.ui.activities.base.BaseActivity
 import org.mifos.mobile.ui.fragments.AccountOverviewFragment
+
 
 /**
  * @author Rajan Maurya
@@ -12,9 +14,12 @@ import org.mifos.mobile.ui.fragments.AccountOverviewFragment
  */
 class AccountOverviewActivity : BaseActivity() {
 
+    private lateinit var binding: ActivityContainerBinding
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_container)
+        binding = ActivityContainerBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         replaceFragment(AccountOverviewFragment.newInstance(), false, R.id.container)
         showBackButton()
         hideToolbarElevation()

--- a/app/src/main/java/org/mifos/mobile/ui/activities/AddBeneficiaryActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/AddBeneficiaryActivity.kt
@@ -3,6 +3,7 @@ package org.mifos.mobile.ui.activities
 import android.os.Bundle
 
 import org.mifos.mobile.R
+import org.mifos.mobile.databinding.ActivityContainerBinding
 import org.mifos.mobile.ui.activities.base.BaseActivity
 import org.mifos.mobile.ui.fragments.BeneficiaryAddOptionsFragment
 
@@ -12,9 +13,12 @@ import org.mifos.mobile.ui.fragments.BeneficiaryAddOptionsFragment
  */
 class AddBeneficiaryActivity : BaseActivity() {
 
+    private lateinit var binding: ActivityContainerBinding
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_container)
+        binding = ActivityContainerBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         showBackButton()
         replaceFragment(BeneficiaryAddOptionsFragment.newInstance(), false, R.id.container)
     }

--- a/app/src/main/java/org/mifos/mobile/ui/activities/EditUserDetailActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/EditUserDetailActivity.kt
@@ -2,9 +2,8 @@ package org.mifos.mobile.ui.activities
 
 import android.os.Bundle
 
-import butterknife.ButterKnife
-
 import org.mifos.mobile.R
+import org.mifos.mobile.databinding.ActivityEditUserDetailBinding
 import org.mifos.mobile.ui.activities.base.BaseActivity
 import org.mifos.mobile.ui.fragments.UpdatePasswordFragment
 
@@ -13,10 +12,12 @@ import org.mifos.mobile.ui.fragments.UpdatePasswordFragment
 */
 class EditUserDetailActivity : BaseActivity() {
 
+    private lateinit var binding: ActivityEditUserDetailBinding
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_edit_user_detail)
-        ButterKnife.bind(this)
+        binding = ActivityEditUserDetailBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         setToolbarTitle(getString(R.string.string_and_string, getString(R.string.edit),
                 getString(R.string.user_details)))
         showBackButton()

--- a/app/src/main/java/org/mifos/mobile/ui/activities/HomeActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/HomeActivity.kt
@@ -1,6 +1,5 @@
 package org.mifos.mobile.ui.activities
 
-import android.app.UiModeManager
 import android.content.*
 import android.graphics.Bitmap
 import android.net.Uri
@@ -10,17 +9,12 @@ import android.util.Log
 import android.view.MenuItem
 import android.view.View
 import android.view.inputmethod.InputMethodManager
-import android.widget.ImageView
 import android.widget.TextView
 import android.widget.Toast
 
 import androidx.appcompat.app.ActionBarDrawerToggle
-import androidx.core.content.ContextCompat
 import androidx.core.view.GravityCompat
-import androidx.drawerlayout.widget.DrawerLayout
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
-import butterknife.BindView
-import butterknife.ButterKnife
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -28,6 +22,8 @@ import com.google.android.material.imageview.ShapeableImageView
 import com.google.android.material.navigation.NavigationView
 import org.mifos.mobile.R
 import org.mifos.mobile.api.local.PreferencesHelper
+import org.mifos.mobile.databinding.ActivityHomeBinding
+import org.mifos.mobile.databinding.NavDrawerHeaderBinding
 import org.mifos.mobile.models.client.Client
 import org.mifos.mobile.presenters.UserDetailsPresenter
 import org.mifos.mobile.ui.activities.base.BaseActivity
@@ -45,13 +41,9 @@ import javax.inject.Inject
  * @since 14/07/2016
  */
 class HomeActivity : BaseActivity(), UserDetailsView, NavigationView.OnNavigationItemSelectedListener {
-    @JvmField
-    @BindView(R.id.navigation_view)
-    var navigationView: NavigationView? = null
 
-    @JvmField
-    @BindView(R.id.drawer)
-    var drawerLayout: DrawerLayout? = null
+    private lateinit var binding: ActivityHomeBinding
+    private lateinit var navHeaderBinding: NavDrawerHeaderBinding
 
     @JvmField
     @Inject
@@ -71,9 +63,9 @@ class HomeActivity : BaseActivity(), UserDetailsView, NavigationView.OnNavigatio
     var doubleBackToExitPressedOnce = false
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        binding = ActivityHomeBinding.inflate(layoutInflater)
         activityComponent?.inject(this)
-        setContentView(R.layout.activity_home)
-        ButterKnife.bind(this)
+        setContentView(binding.root)
         clientId = preferencesHelper?.clientId
         setupNavigationBar()
         setToolbarElevation()
@@ -170,7 +162,7 @@ class HomeActivity : BaseActivity(), UserDetailsView, NavigationView.OnNavigatio
         }
 
         // close the drawer
-        drawerLayout?.closeDrawer(GravityCompat.START)
+        binding.drawer.closeDrawer(GravityCompat.START)
         return true
     }
 
@@ -199,18 +191,18 @@ class HomeActivity : BaseActivity(), UserDetailsView, NavigationView.OnNavigatio
      * self-service application
      */
     private fun setupNavigationBar() {
-        navigationView?.setNavigationItemSelectedListener(this)
+        binding.navigationView.setNavigationItemSelectedListener(this)
         val actionBarDrawerToggle: ActionBarDrawerToggle = object : ActionBarDrawerToggle(this,
-                drawerLayout, toolbar, R.string.open_drawer, R.string.close_drawer) {
+                binding.drawer, toolbar, R.string.open_drawer, R.string.close_drawer) {
 
             override fun onDrawerOpened(drawerView: View) {
                 super.onDrawerOpened(drawerView)
                 hideKeyboard(drawerView)
             }
         }
-        drawerLayout?.addDrawerListener(actionBarDrawerToggle)
+        binding.drawer.addDrawerListener(actionBarDrawerToggle)
         actionBarDrawerToggle.syncState()
-        navigationView?.getHeaderView(0)?.let { setupHeaderView(it) }
+        binding.navigationView.getHeaderView(0)?.let { setupHeaderView(it) }
         setUpBackStackListener()
     }
 
@@ -220,11 +212,12 @@ class HomeActivity : BaseActivity(), UserDetailsView, NavigationView.OnNavigatio
      * @param headerView Header view of NavigationView
      */
     private fun setupHeaderView(headerView: View) {
-        tvUsername = ButterKnife.findById(headerView, R.id.tv_user_name)
-        drawerUserImage = ButterKnife.findById(headerView, R.id.user_image_round)
+        navHeaderBinding = NavDrawerHeaderBinding.bind(headerView)
+        tvUsername = navHeaderBinding.tvUserName
+        drawerUserImage = navHeaderBinding.userImageRound
         drawerUserImage?.setOnClickListener{
             startActivity(Intent(this, UserProfileActivity::class.java))
-            drawerLayout?.closeDrawer(GravityCompat.START)
+            binding.drawer.closeDrawer(GravityCompat.START)
         }
     }
 
@@ -293,8 +286,8 @@ class HomeActivity : BaseActivity(), UserDetailsView, NavigationView.OnNavigatio
      * Handling back press
      */
     override fun onBackPressed() {
-        if (drawerLayout?.isDrawerOpen(GravityCompat.START) == true) {
-            drawerLayout?.closeDrawer(GravityCompat.START)
+        if (binding.drawer.isDrawerOpen(GravityCompat.START)) {
+            binding.drawer.closeDrawer(GravityCompat.START)
             return
         }
         val fragment = supportFragmentManager.findFragmentById(R.id.container)
@@ -344,7 +337,7 @@ class HomeActivity : BaseActivity(), UserDetailsView, NavigationView.OnNavigatio
     }
 
     fun setNavigationViewSelectedItem(id: Int) {
-        navigationView?.setCheckedItem(id)
+        binding.navigationView.setCheckedItem(id)
     }
 
 

--- a/app/src/main/java/org/mifos/mobile/ui/activities/LoanAccountContainerActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/LoanAccountContainerActivity.kt
@@ -3,6 +3,7 @@ package org.mifos.mobile.ui.activities
 import android.os.Bundle
 
 import org.mifos.mobile.R
+import org.mifos.mobile.databinding.ActivityContainerBinding
 import org.mifos.mobile.ui.activities.base.BaseActivity
 import org.mifos.mobile.ui.fragments.LoanAccountsDetailFragment
 import org.mifos.mobile.utils.Constants
@@ -13,10 +14,13 @@ import org.mifos.mobile.utils.Constants
 */
 class LoanAccountContainerActivity : BaseActivity() {
 
+    private lateinit var binding: ActivityContainerBinding
+
     private var loanId: Long = 0
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_container)
+        binding = ActivityContainerBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         loanId = intent?.extras?.getLong(Constants.LOAN_ID)!!
         replaceFragment(LoanAccountsDetailFragment.newInstance(loanId), false, R.id.container)
         showBackButton()

--- a/app/src/main/java/org/mifos/mobile/ui/activities/LoanApplicationActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/LoanApplicationActivity.kt
@@ -3,15 +3,19 @@ package org.mifos.mobile.ui.activities
 import android.os.Bundle
 
 import org.mifos.mobile.R
+import org.mifos.mobile.databinding.ActivityLoanApplicationBinding
 import org.mifos.mobile.ui.activities.base.BaseActivity
 import org.mifos.mobile.ui.enums.LoanState
 import org.mifos.mobile.ui.fragments.LoanApplicationFragment
 
 class LoanApplicationActivity : BaseActivity() {
 
+    private lateinit var binding: ActivityLoanApplicationBinding
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_loan_application)
+        binding = ActivityLoanApplicationBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         if (savedInstanceState == null) {
             replaceFragment(LoanApplicationFragment.newInstance(LoanState.CREATE), false,
                     R.id.container)

--- a/app/src/main/java/org/mifos/mobile/ui/activities/LoginActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/LoginActivity.kt
@@ -5,16 +5,9 @@ import android.os.Bundle
 import android.view.View
 import android.view.ViewGroup
 import android.widget.EditText
-import android.widget.LinearLayout
 import android.widget.Toast
-import androidx.appcompat.widget.AppCompatButton
-import butterknife.BindView
-import butterknife.ButterKnife
-import butterknife.OnClick
-import butterknife.OnTouch
-import com.google.android.material.textfield.TextInputLayout
-import kotlinx.android.synthetic.main.activity_login.*
 import org.mifos.mobile.R
+import org.mifos.mobile.databinding.ActivityLoginBinding
 import org.mifos.mobile.models.payload.LoginPayload
 import org.mifos.mobile.presenters.LoginPresenter
 import org.mifos.mobile.ui.activities.base.BaseActivity
@@ -35,29 +28,28 @@ class LoginActivity : BaseActivity(), LoginView {
     @Inject
     var loginPresenter: LoginPresenter? = null
 
-    @JvmField
-    @BindView(R.id.btn_login)
-    var btnLogin: AppCompatButton? = null
-
-    @JvmField
-    @BindView(R.id.til_username)
-    var tilUsername: TextInputLayout? = null
-
-    @JvmField
-    @BindView(R.id.til_password)
-    var tilPassword: TextInputLayout? = null
-
-    @JvmField
-    @BindView(R.id.ll_login)
-    var llLogin: LinearLayout? = null
+    private lateinit var binding: ActivityLoginBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        binding = ActivityLoginBinding.inflate(layoutInflater)
         activityComponent?.inject(this)
-        setContentView(R.layout.activity_login)
-        ButterKnife.bind(this)
+        setContentView(binding.root)
         loginPresenter?.attachView(this)
-        dismissSoftKeyboardOnBkgTap(nsv_background)
+        dismissSoftKeyboardOnBkgTap(binding.nsvBackground)
+        binding.btnLogin.setOnClickListener {
+            onLoginClicked()
+        }
+        binding.btnRegister.setOnClickListener {
+            onRegisterClicked()
+        }
+        binding.etUsername.setOnTouchListener { view, event ->
+            onTouch(view)
+        }
+
+        binding.etPassword.setOnTouchListener { view, event ->
+            onTouch(view)
+        }
     }
 
     private fun dismissSoftKeyboardOnBkgTap(view: View) {
@@ -75,11 +67,10 @@ class LoginActivity : BaseActivity(), LoginView {
         }
     }
 
-    @OnTouch(R.id.et_username, R.id.et_password)
-    fun onTouch(v : View): Boolean {
-        when(v.id) {
-            R.id.et_username -> loginPresenter?.mvpView?.clearUsernameError()
-            R.id.et_password -> loginPresenter?.mvpView?.clearPasswordError()
+    fun onTouch(v: View): Boolean {
+        when (v) {
+            binding.etUsername -> loginPresenter?.mvpView?.clearUsernameError()
+            binding.etPassword -> loginPresenter?.mvpView?.clearPasswordError()
         }
         return false
     }
@@ -120,44 +111,42 @@ class LoginActivity : BaseActivity(), LoginView {
      */
     override fun showMessage(errorMessage: String?) {
         showToast(errorMessage!!, Toast.LENGTH_LONG)
-        llLogin?.visibility = View.VISIBLE
+        binding.llLogin.visibility = View.VISIBLE
     }
 
     override fun showUsernameError(error: String?) {
-        tilUsername?.error = error
+        binding.tilUsername.error = error
     }
 
     override fun showPasswordError(error: String?) {
-        tilPassword?.error = error
+        binding.tilPassword.error = error
     }
 
     override fun clearUsernameError() {
-        tilUsername?.isErrorEnabled = false
+        binding.tilUsername.isErrorEnabled = false
     }
 
     override fun clearPasswordError() {
-        tilPassword?.isErrorEnabled = false
+        binding.tilPassword.isErrorEnabled = false
     }
 
     /**
      * Called when Login Button is clicked, used for logging in the user
      */
 
-    @OnClick(R.id.btn_login)
     fun onLoginClicked() {
-        val username = tilUsername?.editText?.editableText.toString()
-        val password = tilPassword?.editText?.editableText.toString()
+        val username = binding.tilUsername.editText?.editableText.toString()
+        val password = binding.tilPassword.editText?.editableText.toString()
         if (Network.isConnected(this)) {
             val payload = LoginPayload()
             payload.username = username
             payload.password = password
             loginPresenter?.login(payload)
         } else {
-            Toaster.show(llLogin, getString(R.string.no_internet_connection))
+            Toaster.show(binding.llLogin, getString(R.string.no_internet_connection))
         }
     }
 
-    @OnClick(R.id.btn_register)
     fun onRegisterClicked() {
         startActivity(Intent(this@LoginActivity, RegistrationActivity::class.java))
     }

--- a/app/src/main/java/org/mifos/mobile/ui/activities/NotificationActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/NotificationActivity.kt
@@ -3,14 +3,18 @@ package org.mifos.mobile.ui.activities
 import android.os.Bundle
 
 import org.mifos.mobile.R
+import org.mifos.mobile.databinding.ActivityNotificationBinding
 import org.mifos.mobile.ui.activities.base.BaseActivity
 import org.mifos.mobile.ui.fragments.NotificationFragment
 
 class NotificationActivity : BaseActivity() {
 
+    private lateinit var binding: ActivityNotificationBinding
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_notification)
+        binding = ActivityNotificationBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         replaceFragment(NotificationFragment.newInstance(), false, R.id.container)
     }

--- a/app/src/main/java/org/mifos/mobile/ui/activities/RegistrationActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/RegistrationActivity.kt
@@ -4,15 +4,19 @@ import android.content.DialogInterface
 import android.os.Bundle
 
 import org.mifos.mobile.R
+import org.mifos.mobile.databinding.ActivityRegistrationBinding
 import org.mifos.mobile.ui.activities.base.BaseActivity
 import org.mifos.mobile.ui.fragments.RegistrationFragment
 import org.mifos.mobile.utils.MaterialDialog
 
 class RegistrationActivity : BaseActivity() {
 
+    private lateinit var binding: ActivityRegistrationBinding
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_registration)
+        binding = ActivityRegistrationBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         replaceFragment(RegistrationFragment.newInstance(), false, R.id.container)
     }
 

--- a/app/src/main/java/org/mifos/mobile/ui/activities/SavingsAccountApplicationActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/SavingsAccountApplicationActivity.kt
@@ -3,6 +3,7 @@ package org.mifos.mobile.ui.activities
 import android.os.Bundle
 
 import org.mifos.mobile.R
+import org.mifos.mobile.databinding.ActivitySavingsAccountApplicationBinding
 import org.mifos.mobile.ui.activities.base.BaseActivity
 import org.mifos.mobile.ui.enums.SavingsAccountState
 import org.mifos.mobile.ui.fragments.SavingsAccountApplicationFragment.Companion.newInstance
@@ -12,9 +13,12 @@ import org.mifos.mobile.ui.fragments.SavingsAccountApplicationFragment.Companion
 */
 class SavingsAccountApplicationActivity : BaseActivity() {
 
+    private lateinit var binding: ActivitySavingsAccountApplicationBinding
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_savings_account_application)
+        binding = ActivitySavingsAccountApplicationBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         setToolbarTitle(getString(R.string.apply_savings_account))
         showBackButton()
         replaceFragment(newInstance(SavingsAccountState.CREATE,

--- a/app/src/main/java/org/mifos/mobile/ui/activities/SavingsAccountContainerActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/SavingsAccountContainerActivity.kt
@@ -3,6 +3,7 @@ package org.mifos.mobile.ui.activities
 import android.os.Bundle
 
 import org.mifos.mobile.R
+import org.mifos.mobile.databinding.ActivityContainerBinding
 import org.mifos.mobile.ui.activities.base.BaseActivity
 import org.mifos.mobile.ui.fragments.SavingAccountsDetailFragment
 import org.mifos.mobile.utils.Constants
@@ -12,10 +13,13 @@ import org.mifos.mobile.utils.Constants
  */
 class SavingsAccountContainerActivity : BaseActivity() {
 
+    private lateinit var binding: ActivityContainerBinding
+
     private var savingsId: Long = 0
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_container)
+        binding = ActivityContainerBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         savingsId = intent?.extras?.getLong(Constants.SAVINGS_ID)!!
         replaceFragment(SavingAccountsDetailFragment.newInstance(savingsId), false, R.id.container)
         showBackButton()

--- a/app/src/main/java/org/mifos/mobile/ui/activities/UserProfileActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/UserProfileActivity.kt
@@ -3,14 +3,18 @@ package org.mifos.mobile.ui.activities
 import android.os.Bundle
 
 import org.mifos.mobile.R
+import org.mifos.mobile.databinding.ActivityUserProfileBinding
 import org.mifos.mobile.ui.activities.base.BaseActivity
 import org.mifos.mobile.ui.fragments.UserProfileFragment
 
 class UserProfileActivity : BaseActivity() {
 
+    private lateinit var binding: ActivityUserProfileBinding
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_user_profile)
+        binding = ActivityUserProfileBinding.inflate(layoutInflater)
+        setContentView(binding.root)
         replaceFragment(UserProfileFragment.newInstance(), false, R.id.container)
     }
 }

--- a/app/src/main/java/org/mifos/mobile/ui/activities/base/BaseActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/base/BaseActivity.kt
@@ -5,6 +5,7 @@ import android.app.Activity
 import android.app.ProgressDialog
 import android.content.Context
 import android.view.MenuItem
+import android.view.View
 import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
 import androidx.appcompat.widget.Toolbar
@@ -51,6 +52,16 @@ open class BaseActivity : BasePassCodeActivity(), BaseActivityCallback {
     private var progress: ProgressDialog? = null
     override fun setContentView(layoutResID: Int) {
         super.setContentView(layoutResID)
+        toolbar = findViewById(R.id.toolbar)
+        if (toolbar != null) {
+            setSupportActionBar(toolbar)
+            setToolbarElevation()
+        }
+    }
+
+
+    override fun setContentView(view: View?) {
+        super.setContentView(view)
         toolbar = findViewById(R.id.toolbar)
         if (toolbar != null) {
             setSupportActionBar(toolbar)


### PR DESCRIPTION
fixes #2142 
Migrated Activities from  butterknife to viewbinding as part of GSoC 23.
build.gradle file will be redundant if PR #2143 gets merged and in that case , I will remove it from this PR

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.