### PR TITLE
feat : updatepassword fragment mvvm migration

### DIFF
--- a/app/src/main/java/org/mifos/mobile/injection/module/RepositoryModule.kt
+++ b/app/src/main/java/org/mifos/mobile/injection/module/RepositoryModule.kt
@@ -5,6 +5,9 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import org.mifos.mobile.api.DataManager
+import org.mifos.mobile.api.local.PreferencesHelper
+import org.mifos.mobile.repositories.ClientRepository
+import org.mifos.mobile.repositories.ClientRepositoryImp
 import org.mifos.mobile.repositories.UserAuthRepository
 import org.mifos.mobile.repositories.UserAuthRepositoryImp
 
@@ -15,5 +18,10 @@ class RepositoryModule {
     @Provides
     fun providesUserAuthRepository(dataManager: DataManager): UserAuthRepository {
         return UserAuthRepositoryImp(dataManager)
+    }
+
+    @Provides
+    fun providesClientRepository(preferencesHelper: PreferencesHelper): ClientRepository {
+        return ClientRepositoryImp(preferencesHelper)
     }
 }

--- a/app/src/main/java/org/mifos/mobile/repositories/ClientRepository.kt
+++ b/app/src/main/java/org/mifos/mobile/repositories/ClientRepository.kt
@@ -1,0 +1,6 @@
+package org.mifos.mobile.repositories
+
+interface ClientRepository {
+
+    fun updateAuthenticationToken(password: String)
+}

--- a/app/src/main/java/org/mifos/mobile/repositories/ClientRepositoryImp.kt
+++ b/app/src/main/java/org/mifos/mobile/repositories/ClientRepositoryImp.kt
@@ -1,0 +1,19 @@
+package org.mifos.mobile.repositories
+
+import okhttp3.Credentials
+import org.mifos.mobile.api.BaseApiManager
+import org.mifos.mobile.api.local.PreferencesHelper
+import javax.inject.Inject
+
+class ClientRepositoryImp @Inject constructor(private val preferencesHelper: PreferencesHelper) : ClientRepository {
+
+    override fun updateAuthenticationToken(password: String) {
+        val authenticationToken = Credentials.basic(preferencesHelper.userName!!, password)
+        preferencesHelper.saveToken(authenticationToken)
+        BaseApiManager.createService(
+            preferencesHelper.baseUrl,
+            preferencesHelper.tenant,
+            preferencesHelper.token,
+        )
+    }
+}

--- a/app/src/main/java/org/mifos/mobile/repositories/UserAuthRepository.kt
+++ b/app/src/main/java/org/mifos/mobile/repositories/UserAuthRepository.kt
@@ -15,4 +15,9 @@ interface UserAuthRepository {
         password: String?,
         username: String?
     ): Observable<ResponseBody?>?
+
+    fun updateAccountPassword(
+        newPassword: String, confirmPassword: String
+    ): Observable<ResponseBody?>?
+
 }

--- a/app/src/main/java/org/mifos/mobile/repositories/UserAuthRepositoryImp.kt
+++ b/app/src/main/java/org/mifos/mobile/repositories/UserAuthRepositoryImp.kt
@@ -3,11 +3,11 @@ package org.mifos.mobile.repositories
 import io.reactivex.Observable
 import okhttp3.ResponseBody
 import org.mifos.mobile.api.DataManager
+import org.mifos.mobile.models.UpdatePasswordPayload
 import org.mifos.mobile.models.register.RegisterPayload
 import javax.inject.Inject
 
-class UserAuthRepositoryImp @Inject constructor(private val dataManager: DataManager) :
-    UserAuthRepository {
+class UserAuthRepositoryImp @Inject constructor(private val dataManager: DataManager) : UserAuthRepository {
 
     override fun registerUser(
         accountNumber: String?,
@@ -31,4 +31,16 @@ class UserAuthRepositoryImp @Inject constructor(private val dataManager: DataMan
         }
         return dataManager.registerUser(registerPayload)
     }
+
+    override fun updateAccountPassword(
+        newPassword: String, confirmPassword: String
+    ): Observable<ResponseBody?>? {
+        val payload = UpdatePasswordPayload().apply {
+            this.password = newPassword
+            this.repeatPassword = confirmPassword
+        }
+
+        return dataManager.updateAccountPassword(payload)
+    }
+
 }

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/RegistrationFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/RegistrationFragment.kt
@@ -19,7 +19,7 @@ import org.mifos.mobile.ui.fragments.base.BaseFragment
 import org.mifos.mobile.utils.MFErrorParser
 import org.mifos.mobile.utils.Network
 import org.mifos.mobile.utils.PasswordStrength
-import org.mifos.mobile.utils.RegistrationUiState
+import org.mifos.mobile.utils.UiState
 import org.mifos.mobile.utils.Toaster
 import org.mifos.mobile.viewModels.RegistrationViewModel
 
@@ -91,14 +91,14 @@ class RegistrationFragment : BaseFragment() {
 
         viewModel.registrationUiState.observe(viewLifecycleOwner) { state ->
             when (state) {
-                RegistrationUiState.Loading -> showProgress()
+                UiState.Loading -> showProgress()
 
-                RegistrationUiState.RegistrationSuccessful -> {
+                UiState.Success -> {
                     hideProgress()
                     showRegisteredSuccessfully()
                 }
 
-                is RegistrationUiState.ErrorOnRegistration -> {
+                is UiState.Error -> {
                     hideProgress()
                     showError(MFErrorParser.errorMessage(state.exception))
                 }

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/RegistrationFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/RegistrationFragment.kt
@@ -19,7 +19,7 @@ import org.mifos.mobile.ui.fragments.base.BaseFragment
 import org.mifos.mobile.utils.MFErrorParser
 import org.mifos.mobile.utils.Network
 import org.mifos.mobile.utils.PasswordStrength
-import org.mifos.mobile.utils.UiState
+import org.mifos.mobile.utils.RegistrationUiState
 import org.mifos.mobile.utils.Toaster
 import org.mifos.mobile.viewModels.RegistrationViewModel
 
@@ -91,14 +91,14 @@ class RegistrationFragment : BaseFragment() {
 
         viewModel.registrationUiState.observe(viewLifecycleOwner) { state ->
             when (state) {
-                UiState.Loading -> showProgress()
+                RegistrationUiState.Loading -> showProgress()
 
-                UiState.Success -> {
+                RegistrationUiState.Success -> {
                     hideProgress()
                     showRegisteredSuccessfully()
                 }
 
-                is UiState.Error -> {
+                is RegistrationUiState.Error -> {
                     hideProgress()
                     showError(MFErrorParser.errorMessage(state.exception))
                 }

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/UpdatePasswordFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/UpdatePasswordFragment.kt
@@ -8,40 +8,27 @@ import android.view.View
 import android.view.View.OnFocusChangeListener
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.lifecycle.ViewModelProvider
 import dagger.hilt.android.AndroidEntryPoint
 import org.mifos.mobile.R
-import org.mifos.mobile.api.local.PreferencesHelper
 import org.mifos.mobile.databinding.FragmentUpdatePasswordBinding
-import org.mifos.mobile.models.UpdatePasswordPayload
-import org.mifos.mobile.presenters.UpdatePasswordPresenter
 import org.mifos.mobile.ui.activities.base.BaseActivity
 import org.mifos.mobile.ui.fragments.base.BaseFragment
-import org.mifos.mobile.ui.views.UpdatePasswordView
+import org.mifos.mobile.utils.MFErrorParser
 import org.mifos.mobile.utils.Network
 import org.mifos.mobile.utils.Toaster
-import javax.inject.Inject
+import org.mifos.mobile.utils.UiState
+import org.mifos.mobile.viewModels.UpdatePasswordViewModel
 
 /*
 * Created by saksham on 13/July/2018
 */
 @AndroidEntryPoint
-class UpdatePasswordFragment :
-    BaseFragment(),
-    UpdatePasswordView,
-    TextWatcher,
-    OnFocusChangeListener {
+class UpdatePasswordFragment : BaseFragment(), TextWatcher, OnFocusChangeListener {
 
     private var _binding: FragmentUpdatePasswordBinding? = null
     private val binding get() = _binding!!
-
-    @JvmField
-    @Inject
-    var presenter: UpdatePasswordPresenter? = null
-
-    @JvmField
-    @Inject
-    var preferencesHelper: PreferencesHelper? = null
-    private var payload: UpdatePasswordPayload? = null
+    private lateinit var viewModel: UpdatePasswordViewModel
     private var isFocusLostNewPassword = false
     private var isFocusLostConfirmPassword = false
 
@@ -52,7 +39,7 @@ class UpdatePasswordFragment :
     ): View {
         _binding = FragmentUpdatePasswordBinding.inflate(inflater, container, false)
         setToolbarTitle(getString(R.string.change_password))
-        presenter?.attachView(this)
+        viewModel = ViewModelProvider(this)[UpdatePasswordViewModel::class.java]
         binding.tilNewPassword.editText?.addTextChangedListener(this)
         binding.tilConfirmNewPassword.editText?.addTextChangedListener(this)
         binding.tilNewPassword.editText?.onFocusChangeListener = this
@@ -65,50 +52,115 @@ class UpdatePasswordFragment :
         binding.btnUpdatePassword.setOnClickListener {
             updatePassword()
         }
-    }
 
-    fun updatePassword() {
-        if (isFieldsCompleted) {
-            presenter?.updateAccountPassword(updatePasswordPayload)
+        viewModel.updatePasswordUiState.observe(viewLifecycleOwner) { state ->
+            when (state) {
+                UiState.Loading -> showProgress()
+                UiState.Success -> {
+                    hideProgress()
+                    showPasswordUpdatedSuccessfully()
+                }
+
+                is UiState.Error -> {
+                    hideProgress()
+                    showError(MFErrorParser.errorMessage(state.exception))
+                }
+            }
         }
     }
 
-    private val isFieldsCompleted: Boolean
-        get() {
-            var rv = true
-            val newPassword = binding.tilNewPassword.editText?.text.toString().trim { it <= ' ' }
-            val repeatPassword =
-                binding.tilConfirmNewPassword.editText?.text.toString().trim { it <= ' ' }
-            if (!checkNewPasswordFieldsComplete()) {
-                rv = false
-            }
-            if (!checkConfirmPasswordFieldsComplete()) {
-                rv = false
-            }
-            if (newPassword != repeatPassword) {
+    private fun updatePassword() {
+        val newPassword = binding.tilNewPassword.editText?.text.toString().trim()
+        val confirmPassword = binding.tilConfirmNewPassword.editText?.text.toString().trim()
+
+        if (areFieldsValidated(newPassword, confirmPassword)) {
+            viewModel.updateAccountPassword(newPassword, confirmPassword)
+        }
+    }
+
+    private fun areFieldsValidated(newPassword: String, confirmPassword: String): Boolean {
+        return when {
+            !isNewPasswordValidated() -> false
+            !isConfirmPasswordValidated() -> false
+            (!viewModel.validatePasswordMatch(newPassword, confirmPassword)) -> {
                 Toaster.show(binding.root, getString(R.string.error_password_not_match))
-                rv = false
+                false
             }
-            return rv
-        }
-    private val updatePasswordPayload: UpdatePasswordPayload?
-        get() {
-            payload = UpdatePasswordPayload()
-            payload?.password = binding.tilNewPassword.editText?.text.toString().trim { it <= ' ' }
-            payload?.repeatPassword =
-                binding.tilConfirmNewPassword.editText?.text.toString().trim { it <= ' ' }
-            return payload
-        }
 
-    override fun showError(message: String?) {
-        var message = message
-        if (!Network.isConnected(activity)) {
-            message = getString(R.string.no_internet_connection)
+            else -> true
         }
-        Toaster.show(binding.root, message)
     }
 
-    override fun showPasswordUpdatedSuccessfully() {
+    private fun isNewPasswordValidated(): Boolean {
+        with(binding) {
+            val newPassword = tilNewPassword.editText?.text.toString()
+            isFocusLostNewPassword = true
+            return when {
+                viewModel.isInputFieldEmpty(newPassword) -> {
+                    tilNewPassword.error = getString(
+                        R.string.error_validation_blank,
+                        getString(R.string.new_password),
+                    )
+                    false
+                }
+
+                viewModel.isInputLengthInadequate(newPassword) -> {
+                    tilNewPassword.error = getString(
+                        R.string.error_validation_minimum_chars,
+                        getString(R.string.new_password),
+                        resources.getInteger(R.integer.password_minimum_length),
+                    )
+                    false
+                }
+
+                else -> {
+                    tilNewPassword.isErrorEnabled = false
+                    return true
+                }
+            }
+        }
+    }
+
+    private fun isConfirmPasswordValidated(): Boolean {
+        with(binding) {
+            val confirmPassword = tilConfirmNewPassword.editText?.text.toString()
+            isFocusLostConfirmPassword = true
+            return when {
+                viewModel.isInputFieldEmpty(confirmPassword) -> {
+                    tilConfirmNewPassword.error = getString(
+                        R.string.error_validation_blank,
+                        getString(R.string.confirm_password),
+                    )
+                    false
+                }
+
+                viewModel.isInputLengthInadequate(confirmPassword) -> {
+                    tilConfirmNewPassword.error = getString(
+                        R.string.error_validation_minimum_chars,
+                        getString(R.string.confirm_password),
+                        resources.getInteger(R.integer.password_minimum_length),
+                    )
+                    return false
+                }
+
+                else -> {
+                    tilConfirmNewPassword.isErrorEnabled = false
+                    return true
+                }
+            }
+        }
+
+    }
+
+    fun showError(message: String?) {
+        var errorMessage = message
+        if (!Network.isConnected(activity)) {
+            errorMessage = getString(R.string.no_internet_connection)
+        }
+        Toaster.show(binding.root, errorMessage)
+    }
+
+    private fun showPasswordUpdatedSuccessfully() {
         Toast.makeText(
             context,
             getString(
@@ -125,84 +177,39 @@ class UpdatePasswordFragment :
         )
     }
 
-    override fun showProgress() {
+    fun showProgress() {
         showMifosProgressDialog(getString(R.string.progress_message_loading))
     }
 
-    override fun hideProgress() {
+    fun hideProgress() {
         hideMifosProgressDialog()
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
-        presenter?.detachView()
         _binding = null
     }
 
     override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
     override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
         if (binding.tilNewPassword.editText?.hasFocus() == true && isFocusLostNewPassword) {
-            checkNewPasswordFieldsComplete()
+            isNewPasswordValidated()
         }
         if (binding.tilConfirmNewPassword.editText?.hasFocus() == true && isFocusLostConfirmPassword) {
-            checkConfirmPasswordFieldsComplete()
+            isConfirmPasswordValidated()
         }
     }
 
     override fun afterTextChanged(s: Editable) {}
     override fun onFocusChange(v: View, hasFocus: Boolean) {
         if (v.id == R.id.et_new_password && !isFocusLostNewPassword && !hasFocus) {
-            checkNewPasswordFieldsComplete()
+            isNewPasswordValidated()
             isFocusLostNewPassword = true
         }
         if (v.id == R.id.et_confirm_password && !isFocusLostConfirmPassword && !hasFocus) {
-            checkConfirmPasswordFieldsComplete()
+            isConfirmPasswordValidated()
             isFocusLostConfirmPassword = true
         }
-    }
-
-    private fun checkNewPasswordFieldsComplete(): Boolean {
-        val newPassword = binding.tilNewPassword.editText?.text.toString()
-        isFocusLostNewPassword = true
-        if (newPassword.isEmpty()) {
-            binding.tilNewPassword.error = getString(
-                R.string.error_validation_blank,
-                getString(R.string.new_password),
-            )
-            return false
-        }
-        if (newPassword.length < 6) {
-            binding.tilNewPassword.error = getString(
-                R.string.error_validation_minimum_chars,
-                getString(R.string.new_password),
-                resources.getInteger(R.integer.password_minimum_length),
-            )
-            return false
-        }
-        binding.tilNewPassword.isErrorEnabled = false
-        return true
-    }
-
-    private fun checkConfirmPasswordFieldsComplete(): Boolean {
-        val confirmPassword = binding.tilConfirmNewPassword.editText?.text.toString()
-        isFocusLostConfirmPassword = true
-        if (confirmPassword.isEmpty()) {
-            binding.tilConfirmNewPassword.error = getString(
-                R.string.error_validation_blank,
-                getString(R.string.confirm_password),
-            )
-            return false
-        }
-        if (confirmPassword.length < 6) {
-            binding.tilConfirmNewPassword.error = getString(
-                R.string.error_validation_minimum_chars,
-                getString(R.string.confirm_password),
-                resources.getInteger(R.integer.password_minimum_length),
-            )
-            return false
-        }
-        binding.tilConfirmNewPassword.isErrorEnabled = false
-        return true
     }
 
     companion object {

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/UpdatePasswordFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/UpdatePasswordFragment.kt
@@ -17,7 +17,7 @@ import org.mifos.mobile.ui.fragments.base.BaseFragment
 import org.mifos.mobile.utils.MFErrorParser
 import org.mifos.mobile.utils.Network
 import org.mifos.mobile.utils.Toaster
-import org.mifos.mobile.utils.UiState
+import org.mifos.mobile.utils.RegistrationUiState
 import org.mifos.mobile.viewModels.UpdatePasswordViewModel
 
 /*
@@ -55,13 +55,13 @@ class UpdatePasswordFragment : BaseFragment(), TextWatcher, OnFocusChangeListene
 
         viewModel.updatePasswordUiState.observe(viewLifecycleOwner) { state ->
             when (state) {
-                UiState.Loading -> showProgress()
-                UiState.Success -> {
+                RegistrationUiState.Loading -> showProgress()
+                RegistrationUiState.Success -> {
                     hideProgress()
                     showPasswordUpdatedSuccessfully()
                 }
 
-                is UiState.Error -> {
+                is RegistrationUiState.Error -> {
                     hideProgress()
                     showError(MFErrorParser.errorMessage(state.exception))
                 }

--- a/app/src/main/java/org/mifos/mobile/utils/RegistrationUiState.kt
+++ b/app/src/main/java/org/mifos/mobile/utils/RegistrationUiState.kt
@@ -1,0 +1,7 @@
+package org.mifos.mobile.utils
+
+sealed class RegistrationUiState {
+    data class Error(val exception: Throwable) : RegistrationUiState()
+    object Success : RegistrationUiState()
+    object Loading : RegistrationUiState()
+}

--- a/app/src/main/java/org/mifos/mobile/utils/RegistrationUiState.kt
+++ b/app/src/main/java/org/mifos/mobile/utils/RegistrationUiState.kt
@@ -1,7 +1,0 @@
-package org.mifos.mobile.utils
-
-sealed class RegistrationUiState {
-    data class ErrorOnRegistration(val exception: Throwable) : RegistrationUiState()
-    object RegistrationSuccessful : RegistrationUiState()
-    object Loading : RegistrationUiState()
-}

--- a/app/src/main/java/org/mifos/mobile/utils/UiState.kt
+++ b/app/src/main/java/org/mifos/mobile/utils/UiState.kt
@@ -1,0 +1,7 @@
+package org.mifos.mobile.utils
+
+sealed class UiState {
+    data class Error(val exception: Throwable) : UiState()
+    object Success : UiState()
+    object Loading : UiState()
+}

--- a/app/src/main/java/org/mifos/mobile/utils/UiState.kt
+++ b/app/src/main/java/org/mifos/mobile/utils/UiState.kt
@@ -1,7 +1,0 @@
-package org.mifos.mobile.utils
-
-sealed class UiState {
-    data class Error(val exception: Throwable) : UiState()
-    object Success : UiState()
-    object Loading : UiState()
-}

--- a/app/src/main/java/org/mifos/mobile/viewModels/RegistrationViewModel.kt
+++ b/app/src/main/java/org/mifos/mobile/viewModels/RegistrationViewModel.kt
@@ -11,7 +11,7 @@ import io.reactivex.observers.DisposableObserver
 import io.reactivex.schedulers.Schedulers
 import okhttp3.ResponseBody
 import org.mifos.mobile.repositories.UserAuthRepository
-import org.mifos.mobile.utils.UiState
+import org.mifos.mobile.utils.RegistrationUiState
 import javax.inject.Inject
 
 @HiltViewModel
@@ -19,8 +19,8 @@ class RegistrationViewModel @Inject constructor(private val userAuthRepositoryIm
     ViewModel() {
     private val compositeDisposables: CompositeDisposable = CompositeDisposable()
 
-    private val _registrationUiState = MutableLiveData<UiState>()
-    val registrationUiState: LiveData<UiState> get() = _registrationUiState
+    private val _registrationUiState = MutableLiveData<RegistrationUiState>()
+    val registrationUiState: LiveData<RegistrationUiState> get() = _registrationUiState
 
     fun isInputFieldBlank(fieldText: String): Boolean {
         return fieldText.trim().isEmpty()
@@ -52,7 +52,7 @@ class RegistrationViewModel @Inject constructor(private val userAuthRepositoryIm
         password: String,
         username: String
     ) {
-        _registrationUiState.value = UiState.Loading
+        _registrationUiState.value = RegistrationUiState.Loading
         userAuthRepositoryImp.registerUser(
             accountNumber,
             authenticationMode,
@@ -66,11 +66,11 @@ class RegistrationViewModel @Inject constructor(private val userAuthRepositoryIm
             ?.subscribeWith(object : DisposableObserver<ResponseBody?>() {
                 override fun onComplete() {}
                 override fun onError(e: Throwable) {
-                    _registrationUiState.value = UiState.Error(e)
+                    _registrationUiState.value = RegistrationUiState.Error(e)
                 }
 
                 override fun onNext(responseBody: ResponseBody) {
-                    _registrationUiState.value = UiState.Success
+                    _registrationUiState.value = RegistrationUiState.Success
                 }
             })?.let { compositeDisposables.add(it) }
     }

--- a/app/src/main/java/org/mifos/mobile/viewModels/RegistrationViewModel.kt
+++ b/app/src/main/java/org/mifos/mobile/viewModels/RegistrationViewModel.kt
@@ -11,7 +11,7 @@ import io.reactivex.observers.DisposableObserver
 import io.reactivex.schedulers.Schedulers
 import okhttp3.ResponseBody
 import org.mifos.mobile.repositories.UserAuthRepository
-import org.mifos.mobile.utils.RegistrationUiState
+import org.mifos.mobile.utils.UiState
 import javax.inject.Inject
 
 @HiltViewModel
@@ -19,8 +19,8 @@ class RegistrationViewModel @Inject constructor(private val userAuthRepositoryIm
     ViewModel() {
     private val compositeDisposables: CompositeDisposable = CompositeDisposable()
 
-    private val _registrationUiState = MutableLiveData<RegistrationUiState>()
-    val registrationUiState: LiveData<RegistrationUiState> get() = _registrationUiState
+    private val _registrationUiState = MutableLiveData<UiState>()
+    val registrationUiState: LiveData<UiState> get() = _registrationUiState
 
     fun isInputFieldBlank(fieldText: String): Boolean {
         return fieldText.trim().isEmpty()
@@ -52,7 +52,7 @@ class RegistrationViewModel @Inject constructor(private val userAuthRepositoryIm
         password: String,
         username: String
     ) {
-        _registrationUiState.value = RegistrationUiState.Loading
+        _registrationUiState.value = UiState.Loading
         userAuthRepositoryImp.registerUser(
             accountNumber,
             authenticationMode,
@@ -66,11 +66,11 @@ class RegistrationViewModel @Inject constructor(private val userAuthRepositoryIm
             ?.subscribeWith(object : DisposableObserver<ResponseBody?>() {
                 override fun onComplete() {}
                 override fun onError(e: Throwable) {
-                    _registrationUiState.value = RegistrationUiState.ErrorOnRegistration(e)
+                    _registrationUiState.value = UiState.Error(e)
                 }
 
                 override fun onNext(responseBody: ResponseBody) {
-                    _registrationUiState.value = RegistrationUiState.RegistrationSuccessful
+                    _registrationUiState.value = UiState.Success
                 }
             })?.let { compositeDisposables.add(it) }
     }

--- a/app/src/main/java/org/mifos/mobile/viewModels/UpdatePasswordViewModel.kt
+++ b/app/src/main/java/org/mifos/mobile/viewModels/UpdatePasswordViewModel.kt
@@ -1,0 +1,62 @@
+package org.mifos.mobile.viewModels
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.observers.DisposableObserver
+import io.reactivex.schedulers.Schedulers
+import okhttp3.ResponseBody
+import org.mifos.mobile.repositories.ClientRepository
+import org.mifos.mobile.repositories.UserAuthRepository
+import org.mifos.mobile.utils.UiState
+import javax.inject.Inject
+
+@HiltViewModel
+class UpdatePasswordViewModel @Inject constructor(
+    private val userAuthRepositoryImp: UserAuthRepository,
+    private val clientRepositoryImp: ClientRepository
+) : ViewModel() {
+
+    private val compositeDisposable = CompositeDisposable()
+    private val _updatePasswordUiState = MutableLiveData<UiState>()
+    val updatePasswordUiState: LiveData<UiState> get() = _updatePasswordUiState
+    fun isInputFieldEmpty(fieldText: String): Boolean {
+        return fieldText.isEmpty()
+    }
+
+    fun isInputLengthInadequate(fieldText: String): Boolean {
+        return fieldText.length < 6
+    }
+
+    fun validatePasswordMatch(newPassword: String, confirmPassword: String): Boolean {
+        return newPassword == confirmPassword
+    }
+
+    fun updateAccountPassword(newPassword: String, confirmPassword: String) {
+        _updatePasswordUiState.value = UiState.Loading
+        userAuthRepositoryImp.updateAccountPassword(newPassword, confirmPassword)
+            ?.subscribeOn(Schedulers.io())
+            ?.observeOn(AndroidSchedulers.mainThread())
+            ?.subscribeWith(object : DisposableObserver<ResponseBody?>() {
+                override fun onNext(responseBody: ResponseBody) {
+                    _updatePasswordUiState.value = UiState.Success
+                    clientRepositoryImp.updateAuthenticationToken(newPassword)
+                }
+
+                override fun onError(e: Throwable) {
+                    _updatePasswordUiState.value = UiState.Error(e)
+                }
+
+                override fun onComplete() {}
+            })?.let { compositeDisposable.add(it) }
+    }
+
+
+    override fun onCleared() {
+        super.onCleared()
+        compositeDisposable.clear()
+    }
+}

--- a/app/src/main/java/org/mifos/mobile/viewModels/UpdatePasswordViewModel.kt
+++ b/app/src/main/java/org/mifos/mobile/viewModels/UpdatePasswordViewModel.kt
@@ -11,7 +11,7 @@ import io.reactivex.schedulers.Schedulers
 import okhttp3.ResponseBody
 import org.mifos.mobile.repositories.ClientRepository
 import org.mifos.mobile.repositories.UserAuthRepository
-import org.mifos.mobile.utils.UiState
+import org.mifos.mobile.utils.RegistrationUiState
 import javax.inject.Inject
 
 @HiltViewModel
@@ -21,8 +21,8 @@ class UpdatePasswordViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val compositeDisposable = CompositeDisposable()
-    private val _updatePasswordUiState = MutableLiveData<UiState>()
-    val updatePasswordUiState: LiveData<UiState> get() = _updatePasswordUiState
+    private val _updatePasswordUiState = MutableLiveData<RegistrationUiState>()
+    val updatePasswordUiState: LiveData<RegistrationUiState> get() = _updatePasswordUiState
     fun isInputFieldEmpty(fieldText: String): Boolean {
         return fieldText.isEmpty()
     }
@@ -36,18 +36,18 @@ class UpdatePasswordViewModel @Inject constructor(
     }
 
     fun updateAccountPassword(newPassword: String, confirmPassword: String) {
-        _updatePasswordUiState.value = UiState.Loading
+        _updatePasswordUiState.value = RegistrationUiState.Loading
         userAuthRepositoryImp.updateAccountPassword(newPassword, confirmPassword)
             ?.subscribeOn(Schedulers.io())
             ?.observeOn(AndroidSchedulers.mainThread())
             ?.subscribeWith(object : DisposableObserver<ResponseBody?>() {
                 override fun onNext(responseBody: ResponseBody) {
-                    _updatePasswordUiState.value = UiState.Success
+                    _updatePasswordUiState.value = RegistrationUiState.Success
                     clientRepositoryImp.updateAuthenticationToken(newPassword)
                 }
 
                 override fun onError(e: Throwable) {
-                    _updatePasswordUiState.value = UiState.Error(e)
+                    _updatePasswordUiState.value = RegistrationUiState.Error(e)
                 }
 
                 override fun onComplete() {}

--- a/app/src/test/java/org/mifos/mobile/repositories/ClientRepositoryImpTest.kt
+++ b/app/src/test/java/org/mifos/mobile/repositories/ClientRepositoryImpTest.kt
@@ -1,0 +1,42 @@
+package org.mifos.mobile.repositories
+
+import okhttp3.Credentials
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mifos.mobile.api.BaseURL
+import org.mifos.mobile.api.local.PreferencesHelper
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.MockitoAnnotations
+import org.mockito.junit.MockitoJUnitRunner
+
+@RunWith(MockitoJUnitRunner::class)
+class ClientRepositoryImpTest {
+
+    @Mock
+    lateinit var preferencesHelper: PreferencesHelper
+
+    private lateinit var clientRepositoryImp: ClientRepository
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        clientRepositoryImp = ClientRepositoryImp(preferencesHelper)
+    }
+
+    @Test
+    fun test() {
+        val mockPassword = "testPassword"
+        val mockUsername = "testUsername"
+        Mockito.`when`(preferencesHelper.userName).thenReturn(mockUsername)
+
+        Mockito.`when`(preferencesHelper.baseUrl)
+            .thenReturn(BaseURL.PROTOCOL_HTTPS + BaseURL.API_ENDPOINT)
+
+        clientRepositoryImp.updateAuthenticationToken(mockPassword)
+        val authenticationToken = Credentials.basic(preferencesHelper.userName!!, mockPassword)
+
+        Mockito.verify(preferencesHelper).saveToken(authenticationToken)
+    }
+}

--- a/app/src/test/java/org/mifos/mobile/repositories/ClientRepositoryImpTest.kt
+++ b/app/src/test/java/org/mifos/mobile/repositories/ClientRepositoryImpTest.kt
@@ -26,7 +26,7 @@ class ClientRepositoryImpTest {
     }
 
     @Test
-    fun test() {
+    fun testUpdateAuthenticationToken() {
         val mockPassword = "testPassword"
         val mockUsername = "testUsername"
         Mockito.`when`(preferencesHelper.userName).thenReturn(mockUsername)

--- a/app/src/test/java/org/mifos/mobile/viewModels/RegistrationViewModelTest.kt
+++ b/app/src/test/java/org/mifos/mobile/viewModels/RegistrationViewModelTest.kt
@@ -12,7 +12,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mifos.mobile.repositories.UserAuthRepositoryImp
 import org.mifos.mobile.util.RxSchedulersOverrideRule
-import org.mifos.mobile.utils.RegistrationUiState
+import org.mifos.mobile.utils.UiState
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.MockitoAnnotations
@@ -33,7 +33,7 @@ class RegistrationViewModelTest {
     lateinit var userAuthRepositoryImp: UserAuthRepositoryImp
 
     @Mock
-    lateinit var registrationUiStateObserver: Observer<RegistrationUiState>
+    lateinit var registrationUiStateObserver: Observer<UiState>
 
     private lateinit var registrationViewModel: RegistrationViewModel
 
@@ -127,9 +127,8 @@ class RegistrationViewModelTest {
             "userName"
         )
 
-        Mockito.verify(registrationUiStateObserver).onChanged(RegistrationUiState.Loading)
-        Mockito.verify(registrationUiStateObserver)
-            .onChanged(RegistrationUiState.RegistrationSuccessful)
+        Mockito.verify(registrationUiStateObserver).onChanged(UiState.Loading)
+        Mockito.verify(registrationUiStateObserver).onChanged(UiState.Success)
         Mockito.verifyNoMoreInteractions(registrationUiStateObserver)
     }
 
@@ -160,9 +159,8 @@ class RegistrationViewModelTest {
             "username"
         )
 
-        Mockito.verify(registrationUiStateObserver).onChanged(RegistrationUiState.Loading)
-        Mockito.verify(registrationUiStateObserver)
-            .onChanged(RegistrationUiState.ErrorOnRegistration(error))
+        Mockito.verify(registrationUiStateObserver).onChanged(UiState.Loading)
+        Mockito.verify(registrationUiStateObserver).onChanged(UiState.Error(error))
         Mockito.verifyNoMoreInteractions(registrationUiStateObserver)
     }
 

--- a/app/src/test/java/org/mifos/mobile/viewModels/RegistrationViewModelTest.kt
+++ b/app/src/test/java/org/mifos/mobile/viewModels/RegistrationViewModelTest.kt
@@ -12,7 +12,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mifos.mobile.repositories.UserAuthRepositoryImp
 import org.mifos.mobile.util.RxSchedulersOverrideRule
-import org.mifos.mobile.utils.UiState
+import org.mifos.mobile.utils.RegistrationUiState
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.MockitoAnnotations
@@ -33,7 +33,7 @@ class RegistrationViewModelTest {
     lateinit var userAuthRepositoryImp: UserAuthRepositoryImp
 
     @Mock
-    lateinit var registrationUiStateObserver: Observer<UiState>
+    lateinit var registrationUiStateObserver: Observer<RegistrationUiState>
 
     private lateinit var registrationViewModel: RegistrationViewModel
 
@@ -70,7 +70,7 @@ class RegistrationViewModelTest {
 
     @Test
     fun testInputHasSpaces_WithSpacesInput_ReturnsTrue() {
-        val result = registrationViewModel.inputHasSpaces("test string")
+        val result = registrationViewModel.inputHasSpaces("testUpdateAuthenticationToken string")
         Assert.assertTrue(result)
     }
 
@@ -94,7 +94,7 @@ class RegistrationViewModelTest {
 
     @Test
     fun testIsEmailInvalid_WithValidEmailInput_ReturnsFalse() {
-        val result = registrationViewModel.isEmailInvalid("test@example.com")
+        val result = registrationViewModel.isEmailInvalid("testUpdateAuthenticationToken@example.com")
         Assert.assertFalse(result)
     }
 
@@ -127,8 +127,8 @@ class RegistrationViewModelTest {
             "userName"
         )
 
-        Mockito.verify(registrationUiStateObserver).onChanged(UiState.Loading)
-        Mockito.verify(registrationUiStateObserver).onChanged(UiState.Success)
+        Mockito.verify(registrationUiStateObserver).onChanged(RegistrationUiState.Loading)
+        Mockito.verify(registrationUiStateObserver).onChanged(RegistrationUiState.Success)
         Mockito.verifyNoMoreInteractions(registrationUiStateObserver)
     }
 
@@ -159,8 +159,8 @@ class RegistrationViewModelTest {
             "username"
         )
 
-        Mockito.verify(registrationUiStateObserver).onChanged(UiState.Loading)
-        Mockito.verify(registrationUiStateObserver).onChanged(UiState.Error(error))
+        Mockito.verify(registrationUiStateObserver).onChanged(RegistrationUiState.Loading)
+        Mockito.verify(registrationUiStateObserver).onChanged(RegistrationUiState.Error(error))
         Mockito.verifyNoMoreInteractions(registrationUiStateObserver)
     }
 

--- a/app/src/test/java/org/mifos/mobile/viewModels/UpdatePasswordViewModelTest.kt
+++ b/app/src/test/java/org/mifos/mobile/viewModels/UpdatePasswordViewModelTest.kt
@@ -1,0 +1,122 @@
+package org.mifos.mobile.viewModels
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.Observer
+import io.reactivex.Observable
+import okhttp3.ResponseBody
+
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mifos.mobile.repositories.ClientRepository
+import org.mifos.mobile.repositories.UserAuthRepository
+import org.mifos.mobile.util.RxSchedulersOverrideRule
+import org.mifos.mobile.utils.UiState
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.MockitoAnnotations
+import org.mockito.junit.MockitoJUnitRunner
+import kotlin.RuntimeException
+
+@RunWith(MockitoJUnitRunner::class)
+class UpdatePasswordViewModelTest {
+
+    @JvmField
+    @Rule
+    val mOverrideSchedulersRule = RxSchedulersOverrideRule()
+
+    @get:Rule
+    val rule = InstantTaskExecutorRule()
+
+    @Mock
+    lateinit var userAuthRepositoryImp: UserAuthRepository
+
+    @Mock
+    lateinit var clientRepositoryImp: ClientRepository
+
+    @Mock
+    private lateinit var updatePasswordUiStateObserver: Observer<UiState>
+
+    private lateinit var updatePasswordViewModel: UpdatePasswordViewModel
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.openMocks(this)
+        updatePasswordViewModel =
+            UpdatePasswordViewModel(userAuthRepositoryImp, clientRepositoryImp)
+        updatePasswordViewModel.updatePasswordUiState.observeForever(updatePasswordUiStateObserver)
+    }
+
+    @Test
+    fun testIsInputFieldEmpty_WithEmptyStringInput_ReturnsTrue() {
+        val result = updatePasswordViewModel.isInputFieldEmpty("")
+        Assert.assertTrue(result)
+    }
+
+    @Test
+    fun testIsInputFieldEmpty_WithNonEmptyStringInput_ReturnsFalse() {
+        val result = updatePasswordViewModel.isInputFieldEmpty("nonEmptyStringInput")
+        Assert.assertFalse(result)
+    }
+
+    @Test
+    fun testIsInputLengthInadequate_WithAdequateLengthInput_ReturnsFalse() {
+        val result = updatePasswordViewModel.isInputLengthInadequate("Password123")
+        Assert.assertFalse(result)
+    }
+
+    @Test
+    fun testIsInputLengthInadequate_WithInadequateLengthInput_ReturnsTrue() {
+        val result = updatePasswordViewModel.isInputLengthInadequate("")
+        Assert.assertTrue(result)
+    }
+
+    @Test
+    fun testValidatePasswordMatch_WithSamePasswords_ReturnsTrue() {
+        val result = updatePasswordViewModel.validatePasswordMatch("password", "password")
+        Assert.assertTrue(result)
+    }
+
+    @Test
+    fun testValidatePasswordMatch_WithDifferentPasswords_ReturnsFalse() {
+        val result = updatePasswordViewModel.validatePasswordMatch("password1", "password2")
+        Assert.assertFalse(result)
+    }
+
+    @Test
+    fun testUpdateAccountPassword_SuccessReceivedFromRepository_ReturnsSuccess() {
+        val responseBody = Mockito.mock(ResponseBody::class.java)
+        Mockito.`when`(
+            userAuthRepositoryImp.updateAccountPassword(Mockito.anyString(), Mockito.anyString())
+        ).thenReturn(Observable.just(responseBody))
+
+        updatePasswordViewModel.updateAccountPassword("newPassword", "newPassword")
+        Mockito.verify(updatePasswordUiStateObserver).onChanged(UiState.Loading)
+        Mockito.verify(updatePasswordUiStateObserver).onChanged(UiState.Success)
+        Mockito.verify(clientRepositoryImp).updateAuthenticationToken("newPassword")
+        Mockito.verifyNoMoreInteractions(updatePasswordUiStateObserver)
+    }
+
+    @Test
+    fun testUpdateAccountPassword_ErrorReceivedFromRepository_ReturnsError() {
+        val error = RuntimeException("fail")
+        Mockito.`when`(
+            userAuthRepositoryImp.updateAccountPassword(Mockito.anyString(), Mockito.anyString())
+        ).thenReturn(Observable.error(error))
+
+        updatePasswordViewModel.updateAccountPassword("newPassword", "newPassword")
+
+        Mockito.verify(updatePasswordUiStateObserver).onChanged(UiState.Loading)
+        Mockito.verify(updatePasswordUiStateObserver).onChanged(UiState.Error(error))
+        Mockito.verifyNoMoreInteractions(updatePasswordUiStateObserver)
+    }
+
+
+    @After
+    fun tearDown() {
+        updatePasswordViewModel.updatePasswordUiState.removeObserver(updatePasswordUiStateObserver)
+    }
+}

--- a/app/src/test/java/org/mifos/mobile/viewModels/UpdatePasswordViewModelTest.kt
+++ b/app/src/test/java/org/mifos/mobile/viewModels/UpdatePasswordViewModelTest.kt
@@ -14,7 +14,7 @@ import org.junit.runner.RunWith
 import org.mifos.mobile.repositories.ClientRepository
 import org.mifos.mobile.repositories.UserAuthRepository
 import org.mifos.mobile.util.RxSchedulersOverrideRule
-import org.mifos.mobile.utils.UiState
+import org.mifos.mobile.utils.RegistrationUiState
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.MockitoAnnotations
@@ -38,7 +38,7 @@ class UpdatePasswordViewModelTest {
     lateinit var clientRepositoryImp: ClientRepository
 
     @Mock
-    private lateinit var updatePasswordUiStateObserver: Observer<UiState>
+    private lateinit var updatePasswordUiStateObserver: Observer<RegistrationUiState>
 
     private lateinit var updatePasswordViewModel: UpdatePasswordViewModel
 
@@ -94,8 +94,8 @@ class UpdatePasswordViewModelTest {
         ).thenReturn(Observable.just(responseBody))
 
         updatePasswordViewModel.updateAccountPassword("newPassword", "newPassword")
-        Mockito.verify(updatePasswordUiStateObserver).onChanged(UiState.Loading)
-        Mockito.verify(updatePasswordUiStateObserver).onChanged(UiState.Success)
+        Mockito.verify(updatePasswordUiStateObserver).onChanged(RegistrationUiState.Loading)
+        Mockito.verify(updatePasswordUiStateObserver).onChanged(RegistrationUiState.Success)
         Mockito.verify(clientRepositoryImp).updateAuthenticationToken("newPassword")
         Mockito.verifyNoMoreInteractions(updatePasswordUiStateObserver)
     }
@@ -109,8 +109,8 @@ class UpdatePasswordViewModelTest {
 
         updatePasswordViewModel.updateAccountPassword("newPassword", "newPassword")
 
-        Mockito.verify(updatePasswordUiStateObserver).onChanged(UiState.Loading)
-        Mockito.verify(updatePasswordUiStateObserver).onChanged(UiState.Error(error))
+        Mockito.verify(updatePasswordUiStateObserver).onChanged(RegistrationUiState.Loading)
+        Mockito.verify(updatePasswordUiStateObserver).onChanged(RegistrationUiState.Error(error))
         Mockito.verifyNoMoreInteractions(updatePasswordUiStateObserver)
     }
 


### PR DESCRIPTION
fixes : MOBILE-97

-> added viewModel and repository
-> refactored "RegistrationUiState" to "UiState" so that it could be used across registrationFragment and updatePasscode fragment 
-> refactored updatePassword fragment's exisiting code, to use more kotlin specific ways.

Fixes #Issue_Number

Please Add Screenshots If there are any UI changes.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.