### PR TITLE
FilterIcon tint color Fixed #2357

### DIFF
--- a/app/src/main/res/drawable/ic_filter_list_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_filter_list_black_24dp.xml
@@ -1,5 +1,10 @@
-<vector android:height="24dp" android:tint="#000000"
-    android:viewportHeight="24" android:viewportWidth="24"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@android:color/white" android:pathData="M10,18h4v-2h-4v2zM3,6v2h18L21,6L3,6zM6,13h12v-2L6,11v2z"/>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M10,18h4v-2h-4v2zM3,6v2h18L21,6L3,6zM6,13h12v-2L6,11v2z" />
 </vector>


### PR DESCRIPTION
Fixed #2357
Filter Icon tint color fixed.

Please add #hacktoberfest on merge.

Screenshots:
<p>
 <img src="https://github.com/openMF/mifos-mobile/assets/73953395/24be6b56-dc01-4f7f-abb9-ab0079e0dbee" alt="android" width="225" height="450"/>
 <img src="https://github.com/openMF/mifos-mobile/assets/73953395/1b9f7b9e-0bb4-4595-834f-4f4261d92637" alt="android" width="225" height="450"/>
</p>

