### PR TITLE
fix-#1299-Apply-for-loan-icon-should-be-unique

### DIFF
--- a/app/src/main/res/layout/fragment_home_old.xml
+++ b/app/src/main/res/layout/fragment_home_old.xml
@@ -290,7 +290,7 @@
                         <ImageView
                             android:layout_width="@dimen/width_56dp"
                             android:layout_height="@dimen/height_56dp"
-                            app:srcCompat="@drawable/ic_account_balance_black_24dp" />
+                            app:srcCompat="@drawable/ic_loan" />
 
                         <TextView
                             android:layout_width="match_parent"


### PR DESCRIPTION
Fixes #1299 

<img width="198" alt="image" src="https://github.com/openMF/mifos-mobile/assets/132065924/bd5b855d-5c69-4b11-af85-66f0313d471e">

