### PR TITLE
fix #2474- About Us page section's text not visible properly while in dark mode

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/about/AboutUsHeader.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/about/AboutUsHeader.kt
@@ -1,6 +1,8 @@
 package org.mifos.mobile.ui.about
 
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -10,6 +12,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -31,6 +34,11 @@ fun AboutUsHeader() {
         Text(
             text = stringResource(id = R.string.app_name),
             style = MaterialTheme.typography.headlineMedium,
+            color = if(AppCompatDelegate.getDefaultNightMode() == 2 || (AppCompatDelegate.getDefaultNightMode() ==- 1 && isSystemInDarkTheme())) {
+                Color.White
+            }else {
+                       Color.Black
+                       },
             textAlign = TextAlign.Center,
             modifier = Modifier
                 .fillMaxWidth()
@@ -40,6 +48,11 @@ fun AboutUsHeader() {
         Text(
             text = stringResource(id = R.string.about_app_description),
             style = MaterialTheme.typography.titleSmall.copy(),
+            color = if(AppCompatDelegate.getDefaultNightMode() == 2 || (AppCompatDelegate.getDefaultNightMode() ==- 1 && isSystemInDarkTheme())) {
+                Color.White
+            }else {
+                Color.Black
+            },
             textAlign = TextAlign.Center,
             modifier = Modifier
                 .fillMaxWidth()


### PR DESCRIPTION
Fixes #2474 

![Screenshot_20240107-153338](https://github.com/openMF/mifos-mobile/assets/12993867/32c7c1dd-eb1f-4757-b28e-c555ea369f36)
![Screenshot_20240107-153353](https://github.com/openMF/mifos-mobile/assets/12993867/46ed1fdd-b9b7-47fb-9aac-9c6669851122)


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.