### PR TITLE
fix: Repayment schedule is hardly readable when the app is in dark mode

### DIFF
--- a/app/src/main/res/layout/cell_loan_repayment_schedule.xml
+++ b/app/src/main/res/layout/cell_loan_repayment_schedule.xml
@@ -9,6 +9,7 @@
     android:id="@+id/cell_container"
     android:layout_width="wrap_content"
     android:layout_height="@dimen/cell_height"
+    android:backgroundTint="?android:attr/windowBackground"
     android:gravity="center"
     android:orientation="vertical"
     android:padding="@dimen/Mifos.DesignSystem.Spacing.CardInnerPadding">
@@ -21,6 +22,7 @@
         android:layout_gravity="center_vertical"
         android:gravity="center"
         android:maxLines="1"
+        android:textAppearance="@style/Base.TextAppearance.AppCompat.Medium"
         android:visibility="visible"
         tools:text="Cell Data" />
 

--- a/app/src/main/res/layout/column_header_loan_repayment_schedule.xml
+++ b/app/src/main/res/layout/column_header_loan_repayment_schedule.xml
@@ -10,6 +10,7 @@
     android:id="@+id/column_header_container"
     android:layout_width="wrap_content"
     android:layout_height="@dimen/default_column_header_height"
+    android:backgroundTint="?android:attr/windowBackground"
     android:orientation="vertical">
 
 
@@ -21,6 +22,7 @@
         android:layout_gravity="center"
         android:layout_weight="4"
         android:gravity="center"
+        android:textAppearance="@style/Base.TextAppearance.AppCompat.Medium"
         tools:text="Header Data" />
 
 

--- a/app/src/main/res/layout/fragment_loan_repayment_schedule.xml
+++ b/app/src/main/res/layout/fragment_loan_repayment_schedule.xml
@@ -37,8 +37,7 @@
                         android:layout_gravity="start"
                         android:layout_weight="1"
                         android:text="@string/account_number"
-                        android:textAppearance="@style/Base.TextAppearance.AppCompat.Medium"
-                        android:textColor="@color/black" />
+                        android:textAppearance="@style/Base.TextAppearance.AppCompat.Medium" />
 
                     <TextView
                         android:id="@+id/tv_account_number"
@@ -59,8 +58,7 @@
                         android:layout_gravity="start"
                         android:layout_weight="1"
                         android:text="@string/disbursement_date"
-                        android:textAppearance="@style/Base.TextAppearance.AppCompat.Medium"
-                        android:textColor="@color/black" />
+                        android:textAppearance="@style/Base.TextAppearance.AppCompat.Medium" />
 
                     <TextView
                         android:id="@+id/tv_disbursement_date"
@@ -81,8 +79,7 @@
                         android:layout_gravity="start"
                         android:layout_weight="1"
                         android:text="@string/no_of_payments"
-                        android:textAppearance="@style/Base.TextAppearance.AppCompat.Medium"
-                        android:textColor="@color/black" />
+                        android:textAppearance="@style/Base.TextAppearance.AppCompat.Medium" />
 
                     <TextView
                         android:id="@+id/tv_number_of_payments"

--- a/app/src/main/res/layout/row_header_loan_repayment_schedule.xml
+++ b/app/src/main/res/layout/row_header_loan_repayment_schedule.xml
@@ -14,6 +14,7 @@
         android:id="@+id/row_header_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:backgroundTint="?android:attr/windowBackground"
         android:gravity="center_vertical"
         android:orientation="vertical">
 
@@ -25,11 +26,14 @@
             android:ellipsize="end"
             android:gravity="center"
             android:maxLines="1"
+            android:textColor="@color/black"
             tools:text="Row Data" />
     </LinearLayout>
 
 
     <View
         style="@style/Mifos.DesignSystem.Components.VerticalSpacer"
+
         android:layout_width="wrap_content" />
+
 </RelativeLayout>


### PR DESCRIPTION
Fixes #2098 
before fix
![image](https://github.com/openMF/mifos-mobile/assets/116818222/2e660c8f-7fff-47ca-9c64-40a1f6bbf29d)
after fix
![WhatsApp Image 2023-08-06 at 02 45 14](https://github.com/openMF/mifos-mobile/assets/116818222/fec569e4-a63d-48d1-8a80-27b88a06303f)
