### PR TITLE
fix : no filter selected works properly in accounts fragment

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/fragments/AccountsFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/AccountsFragment.kt
@@ -364,12 +364,19 @@ class AccountsFragment : BaseFragment(), OnRefreshListener, AccountsView {
     fun filterSavingsAccount(statusModelList: List<CheckboxStatus?>?) {
         val filteredSavings: MutableList<SavingAccount?> = ArrayList()
         if (accountsPresenter?.getCheckedStatus(statusModelList) != null && accountsPresenter != null) {
-            for (status in accountsPresenter?.getCheckedStatus(statusModelList)!!) {
-                accountsPresenter?.getFilteredSavingsAccount(
-                    savingAccounts,
-                    status,
-                )?.let { filteredSavings.addAll(it) }
+            if (accountsPresenter?.getCheckedStatus(statusModelList)?.isNotEmpty() == true) {
+                for (status in accountsPresenter?.getCheckedStatus(statusModelList)!!) {
+                    accountsPresenter?.getFilteredSavingsAccount(
+                        savingAccounts,
+                        status,
+                    )?.let { filteredSavings.addAll(it) }
+                }
+            } else {
+                savingAccounts?.forEach {
+                    filteredSavings.add(it)
+                }
             }
+
         }
         if (filteredSavings.size == 0) {
             showEmptyAccounts(getString(R.string.no_saving_account))
@@ -387,13 +394,21 @@ class AccountsFragment : BaseFragment(), OnRefreshListener, AccountsView {
     fun filterLoanAccount(statusModelList: List<CheckboxStatus?>?) {
         val filteredSavings: MutableList<LoanAccount?> = ArrayList()
         if (accountsPresenter?.getCheckedStatus(statusModelList) != null && accountsPresenter != null) {
-            for (status in accountsPresenter?.getCheckedStatus(statusModelList)!!) {
-                accountsPresenter?.getFilteredLoanAccount(
-                    loanAccounts,
-                    status,
-                )?.let { filteredSavings.addAll(it) }
+            if (accountsPresenter?.getCheckedStatus(statusModelList)?.isNotEmpty() == true) {
+                for (status in accountsPresenter?.getCheckedStatus(statusModelList)!!) {
+                    accountsPresenter?.getFilteredLoanAccount(
+                        loanAccounts,
+                        status,
+                    )?.let { filteredSavings.addAll(it) }
+                }
+            } else {
+                loanAccounts?.forEach {
+                    filteredSavings.add(it)
+                }
             }
+
         }
+
         if (filteredSavings.size == 0) {
             showEmptyAccounts(getString(R.string.no_loan_account))
         } else {
@@ -410,13 +425,21 @@ class AccountsFragment : BaseFragment(), OnRefreshListener, AccountsView {
     fun filterShareAccount(statusModelList: List<CheckboxStatus?>?) {
         val filteredSavings: MutableList<ShareAccount?> = ArrayList()
         if (accountsPresenter?.getCheckedStatus(statusModelList) != null && accountsPresenter != null) {
-            for (status in accountsPresenter?.getCheckedStatus(statusModelList)!!) {
-                accountsPresenter?.getFilteredShareAccount(
-                    shareAccounts,
-                    status,
-                )?.let { filteredSavings.addAll(it) }
+            if (accountsPresenter?.getCheckedStatus(statusModelList)?.isNotEmpty() == true) {
+                for (status in accountsPresenter?.getCheckedStatus(statusModelList)!!) {
+                    accountsPresenter?.getFilteredShareAccount(
+                        shareAccounts,
+                        status,
+                    )?.let { filteredSavings.addAll(it) }
+                }
+            } else {
+                shareAccounts?.forEach {
+                    filteredSavings.add(it)
+                }
             }
+
         }
+
         if (filteredSavings.size == 0) {
             showEmptyAccounts(getString(R.string.no_saving_account))
         } else {

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/AccountsFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/AccountsFragment.kt
@@ -363,13 +363,19 @@ class AccountsFragment : BaseFragment(), OnRefreshListener, AccountsView {
      */
     fun filterSavingsAccount(statusModelList: List<CheckboxStatus?>?) {
         val filteredSavings: MutableList<SavingAccount?> = ArrayList()
-        if (accountsPresenter?.getCheckedStatus(statusModelList) != null && accountsPresenter != null) {
+        if (accountsPresenter?.getCheckedStatus(statusModelList) != null && accountsPresenter != null&&accountsPresenter?.getCheckedStatus(statusModelList)?.isNotEmpty()==true) {
             for (status in accountsPresenter?.getCheckedStatus(statusModelList)!!) {
                 accountsPresenter?.getFilteredSavingsAccount(
                     savingAccounts,
                     status,
                 )?.let { filteredSavings.addAll(it) }
             }
+        }
+        else if(accountsPresenter?.getCheckedStatus(statusModelList) != null && accountsPresenter != null&& accountsPresenter?.getCheckedStatus(statusModelList)?.isEmpty()==true){
+            savingAccounts?.forEach{
+                filteredSavings.add(it)
+            }
+
         }
         if (filteredSavings.size == 0) {
             showEmptyAccounts(getString(R.string.no_saving_account))
@@ -386,12 +392,17 @@ class AccountsFragment : BaseFragment(), OnRefreshListener, AccountsView {
      */
     fun filterLoanAccount(statusModelList: List<CheckboxStatus?>?) {
         val filteredSavings: MutableList<LoanAccount?> = ArrayList()
-        if (accountsPresenter?.getCheckedStatus(statusModelList) != null && accountsPresenter != null) {
+        if (accountsPresenter?.getCheckedStatus(statusModelList) != null && accountsPresenter != null&&accountsPresenter?.getCheckedStatus(statusModelList)?.isNotEmpty()==true) {
             for (status in accountsPresenter?.getCheckedStatus(statusModelList)!!) {
                 accountsPresenter?.getFilteredLoanAccount(
                     loanAccounts,
                     status,
                 )?.let { filteredSavings.addAll(it) }
+            }
+        }
+        else if(accountsPresenter?.getCheckedStatus(statusModelList) != null && accountsPresenter != null&& accountsPresenter?.getCheckedStatus(statusModelList)?.isEmpty()==true){
+            loanAccounts?.forEach{
+                filteredSavings.add(it)
             }
         }
         if (filteredSavings.size == 0) {
@@ -409,12 +420,17 @@ class AccountsFragment : BaseFragment(), OnRefreshListener, AccountsView {
      */
     fun filterShareAccount(statusModelList: List<CheckboxStatus?>?) {
         val filteredSavings: MutableList<ShareAccount?> = ArrayList()
-        if (accountsPresenter?.getCheckedStatus(statusModelList) != null && accountsPresenter != null) {
+        if (accountsPresenter?.getCheckedStatus(statusModelList) != null && accountsPresenter != null&& accountsPresenter?.getCheckedStatus(statusModelList)?.isNotEmpty()==true) {
             for (status in accountsPresenter?.getCheckedStatus(statusModelList)!!) {
                 accountsPresenter?.getFilteredShareAccount(
                     shareAccounts,
                     status,
                 )?.let { filteredSavings.addAll(it) }
+            }
+        }
+        else if(accountsPresenter?.getCheckedStatus(statusModelList) != null && accountsPresenter != null&& accountsPresenter?.getCheckedStatus(statusModelList)?.isEmpty()==true){
+            shareAccounts?.forEach{
+                filteredSavings.add(it)
             }
         }
         if (filteredSavings.size == 0) {

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/AccountsFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/AccountsFragment.kt
@@ -363,17 +363,18 @@ class AccountsFragment : BaseFragment(), OnRefreshListener, AccountsView {
      */
     fun filterSavingsAccount(statusModelList: List<CheckboxStatus?>?) {
         val filteredSavings: MutableList<SavingAccount?> = ArrayList()
-        if (accountsPresenter?.getCheckedStatus(statusModelList) != null && accountsPresenter != null&&accountsPresenter?.getCheckedStatus(statusModelList)?.isNotEmpty()==true) {
-            for (status in accountsPresenter?.getCheckedStatus(statusModelList)!!) {
-                accountsPresenter?.getFilteredSavingsAccount(
-                    savingAccounts,
-                    status,
-                )?.let { filteredSavings.addAll(it) }
-            }
-        }
-        else if(accountsPresenter?.getCheckedStatus(statusModelList) != null && accountsPresenter != null&& accountsPresenter?.getCheckedStatus(statusModelList)?.isEmpty()==true){
-            savingAccounts?.forEach{
-                filteredSavings.add(it)
+        if (accountsPresenter?.getCheckedStatus(statusModelList) != null && accountsPresenter != null) {
+            if (accountsPresenter?.getCheckedStatus(statusModelList)?.isNotEmpty() == true) {
+                for (status in accountsPresenter?.getCheckedStatus(statusModelList)!!) {
+                    accountsPresenter?.getFilteredSavingsAccount(
+                        savingAccounts,
+                        status,
+                    )?.let { filteredSavings.addAll(it) }
+                }
+            } else {
+                savingAccounts?.forEach {
+                    filteredSavings.add(it)
+                }
             }
 
         }
@@ -392,19 +393,22 @@ class AccountsFragment : BaseFragment(), OnRefreshListener, AccountsView {
      */
     fun filterLoanAccount(statusModelList: List<CheckboxStatus?>?) {
         val filteredSavings: MutableList<LoanAccount?> = ArrayList()
-        if (accountsPresenter?.getCheckedStatus(statusModelList) != null && accountsPresenter != null&&accountsPresenter?.getCheckedStatus(statusModelList)?.isNotEmpty()==true) {
-            for (status in accountsPresenter?.getCheckedStatus(statusModelList)!!) {
-                accountsPresenter?.getFilteredLoanAccount(
-                    loanAccounts,
-                    status,
-                )?.let { filteredSavings.addAll(it) }
+        if (accountsPresenter?.getCheckedStatus(statusModelList) != null && accountsPresenter != null) {
+            if (accountsPresenter?.getCheckedStatus(statusModelList)?.isNotEmpty() == true) {
+                for (status in accountsPresenter?.getCheckedStatus(statusModelList)!!) {
+                    accountsPresenter?.getFilteredLoanAccount(
+                        loanAccounts,
+                        status,
+                    )?.let { filteredSavings.addAll(it) }
+                }
+            } else {
+                loanAccounts?.forEach {
+                    filteredSavings.add(it)
+                }
             }
+
         }
-        else if(accountsPresenter?.getCheckedStatus(statusModelList) != null && accountsPresenter != null&& accountsPresenter?.getCheckedStatus(statusModelList)?.isEmpty()==true){
-            loanAccounts?.forEach{
-                filteredSavings.add(it)
-            }
-        }
+
         if (filteredSavings.size == 0) {
             showEmptyAccounts(getString(R.string.no_loan_account))
         } else {
@@ -420,19 +424,22 @@ class AccountsFragment : BaseFragment(), OnRefreshListener, AccountsView {
      */
     fun filterShareAccount(statusModelList: List<CheckboxStatus?>?) {
         val filteredSavings: MutableList<ShareAccount?> = ArrayList()
-        if (accountsPresenter?.getCheckedStatus(statusModelList) != null && accountsPresenter != null&& accountsPresenter?.getCheckedStatus(statusModelList)?.isNotEmpty()==true) {
-            for (status in accountsPresenter?.getCheckedStatus(statusModelList)!!) {
-                accountsPresenter?.getFilteredShareAccount(
-                    shareAccounts,
-                    status,
-                )?.let { filteredSavings.addAll(it) }
+        if (accountsPresenter?.getCheckedStatus(statusModelList) != null && accountsPresenter != null) {
+            if (accountsPresenter?.getCheckedStatus(statusModelList)?.isNotEmpty() == true) {
+                for (status in accountsPresenter?.getCheckedStatus(statusModelList)!!) {
+                    accountsPresenter?.getFilteredShareAccount(
+                        shareAccounts,
+                        status,
+                    )?.let { filteredSavings.addAll(it) }
+                }
+            } else {
+                shareAccounts?.forEach {
+                    filteredSavings.add(it)
+                }
             }
+
         }
-        else if(accountsPresenter?.getCheckedStatus(statusModelList) != null && accountsPresenter != null&& accountsPresenter?.getCheckedStatus(statusModelList)?.isEmpty()==true){
-            shareAccounts?.forEach{
-                filteredSavings.add(it)
-            }
-        }
+
         if (filteredSavings.size == 0) {
             showEmptyAccounts(getString(R.string.no_saving_account))
         } else {


### PR DESCRIPTION
fix #1397 <on not selecting any filter account fragment now shows full list earlier it used to show empty list.>
before fix
https://github.com/openMF/mifos-mobile/assets/116818222/ec7f7395-9a28-462e-a9e8-e8e94063ef56
after fix


https://github.com/openMF/mifos-mobile/assets/116818222/92a09d8e-9c04-4d71-90b9-466e65c4801b

