### PR TITLE
fix : finishing checkbox adapter migration to viewbinding

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/adapters/CheckBoxAdapter.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/adapters/CheckBoxAdapter.kt
@@ -1,17 +1,9 @@
 package org.mifos.mobile.ui.adapters
-
 import android.content.res.ColorStateList
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
-import androidx.appcompat.widget.AppCompatCheckBox
+import androidx.core.widget.CompoundButtonCompat
 import androidx.recyclerview.widget.RecyclerView
-import butterknife.BindView
-import butterknife.ButterKnife
-import butterknife.OnCheckedChanged
-import butterknife.OnClick
-import org.mifos.mobile.R
 import org.mifos.mobile.databinding.RowCheckboxBinding
 import org.mifos.mobile.models.CheckboxStatus
 import javax.inject.Inject
@@ -48,10 +40,13 @@ class CheckBoxAdapter @Inject constructor() :
             with(binding) {
                 cbStatusSelect.isChecked = isChecked
                 cbStatusSelect.setOnClickListener {
-                    statusList?.get(adapterPosition)?.isChecked = !isChecked
+                    statusList?.get(bindingAdapterPosition)?.isChecked = !isChecked
                 }
-                cbStatusSelect.supportButtonTintList = ColorStateList(states, colors)
+                CompoundButtonCompat.setButtonTintList(cbStatusSelect, ColorStateList(states, colors))
                 cbStatusSelect.text = status
+                cbStatusSelect.setOnCheckedChangeListener { _, _ ->
+                    statusList?.get(bindingAdapterPosition)?.isChecked = cbStatusSelect.isChecked
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #2142 

1. removing unused imports.
2. fixed a bug with button tint by using a different lib component
3. also added setOnChangeListener which was missed during the previous migration attempt`



Please Add Screenshots If there are any UI changes.
before fixing button tint bug -> 

<img width="356" alt="Screenshot 2023-06-02 at 21 58 57" src="https://github.com/openMF/mifos-mobile/assets/59947871/3c535e78-1a6a-471f-a2e4-fc5d402ec5be">
<img width="355" alt="Screenshot 2023-06-02 at 21 58 21" src="https://github.com/openMF/mifos-mobile/assets/59947871/175c1c24-d448-44b6-8c20-29c32af8edca">


after fixing button tint bug -> 
<img width="357" alt="Screenshot 2023-06-02 at 21 54 51" src="https://github.com/openMF/mifos-mobile/assets/59947871/ff5ac621-ab6c-4ccb-8e32-76e42147f524">
<img width="359" alt="Screenshot 2023-06-02 at 21 57 15" src="https://github.com/openMF/mifos-mobile/assets/59947871/fe089eac-b496-481f-8422-b7354e81e841">

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.