### PR TITLE
Fix#2356 Guarantor Type Selection Fixed

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/fragments/AddGuarantorFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/AddGuarantorFragment.kt
@@ -1,5 +1,6 @@
 package org.mifos.mobile.ui.fragments
 
+import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -39,20 +40,27 @@ class AddGuarantorFragment : BaseFragment() {
 
     private val viewModel: AddGuarantorViewModel by viewModels()
 
-    var guarantorTypeAdapter: ArrayAdapter<String?>? = null
+    private var guarantorTypeAdapter: ArrayAdapter<String?>? = null
     var template: GuarantorTemplatePayload? = null
     var payload: GuarantorPayload? = null
     private var guarantorState: GuarantorState? = null
     private var guarantorApplicationPayload: GuarantorApplicationPayload? = null
     var loanId: Long? = 0
-    var index: Int? = 0
+    private var index: Int? = 0
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         if (arguments != null) {
             loanId = arguments?.getLong(Constants.LOAN_ID)
-            guarantorState = requireArguments()
-                .getSerializable(Constants.GUARANTOR_STATE) as GuarantorState
-            payload = arguments?.getParcelable(Constants.PAYLOAD)
+            guarantorState = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                arguments?.getSerializable(Constants.GUARANTOR_STATE, GuarantorState::class.java)
+            }else{
+                arguments?.getSerializable(Constants.GUARANTOR_STATE) as GuarantorState?
+            }
+            payload = if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU){
+                arguments?.getParcelable(Constants.PAYLOAD, GuarantorPayload::class.java)
+            }else{
+                arguments?.getParcelable(Constants.PAYLOAD) as GuarantorPayload?
+            }
             index = arguments?.getInt(Constants.INDEX)
         }
     }
@@ -115,7 +123,7 @@ class AddGuarantorFragment : BaseFragment() {
         viewModel.getGuarantorTemplate(guarantorState, loanId)
     }
 
-    fun onSubmit() {
+    private fun onSubmit() {
         with(binding) {
             tilFirstName.isErrorEnabled = false
             tilLastName.isErrorEnabled = false
@@ -199,12 +207,12 @@ class AddGuarantorFragment : BaseFragment() {
         _binding = null
     }
 
-    fun showGuarantorApplication(template: GuarantorTemplatePayload?) {
+    private fun showGuarantorApplication(template: GuarantorTemplatePayload?) {
         this.template = template
         setUpSpinner()
     }
 
-    fun showGuarantorUpdation(template: GuarantorTemplatePayload?) {
+    private fun showGuarantorUpdation(template: GuarantorTemplatePayload?) {
         this.template = template
         setUpSpinner()
         with(binding) {
@@ -217,7 +225,6 @@ class AddGuarantorFragment : BaseFragment() {
 
     private fun setUpSpinner() {
         val options: MutableList<String?> = ArrayList()
-        options.addAll(listOf("choicea", "choiceB"))
         for (option in template?.guarantorTypeOptions!!) {
             options.add(option.value)
         }
@@ -231,13 +238,13 @@ class AddGuarantorFragment : BaseFragment() {
         }
     }
 
-    fun updatedSuccessfully(message: String?) {
+    private fun updatedSuccessfully(message: String?) {
         Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
         publish(UpdateGuarantorEvent(guarantorApplicationPayload, index))
         activity?.supportFragmentManager?.popBackStack()
     }
 
-    fun submittedSuccessfully(message: String?, payload: GuarantorApplicationPayload?) {
+    private fun submittedSuccessfully(message: String?, payload: GuarantorApplicationPayload?) {
         Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
         publish(AddGuarantorEvent(payload, index))
         activity?.supportFragmentManager?.popBackStack()


### PR DESCRIPTION
Fixes #2356 

Removed the **choicea** and **choiceB** Options since they had no usage and were added explicitly in the code. Currently it has three Guarantor Type i.e. **CUSTOMER**, **STAFF** and **EXTERNAL**

<img src="https://github.com/openMF/mifos-mobile/assets/73953395/8915db67-5576-4b3a-b756-c7570d1ef86a" height=450/>

Please add #hacktoberfest on merge.