### PR TITLE
Fixes #2463 - Fixed the startup logo to look in 1:1 aspect ratio

### DIFF
--- a/app/src/main/res/drawable/splash_background.xml
+++ b/app/src/main/res/drawable/splash_background.xml
@@ -4,7 +4,8 @@
     <item android:drawable="@color/white" />
 
     <item>
-        <bitmap android:src="@drawable/mifos_splash_screen_logo" />
+        <bitmap android:src="@drawable/mifos_splash_screen_logo"
+            android:gravity="center"/>
     </item>
 
 </layer-list>


### PR DESCRIPTION
Fixes #2463 

![Screenshot_20240102-201456](https://github.com/openMF/mifos-mobile/assets/12993867/ecc5c949-1e73-413e-86d6-e4c004533373)


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.