### PR TITLE
splash screen dark mode fixed

### DIFF
--- a/app/src/main/res/drawable/splash_background.xml
+++ b/app/src/main/res/drawable/splash_background.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <item android:drawable="@color/white" />
+    <item android:drawable="@color/spalsh_bg_color" />
 
     <item>
         <bitmap android:src="@drawable/mifos_splash_screen_logo"

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="spalsh_bg_color">#ffffffff</color>
+    <color name="spalsh_bg_color">#000000</color>
     <color name="white">#ffffffff</color>
     <color name="black">#000000</color>
     <color name="background">#eaeaea</color>


### PR DESCRIPTION
Fixes #2466

fixed dark mode splash screen.

https://github.com/openMF/mifos-mobile/assets/115624967/211a826d-3fef-4ac2-88e6-d6e13c921abc



-> so, i added one dark mode colors file in values.
-> now any dark mode related work can be done there.
-> also fixed splash screen dark mode issue.