### PR TITLE
fix #2142 : migrating adapters to viewbinding

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/adapters/ClientChargeAdapter.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/adapters/ClientChargeAdapter.kt
@@ -2,24 +2,17 @@ package org.mifos.mobile.ui.adapters
 
 import android.content.Context
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
-import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 
-import butterknife.BindView
-import butterknife.ButterKnife
-
 import org.mifos.mobile.R
-import org.mifos.mobile.injection.ActivityContext
+import org.mifos.mobile.databinding.RowClientChargeBinding
 import org.mifos.mobile.models.Charge
 import org.mifos.mobile.ui.getThemeAttributeColor
 import org.mifos.mobile.utils.CurrencyUtil.formatCurrency
 import org.mifos.mobile.utils.DateHelper.getDateAsString
 
 import java.util.*
-import javax.inject.Inject
 
 /**
  * @author Vishwajeet
@@ -27,7 +20,7 @@ import javax.inject.Inject
  */
 class ClientChargeAdapter (
     val onItemClick: (itemPosition: Int) -> Unit
-) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+) : RecyclerView.Adapter<ClientChargeAdapter.ViewHolder>() {
 
     private var clientChargeList: List<Charge?>? = ArrayList()
     fun setClientChargeList(clientChargeList: List<Charge?>?) {
@@ -38,45 +31,23 @@ class ClientChargeAdapter (
         return clientChargeList?.get(position)
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
-        val vh: RecyclerView.ViewHolder
-        val v = LayoutInflater.from(parent.context).inflate(
-                R.layout.row_client_charge, parent, false)
-        vh = ViewHolder(v)
-        v.setOnClickListener {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding = RowClientChargeBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        val vh = ViewHolder(binding)
+        binding.root.setOnClickListener {
             onItemClick(vh.bindingAdapterPosition)
         }
         return vh
     }
 
-    // Binds the values for each of the stored variables to the view
-    // Also changes the color of the circle depending on whether the charge is active or not
-    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val charge = getItem(position)
         var currencyRepresentation = charge?.currency?.displaySymbol
         if (currencyRepresentation == null) {
             currencyRepresentation = charge?.currency?.code
         }
         val context = holder.itemView.context
-        (holder as ViewHolder).tvAmountDue?.text = context.getString(R.string.string_and_string,
-                currencyRepresentation, formatCurrency(context,
-                charge?.amount))
-        holder.tvAmountPaid?.text = context.getString(R.string.string_and_string,
-                currencyRepresentation, formatCurrency(context,
-                charge?.amountPaid))
-        holder.tvAmountWaived?.text = context.getString(R.string.string_and_string, currencyRepresentation,
-                formatCurrency(context, charge?.amountWaived))
-        holder.tvAmountOutstanding?.text = context.getString(R.string.string_and_string, currencyRepresentation,
-                formatCurrency(context, charge?.amountOutstanding))
-        holder.tvClientName?.text = charge?.name
-        if (charge?.dueDate?.isNotEmpty() == true) {
-            holder.tvDueDate?.text = getDateAsString(charge.dueDate)
-        }
-        if (charge?.isPaid == true || charge?.isWaived == true || charge?.paid == true || charge?.waived == true) {
-            holder.circle_status?.setBackgroundColor(holder.itemView.context.getThemeAttributeColor(R.attr.colorError))
-        } else {
-            holder.circle_status?.setBackgroundColor(context.getThemeAttributeColor(R.attr.colorSuccess))
-        }
+        holder.bind(charge, currencyRepresentation, context)
     }
 
     override fun getItemCount(): Int {
@@ -84,37 +55,33 @@ class ClientChargeAdapter (
         else 0
     }
 
-    class ViewHolder(v: View?) : RecyclerView.ViewHolder(v!!) {
-        @JvmField
-        @BindView(R.id.tv_clientName)
-        var tvClientName: TextView? = null
+    class ViewHolder(private val binding : RowClientChargeBinding) : RecyclerView.ViewHolder(binding.root) {
 
-        @JvmField
-        @BindView(R.id.tv_due_date)
-        var tvDueDate: TextView? = null
-
-        @JvmField
-        @BindView(R.id.tv_amount)
-        var tvAmountDue: TextView? = null
-
-        @JvmField
-        @BindView(R.id.tv_amount_paid)
-        var tvAmountPaid: TextView? = null
-
-        @JvmField
-        @BindView(R.id.tv_amount_waived)
-        var tvAmountWaived: TextView? = null
-
-        @JvmField
-        @BindView(R.id.tv_amount_outstanding)
-        var tvAmountOutstanding: TextView? = null
-
-        @JvmField
-        @BindView(R.id.circle_status)
-        var circle_status: View? = null
-
-        init {
-            ButterKnife.bind(this, v!!)
+        // Binds the values for each of the stored variables to the view
+        // Also changes the color of the circle depending on whether the charge is active or not
+        fun bind(charge: Charge?, currencyRepresentation: String?, context: Context?) {
+            with(binding) {
+                tvAmount.text = context?.getString(R.string.string_and_string,
+                    currencyRepresentation, formatCurrency(context,
+                        charge?.amount))
+                tvAmountPaid.text = context?.getString(R.string.string_and_string,
+                    currencyRepresentation, formatCurrency(context,
+                        charge?.amountPaid))
+                tvAmountWaived.text = context?.getString(R.string.string_and_string, currencyRepresentation,
+                    formatCurrency(context, charge?.amountWaived))
+                tvAmountOutstanding.text = context?.getString(R.string.string_and_string, currencyRepresentation,
+                    formatCurrency(context, charge?.amountOutstanding))
+                tvClientName.text = charge?.name
+                if (charge?.dueDate?.isNotEmpty() == true) {
+                    tvDueDate.text = getDateAsString(charge.dueDate)
+                }
+                if (charge?.isPaid == true || charge?.isWaived == true || charge?.paid == true || charge?.waived == true) {
+                    circleStatus.setBackgroundColor(itemView.context.getThemeAttributeColor(R.attr.colorError))
+                } else {
+                    context?.getThemeAttributeColor(R.attr.colorSuccess)
+                        ?.let { circleStatus.setBackgroundColor(it) }
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/org/mifos/mobile/ui/adapters/NotificationAdapter.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/adapters/NotificationAdapter.kt
@@ -4,18 +4,12 @@ import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Button
-import android.widget.ImageView
-import android.widget.TextView
 
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 
-import butterknife.BindView
-import butterknife.ButterKnife
-import butterknife.OnClick
-
 import org.mifos.mobile.R
+import org.mifos.mobile.databinding.RowNotificationBinding
 import org.mifos.mobile.injection.ActivityContext
 import org.mifos.mobile.models.notification.MifosNotification
 import org.mifos.mobile.ui.getThemeAttributeColor
@@ -28,7 +22,7 @@ import javax.inject.Inject
  * Created by dilpreet on 13/9/17.
  */
 class NotificationAdapter @Inject constructor(@param:ActivityContext private val context: Context) :
-        RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+        RecyclerView.Adapter<NotificationAdapter.ViewHolder>() {
 
     private var notificationList: List<MifosNotification?>?
     fun setNotificationList(notificationList: List<MifosNotification?>?) {
@@ -36,22 +30,14 @@ class NotificationAdapter @Inject constructor(@param:ActivityContext private val
         notifyDataSetChanged()
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
-        val v = LayoutInflater.from(context).inflate(R.layout.row_notification, parent, false)
-        return ViewHolder(v)
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding = RowNotificationBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return ViewHolder(binding)
     }
 
-    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val notification = notificationList?.get(position)
-        (holder as ViewHolder).tvNotificationText?.text = notification?.msg
-        holder.tvNotificationTime?.text = getDateAndTimeAsStringFromLong(notification?.timeStamp)
-        if (notification?.isRead() == true) {
-            holder.ivNotificationIcon?.setColorFilter(ContextCompat.getColor(context, R.color.gray_dark))
-            holder.btnDismissNotification?.visibility = View.GONE
-        } else {
-            holder.ivNotificationIcon?.setColorFilter(context.getThemeAttributeColor(R.attr.colorPrimary))
-            holder.btnDismissNotification?.visibility = View.VISIBLE
-        }
+        holder.bind(notification)
     }
 
     override fun getItemCount(): Int {
@@ -59,32 +45,29 @@ class NotificationAdapter @Inject constructor(@param:ActivityContext private val
         else 0
     }
 
-    inner class ViewHolder(itemView: View?) : RecyclerView.ViewHolder(itemView!!) {
-        @JvmField
-        @BindView(R.id.tv_notification_text)
-        var tvNotificationText: TextView? = null
-
-        @JvmField
-        @BindView(R.id.tv_notification_time)
-        var tvNotificationTime: TextView? = null
-
-        @JvmField
-        @BindView(R.id.iv_notification_icon)
-        var ivNotificationIcon: ImageView? = null
-
-        @JvmField
-        @BindView(R.id.btn_dismiss_notification)
-        var btnDismissNotification: Button? = null
-
-        @OnClick(R.id.btn_dismiss_notification)
-        fun dismissNotification() {
-            notificationList?.get(adapterPosition)?.setRead(true)
-            notificationList?.get(adapterPosition)?.save()
-            notifyItemChanged(adapterPosition)
+    inner class ViewHolder(private val binding : RowNotificationBinding) : RecyclerView.ViewHolder(binding.root) {
+        private fun dismissNotification() {
+            notificationList?.get(bindingAdapterPosition)?.setRead(true)
+            notificationList?.get(bindingAdapterPosition)?.save()
+            notifyItemChanged(bindingAdapterPosition)
         }
 
-        init {
-            ButterKnife.bind(this, itemView!!)
+        fun bind(notification: MifosNotification?) {
+            with(binding) {
+                tvNotificationText.text = notification?.msg
+                tvNotificationTime.text = getDateAndTimeAsStringFromLong(notification?.timeStamp)
+                if (notification?.isRead() == true) {
+                    ivNotificationIcon.setColorFilter(ContextCompat.getColor(context, R.color.gray_dark))
+                    btnDismissNotification.visibility = View.GONE
+                } else {
+                    ivNotificationIcon.setColorFilter(context.getThemeAttributeColor(R.attr.colorPrimary))
+                    btnDismissNotification.visibility = View.VISIBLE
+                }
+
+                btnDismissNotification.setOnClickListener {
+                    dismissNotification()
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #2142 

adapters migrated :
1. ClientChargeAdapter.kt
2. NotificationAdapter.kt



Please Add Screenshots If there are any UI changes.

NotificationAdapter.kt after populating it with mock data -> 

https://github.com/openMF/mifos-mobile/assets/59947871/7b637b65-3359-41a5-86b6-b2f4e70c7d36


ClientChargeAdatper.kt with mock data -> 

<img width="355" alt="Screenshot 2023-06-01 at 20 13 17" src="https://github.com/openMF/mifos-mobile/assets/59947871/9961be9e-fcb5-4220-8889-3b7cc9f8c309">

<img width="356" alt="Screenshot 2023-06-01 at 20 13 46" src="https://github.com/openMF/mifos-mobile/assets/59947871/945abb31-48ba-429b-99a2-0f4a82cc1581">





Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.