### PR TITLE
fixed Mifos stretched logo on application startup

### DIFF
--- a/app/src/main/res/drawable/splash_background.xml
+++ b/app/src/main/res/drawable/splash_background.xml
@@ -4,7 +4,9 @@
     <item android:drawable="@color/white" />
 
     <item>
-        <bitmap android:src="@drawable/mifos_splash_screen_logo" />
+        <bitmap android:src="@drawable/mifos_splash_screen_logo"
+                android:gravity="center"
+        />
     </item>
 
 </layer-list>


### PR DESCRIPTION

![Screenshot_20231231-112605](https://github.com/openMF/mifos-mobile/assets/12993867/915e2f2d-1d9a-40d0-b693-9a3c323df8f0)
Fixes #Issue_Number

Please Add Screenshots If there are any UI changes.

Please make sure these boxes are checked before submitting your pull request - thanks! (./gradlew check was not working in stable code too)

- [✓ ] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [ ] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [ ✓] If you have multiple commits please combine them into one commit by squashing them.