### PR TITLE
fix : RecentTransactionList adapter migration to view binding

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/adapters/RecentTransactionListAdapter.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/adapters/RecentTransactionListAdapter.kt
@@ -2,17 +2,16 @@ package org.mifos.mobile.ui.adapters
 
 import android.content.Context
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 
-import butterknife.BindView
-import butterknife.ButterKnife
+import org.mifos.mobile.MifosSelfServiceApp.Companion.context
 
 import org.mifos.mobile.R
+import org.mifos.mobile.databinding.RowRecentTransactionBinding
 import org.mifos.mobile.injection.ActivityContext
 import org.mifos.mobile.models.Transaction
+import org.mifos.mobile.models.client.Type
 import org.mifos.mobile.utils.CurrencyUtil.formatCurrency
 import org.mifos.mobile.utils.DateHelper.getDateAsString
 import org.mifos.mobile.utils.Utils.formatTransactionType
@@ -31,9 +30,8 @@ class RecentTransactionListAdapter @Inject constructor(@ActivityContext context:
     private val context: Context
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-        val view = LayoutInflater.from(parent.context)
-                .inflate(R.layout.row_recent_transaction, parent, false)
-        return ViewHolder(view)
+        val binding = RowRecentTransactionBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return ViewHolder(binding)
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
@@ -42,11 +40,8 @@ class RecentTransactionListAdapter @Inject constructor(@ActivityContext context:
         if (currencyRepresentation == null) {
             currencyRepresentation = currency?.code
         }
-        holder.tvAmount?.text = context.getString(R.string.string_and_string,
-                currencyRepresentation, formatCurrency(context,
-                amount!!))
-        holder.tvTypeValue?.text = formatTransactionType(type.value)
-        holder.tvTransactionsDate?.text = getDateAsString(submittedOnDate)
+
+        holder.bind(currencyRepresentation, type, submittedOnDate, amount)
     }
 
     fun setTransactions(transactions: MutableList<Transaction?>?) {
@@ -64,21 +59,15 @@ class RecentTransactionListAdapter @Inject constructor(@ActivityContext context:
         return transactions.size
     }
 
-    class ViewHolder(v: View?) : RecyclerView.ViewHolder(v!!) {
-        @JvmField
-        @BindView(R.id.tv_transactionDate)
-        var tvTransactionsDate: TextView? = null
-
-        @JvmField
-        @BindView(R.id.tv_amount)
-        var tvAmount: TextView? = null
-
-        @JvmField
-        @BindView(R.id.tv_value)
-        var tvTypeValue: TextView? = null
-
-        init {
-            ButterKnife.bind(this, v!!)
+    class ViewHolder(private val binding : RowRecentTransactionBinding) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(currencyRepresentation: String?, type: Type, submittedOnDate: List<Int>, amount: Double?) {
+            with(binding) {
+                tvAmount.text = context?.getString(R.string.string_and_string,
+                    currencyRepresentation, formatCurrency(context,
+                        amount!!))
+                tvValue.text = formatTransactionType(type.value)
+                tvTransactionDate.text = getDateAsString(submittedOnDate)
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #2142 

migrated RecentTransactionListAdapter.kt from ButterKnife to ViewBinding.

video -> 

https://github.com/openMF/mifos-mobile/assets/59947871/8c6ef728-a5f5-487b-a926-b4b7e7ef6aad



Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.