### PR TITLE
Fix: snack bar messages on errors from api

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/fragments/UpdatePasswordFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/UpdatePasswordFragment.kt
@@ -2,6 +2,7 @@ package org.mifos.mobile.ui.fragments
 
 import android.os.Bundle
 import android.text.Editable
+import android.text.TextUtils
 import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
@@ -10,6 +11,7 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.lifecycle.ViewModelProvider
 import dagger.hilt.android.AndroidEntryPoint
+import org.json.JSONObject
 import org.mifos.mobile.R
 import org.mifos.mobile.databinding.FragmentUpdatePasswordBinding
 import org.mifos.mobile.ui.activities.base.BaseActivity
@@ -63,7 +65,13 @@ class UpdatePasswordFragment : BaseFragment(), TextWatcher, OnFocusChangeListene
 
                 is RegistrationUiState.Error -> {
                     hideProgress()
-                    showError(state.exception)
+                    if (TextUtils.isEmpty(state.exception)) {
+                        showError(getString(R.string.not_found_error))
+                        return@observe
+                    }
+                    val errorResponseObject = JSONObject(state.exception)
+                    val error = errorResponseObject.getString("error")
+                    showError(error)
                 }
             }
         }

--- a/app/src/main/java/org/mifos/mobile/viewModels/UpdatePasswordViewModel.kt
+++ b/app/src/main/java/org/mifos/mobile/viewModels/UpdatePasswordViewModel.kt
@@ -35,7 +35,11 @@ class UpdatePasswordViewModel @Inject constructor(
         viewModelScope.launch {
             _updatePasswordUiState.value = RegistrationUiState.Loading
             val response = userAuthRepositoryImp.updateAccountPassword(newPassword, confirmPassword)
-
+            response?.code()?.compareTo(400)?.let {
+                if (it >= 0) {
+                    _updatePasswordUiState.value = RegistrationUiState.Error("")
+                }
+            }
             try {
                 if (response?.isSuccessful == true) {
                     _updatePasswordUiState.value = RegistrationUiState.Success

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -646,5 +646,5 @@
     </string-array>
     <string name="app_info">App Info</string>
     <string name="login_failed">Login Failed, Please Try Again Later.</string>
-
+    <string name="not_found_error">Could not update password. Please try again later.</string>
 </resources>


### PR DESCRIPTION
Fixes #2363 
I couldn't verify the success response or the error response on my Samsung galaxy M31 device with API 30 because the API for update password kept returning `404` error for credentials `username:mifos, password:password`. If someone with a valid account could try this PR that would be great!
Added an additional block to check for 404 error and return a suitable message in snack bar.
Please Add Screenshots If there are any UI changes.
Previously the snack bar used to show a json which came as error. Updated the code to use the string which come inside this error block of json:
![Screenshot_20231011-132044_Mifos Mobile_previous](https://github.com/openMF/mifos-mobile/assets/53987325/272564c3-d9cf-43fa-83f6-a740a52e7f96)
Now:
![Screenshot_20231011-133540_Mifos Mobile](https://github.com/openMF/mifos-mobile/assets/53987325/32cd059f-90f1-4bbb-836c-be650ecd8037)
![Screenshot_20231011-134520_Mifos Mobile](https://github.com/openMF/mifos-mobile/assets/53987325/55dfdafe-461b-43f6-95e9-15df48dfe5bb)
![Screenshot_20231011-134604_Mifos Mobile](https://github.com/openMF/mifos-mobile/assets/53987325/9cf096a3-38b8-448a-bd12-6d044062afa3)



Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x ] If you have multiple commits please combine them into one commit by squashing them.