### PR TITLE
fix #2478 :  Progress Dialog shown for the infinite period of time in recent transactions

### DIFF
--- a/app/src/main/java/org/mifos/mobile/viewModels/RecentTransactionViewModel.kt
+++ b/app/src/main/java/org/mifos/mobile/viewModels/RecentTransactionViewModel.kt
@@ -24,6 +24,7 @@ class RecentTransactionViewModel @Inject constructor(private val recentTransacti
     val recentTransactionUiState: StateFlow<RecentTransactionUiState> = _recentTransactionUiState
 
     fun loadRecentTransactions(loadmore: Boolean, offset: Int) {
+        if (loadmore && offset < limit) return //all data shown,no need to load
         this.loadmore = loadmore
         loadRecentTransactions(offset, limit)
     }


### PR DESCRIPTION
Fixes #2478 

More transaction were being loaded though we have shown all the recent transactions , which lead to the recenttransactionstate always in loading 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [x] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.

**Screencast after fix ** : 
 

https://github.com/openMF/mifos-mobile/assets/25600880/23aaf842-8038-450a-9852-04f41fc74b2f


