### PR TITLE
Fixed: #2395 Added SDK Checks for Deprecated Parcelable and Serializable Functions

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/activities/HomeActivity.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/activities/HomeActivity.kt
@@ -46,6 +46,7 @@ import org.mifos.mobile.utils.UserDetailUiState
 import org.mifos.mobile.utils.fcm.RegistrationIntentService
 import org.mifos.mobile.ui.user_profile.UserDetailViewModel
 import org.mifos.mobile.ui.user_profile.UserProfileActivity
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedParcelable
 import javax.inject.Inject
 
 /**
@@ -96,7 +97,7 @@ class HomeActivity :
             viewModel.userImage
             showUserImage(null)
         } else {
-            client = savedInstanceState.getParcelable(Constants.USER_DETAILS)
+            client = savedInstanceState.getCheckedParcelable(Client::class.java, Constants.USER_DETAILS)
             viewModel.setUserProfile(preferencesHelper?.userProfileImage)
             showUserDetails(client)
         }

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/AccountsFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/AccountsFragment.kt
@@ -28,6 +28,7 @@ import org.mifos.mobile.ui.adapters.SavingAccountsListAdapter
 import org.mifos.mobile.ui.adapters.ShareAccountsListAdapter
 import org.mifos.mobile.ui.fragments.base.BaseFragment
 import org.mifos.mobile.utils.*
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedArrayListFromParcelable
 import org.mifos.mobile.viewModels.AccountsViewModel
 import java.util.*
 
@@ -137,14 +138,18 @@ class AccountsFragment : BaseFragment(), OnRefreshListener {
             when (accountType) {
                 Constants.SAVINGS_ACCOUNTS -> {
                     val savingAccountList: List<SavingAccount?> =
-                        savedInstanceState.getParcelableArrayList(Constants.SAVINGS_ACCOUNTS)
+                        savedInstanceState.getCheckedArrayListFromParcelable(
+                            SavingAccount::class.java,
+                            Constants.SAVINGS_ACCOUNTS
+                        )
                             ?: listOf()
                     showSavingsAccounts(savingAccountList)
                 }
 
                 Constants.LOAN_ACCOUNTS -> {
                     val loanAccountList: List<LoanAccount?> =
-                        savedInstanceState.getParcelableArrayList(
+                        savedInstanceState.getCheckedArrayListFromParcelable(
+                            LoanAccount::class.java,
                             Constants.LOAN_ACCOUNTS,
                         ) ?: listOf()
                     showLoanAccounts(loanAccountList)
@@ -152,7 +157,8 @@ class AccountsFragment : BaseFragment(), OnRefreshListener {
 
                 Constants.SHARE_ACCOUNTS -> {
                     val shareAccountList: List<ShareAccount?> =
-                        savedInstanceState.getParcelableArrayList(
+                        savedInstanceState.getCheckedArrayListFromParcelable(
+                            ShareAccount::class.java,
                             Constants.SHARE_ACCOUNTS,
                         ) ?: listOf()
                     showShareAccounts(shareAccountList)

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/AddGuarantorFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/AddGuarantorFragment.kt
@@ -23,6 +23,8 @@ import org.mifos.mobile.ui.enums.GuarantorState
 import org.mifos.mobile.ui.fragments.base.BaseFragment
 import org.mifos.mobile.utils.Constants
 import org.mifos.mobile.utils.GuarantorUiState
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedParcelable
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedSerializable
 import org.mifos.mobile.utils.RxBus.publish
 import org.mifos.mobile.utils.RxEvent.AddGuarantorEvent
 import org.mifos.mobile.utils.RxEvent.UpdateGuarantorEvent
@@ -51,16 +53,12 @@ class AddGuarantorFragment : BaseFragment() {
         super.onCreate(savedInstanceState)
         if (arguments != null) {
             loanId = arguments?.getLong(Constants.LOAN_ID)
-            guarantorState = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                arguments?.getSerializable(Constants.GUARANTOR_STATE, GuarantorState::class.java)
-            } else {
-                arguments?.getSerializable(Constants.GUARANTOR_STATE) as GuarantorState?
-            }
-            payload = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                arguments?.getParcelable(Constants.PAYLOAD, GuarantorPayload::class.java)
-            } else {
-                arguments?.getParcelable(Constants.PAYLOAD) as GuarantorPayload?
-            }
+            guarantorState = requireArguments().getCheckedSerializable(
+                GuarantorState::class.java,
+                Constants.GUARANTOR_STATE
+            ) as GuarantorState
+            payload =
+                arguments?.getCheckedParcelable(GuarantorPayload::class.java, Constants.PAYLOAD)
             index = arguments?.getInt(Constants.INDEX)
         }
     }

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/BeneficiaryApplicationFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/BeneficiaryApplicationFragment.kt
@@ -23,6 +23,8 @@ import org.mifos.mobile.ui.fragments.base.BaseFragment
 import org.mifos.mobile.utils.BeneficiaryUiState
 import org.mifos.mobile.utils.Constants
 import org.mifos.mobile.utils.Network
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedParcelable
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedSerializable
 import org.mifos.mobile.utils.Toaster
 import org.mifos.mobile.viewModels.BeneficiaryApplicationViewModel
 
@@ -47,16 +49,24 @@ class BeneficiaryApplicationFragment : BaseFragment() {
         super.onCreate(savedInstanceState)
         setToolbarTitle(getString(R.string.add_beneficiary))
         if (arguments != null) {
-            beneficiaryState = requireArguments()
-                .getSerializable(Constants.BENEFICIARY_STATE) as BeneficiaryState
+            beneficiaryState = requireArguments().getCheckedSerializable(
+                    BeneficiaryState::class.java,
+                    Constants.BENEFICIARY_STATE
+                ) as BeneficiaryState
             when (beneficiaryState) {
                 BeneficiaryState.UPDATE -> {
-                    beneficiary = arguments?.getParcelable(Constants.BENEFICIARY)
+                    beneficiary = arguments?.getCheckedParcelable(
+                        Beneficiary::class.java,
+                        Constants.BENEFICIARY
+                    )
                     setToolbarTitle(getString(R.string.update_beneficiary))
                 }
 
                 BeneficiaryState.CREATE_QR -> {
-                    beneficiary = arguments?.getParcelable(Constants.BENEFICIARY)
+                    beneficiary = arguments?.getCheckedParcelable(
+                        Beneficiary::class.java,
+                        Constants.BENEFICIARY
+                    )
                     setToolbarTitle(getString(R.string.add_beneficiary))
                 }
 
@@ -140,7 +150,12 @@ class BeneficiaryApplicationFragment : BaseFragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         if (savedInstanceState != null) {
-            showBeneficiaryTemplate(savedInstanceState.getParcelable<Parcelable>(Constants.TEMPLATE) as BeneficiaryTemplate)
+            showBeneficiaryTemplate(
+                savedInstanceState.getCheckedParcelable(
+                    BeneficiaryTemplate::class.java,
+                    Constants.TEMPLATE
+                )
+            )
         }
     }
 

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/BeneficiaryDetailFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/BeneficiaryDetailFragment.kt
@@ -24,6 +24,7 @@ import org.mifos.mobile.utils.BeneficiaryUiState
 import org.mifos.mobile.utils.Constants
 import org.mifos.mobile.utils.CurrencyUtil
 import org.mifos.mobile.utils.MaterialDialog
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedParcelable
 import org.mifos.mobile.utils.Toaster
 import org.mifos.mobile.viewModels.BeneficiaryDetailViewModel
 
@@ -42,7 +43,8 @@ class BeneficiaryDetailFragment : BaseFragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         if (arguments != null) {
-            beneficiary = arguments?.getParcelable(Constants.BENEFICIARY)
+            beneficiary =
+                arguments?.getCheckedParcelable(Beneficiary::class.java, Constants.BENEFICIARY)
         }
         setHasOptionsMenu(true)
     }

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/BeneficiaryListFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/BeneficiaryListFragment.kt
@@ -28,6 +28,7 @@ import org.mifos.mobile.utils.BeneficiaryUiState
 import org.mifos.mobile.utils.Constants
 import org.mifos.mobile.utils.DividerItemDecoration
 import org.mifos.mobile.utils.Network
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedArrayListFromParcelable
 import org.mifos.mobile.viewModels.BeneficiaryListViewModel
 
 /**
@@ -114,7 +115,10 @@ class BeneficiaryListFragment : BaseFragment(), OnRefreshListener {
         super.onActivityCreated(savedInstanceState)
         if (savedInstanceState != null) {
             val beneficiaries: List<Beneficiary?> =
-                savedInstanceState.getParcelableArrayList(Constants.BENEFICIARY) ?: listOf()
+                savedInstanceState.getCheckedArrayListFromParcelable(
+                    Beneficiary::class.java,
+                    Constants.BENEFICIARY
+                ) ?: listOf()
             showBeneficiaryList(beneficiaries)
         }
     }

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/ClientAccountsFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/ClientAccountsFragment.kt
@@ -32,6 +32,7 @@ import org.mifos.mobile.ui.adapters.ViewPagerAdapter
 import org.mifos.mobile.ui.enums.AccountType
 import org.mifos.mobile.ui.fragments.base.BaseFragment
 import org.mifos.mobile.utils.Constants
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedSerializable
 import org.mifos.mobile.utils.StatusUtils
 import org.mifos.mobile.viewModels.AccountsViewModel
 import javax.inject.Inject
@@ -56,7 +57,10 @@ class ClientAccountsFragment : BaseFragment() {
         super.onCreate(savedInstanceState)
         setHasOptionsMenu(true)
         if (arguments != null) {
-            accountType = arguments?.getSerializable(Constants.ACCOUNT_TYPE) as AccountType
+            accountType = arguments?.getCheckedSerializable(
+                AccountType::class.java,
+                Constants.ACCOUNT_TYPE
+            ) as AccountType
         }
     }
 

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/ClientChargeFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/ClientChargeFragment.kt
@@ -23,6 +23,8 @@ import org.mifos.mobile.ui.fragments.base.BaseFragment
 import org.mifos.mobile.utils.ClientChargeUiState
 import org.mifos.mobile.utils.Constants
 import org.mifos.mobile.utils.Network
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedArrayListFromParcelable
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedSerializable
 import org.mifos.mobile.utils.Toaster
 import org.mifos.mobile.viewModels.ClientChargeViewModel
 
@@ -48,7 +50,10 @@ class ClientChargeFragment : BaseFragment() {
         super.onCreate(savedInstanceState)
         if (arguments != null) {
             id = arguments?.getLong(Constants.CLIENT_ID)
-            chargeType = arguments?.getSerializable(Constants.CHARGE_TYPE) as ChargeType
+            chargeType = arguments?.getCheckedSerializable(
+                ChargeType::class.java,
+                Constants.CHARGE_TYPE
+            ) as ChargeType
         }
     }
 
@@ -121,8 +126,10 @@ class ClientChargeFragment : BaseFragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         if (savedInstanceState != null) {
-            val charges: List<Charge?> =
-                savedInstanceState.getParcelableArrayList(Constants.CHARGES) ?: listOf()
+            val charges: List<Charge?> = savedInstanceState.getCheckedArrayListFromParcelable(
+                    Charge::class.java,
+                    Constants.CHARGES
+                ) ?: listOf()
             showClientCharges(charges)
         }
     }

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/GuarantorDetailFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/GuarantorDetailFragment.kt
@@ -17,6 +17,7 @@ import org.mifos.mobile.ui.activities.base.BaseActivity
 import org.mifos.mobile.ui.enums.GuarantorState
 import org.mifos.mobile.ui.fragments.base.BaseFragment
 import org.mifos.mobile.utils.*
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedParcelable
 import org.mifos.mobile.utils.RxBus.listen
 import org.mifos.mobile.utils.RxBus.publish
 import org.mifos.mobile.utils.RxEvent.DeleteGuarantorEvent
@@ -44,7 +45,7 @@ class GuarantorDetailFragment : BaseFragment() {
         super.onCreate(savedInstanceState)
         if (arguments != null) {
             loanId = arguments?.getLong(Constants.LOAN_ID)
-            payload = arguments?.getParcelable(Constants.GUARANTOR_DETAILS)
+            payload = arguments?.getCheckedParcelable(GuarantorPayload::class.java, Constants.GUARANTOR_DETAILS)
             index = arguments?.getInt(Constants.INDEX)
             guarantorId = payload?.id
         }

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/LoanAccountSummaryFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/LoanAccountSummaryFragment.kt
@@ -11,6 +11,7 @@ import org.mifos.mobile.models.accounts.loan.LoanWithAssociations
 import org.mifos.mobile.ui.fragments.base.BaseFragment
 import org.mifos.mobile.utils.Constants
 import org.mifos.mobile.utils.CurrencyUtil
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedParcelable
 
 /*
 ~This project is licensed under the open source MPL V2.
@@ -26,7 +27,7 @@ class LoanAccountSummaryFragment : BaseFragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         if (arguments != null) {
-            loanWithAssociations = arguments?.getParcelable(Constants.LOAN_ACCOUNT)
+            loanWithAssociations = arguments?.getCheckedParcelable(LoanWithAssociations::class.java, Constants.LOAN_ACCOUNT)
         }
     }
 

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/LoanAccountTransactionFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/LoanAccountTransactionFragment.kt
@@ -24,6 +24,7 @@ import org.mifos.mobile.ui.fragments.base.BaseFragment
 import org.mifos.mobile.utils.Constants
 import org.mifos.mobile.utils.LoanUiState
 import org.mifos.mobile.utils.Network
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedParcelable
 import org.mifos.mobile.viewModels.LoanAccountTransactionViewModel
 import javax.inject.Inject
 
@@ -78,8 +79,12 @@ class LoanAccountTransactionFragment : BaseFragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         if (savedInstanceState != null) {
-            showLoanTransactions(savedInstanceState.getParcelable<Parcelable>(Constants.LOAN_ACCOUNT) as LoanWithAssociations)
-        }
+            showLoanTransactions(
+                savedInstanceState.getCheckedParcelable(
+                    LoanWithAssociations::class.java,
+                    Constants.LOAN_ACCOUNT
+                )
+            )        }
     }
 
     /**

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/LoanAccountWithdrawFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/LoanAccountWithdrawFragment.kt
@@ -18,6 +18,7 @@ import org.mifos.mobile.ui.fragments.base.BaseFragment
 import org.mifos.mobile.utils.Constants
 import org.mifos.mobile.utils.DateHelper
 import org.mifos.mobile.utils.LoanUiState
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedParcelable
 import org.mifos.mobile.utils.Toaster
 import org.mifos.mobile.viewModels.LoanAccountWithdrawViewModel
 
@@ -36,7 +37,7 @@ class LoanAccountWithdrawFragment : BaseFragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         if (arguments != null) {
-            loanWithAssociations = arguments?.getParcelable(Constants.LOAN_ACCOUNT)
+            loanWithAssociations = arguments?.getCheckedParcelable(LoanWithAssociations::class.java, Constants.LOAN_ACCOUNT)
         }
     }
 

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/LoanAccountsDetailFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/LoanAccountsDetailFragment.kt
@@ -21,6 +21,7 @@ import org.mifos.mobile.ui.enums.ChargeType
 import org.mifos.mobile.ui.enums.LoanState
 import org.mifos.mobile.ui.fragments.base.BaseFragment
 import org.mifos.mobile.utils.*
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedParcelable
 import org.mifos.mobile.viewModels.LoanAccountsDetailViewModel
 import javax.inject.Inject
 
@@ -78,7 +79,7 @@ class LoanAccountsDetailFragment : BaseFragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         if (savedInstanceState != null) {
-            showLoanAccountsDetail(savedInstanceState.getParcelable<Parcelable>(Constants.LOAN_ACCOUNT) as LoanWithAssociations)
+            showLoanAccountsDetail(savedInstanceState.getCheckedParcelable(LoanWithAssociations::class.java, Constants.LOAN_ACCOUNT))
         }
     }
 

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/LoanApplicationFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/LoanApplicationFragment.kt
@@ -24,6 +24,8 @@ import org.mifos.mobile.ui.enums.LoanState
 import org.mifos.mobile.ui.fragments.ReviewLoanApplicationFragment.Companion.newInstance
 import org.mifos.mobile.ui.fragments.base.BaseFragment
 import org.mifos.mobile.utils.*
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedParcelable
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedSerializable
 import org.mifos.mobile.viewModels.LoanApplicationViewModel
 import java.text.SimpleDateFormat
 import java.time.Instant
@@ -99,12 +101,18 @@ class LoanApplicationFragment : BaseFragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         if (arguments != null) {
-            loanState = arguments?.getSerializable(Constants.LOAN_STATE) as LoanState
+            loanState = arguments?.getCheckedSerializable(
+                LoanState::class.java,
+                Constants.LOAN_STATE
+            ) as LoanState
             if (loanState == LoanState.CREATE) {
                 setToolbarTitle(getString(R.string.apply_for_loan))
             } else {
                 setToolbarTitle(getString(R.string.update_loan))
-                loanWithAssociations = arguments?.getParcelable(Constants.LOAN_ACCOUNT)
+                loanWithAssociations = arguments?.getCheckedParcelable(
+                    LoanWithAssociations::class.java,
+                    Constants.LOAN_ACCOUNT
+                )
             }
         }
     }
@@ -131,7 +139,10 @@ class LoanApplicationFragment : BaseFragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         if (savedInstanceState != null) {
-            val template: LoanTemplate? = savedInstanceState.getParcelable(Constants.TEMPLATE)
+            val template: LoanTemplate? = savedInstanceState.getCheckedParcelable(
+                LoanTemplate::class.java,
+                Constants.TEMPLATE
+            )
             if (loanState == LoanState.CREATE) {
                 showLoanTemplate(template)
             } else {

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/LoanRepaymentScheduleFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/LoanRepaymentScheduleFragment.kt
@@ -27,6 +27,7 @@ import org.mifos.mobile.utils.Constants
 import org.mifos.mobile.utils.DateHelper
 import org.mifos.mobile.utils.LoanUiState
 import org.mifos.mobile.utils.Network
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedParcelable
 import org.mifos.mobile.viewModels.LoanRepaymentScheduleViewModel
 import javax.inject.Inject
 
@@ -106,7 +107,12 @@ class LoanRepaymentScheduleFragment : BaseFragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         if (savedInstanceState != null) {
-            showLoanRepaymentSchedule(savedInstanceState.getParcelable<Parcelable>(Constants.LOAN_ACCOUNT) as LoanWithAssociations)
+            showLoanRepaymentSchedule(
+                savedInstanceState.getCheckedParcelable(
+                    LoanWithAssociations::class.java,
+                    Constants.LOAN_ACCOUNT
+                )
+            )
         }
     }
 

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/QrCodeImportFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/QrCodeImportFragment.kt
@@ -26,6 +26,7 @@ import org.mifos.mobile.ui.activities.base.BaseActivity
 import org.mifos.mobile.ui.enums.BeneficiaryState
 import org.mifos.mobile.ui.fragments.base.BaseFragment
 import org.mifos.mobile.utils.Constants
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedParcelable
 import org.mifos.mobile.utils.QrCodeUiState
 import org.mifos.mobile.utils.Toaster
 import org.mifos.mobile.viewModels.QrCodeImportViewModel
@@ -120,8 +121,8 @@ class QrCodeImportFragment : BaseFragment() {
         super.onActivityCreated(savedInstanceState)
         if (savedInstanceState != null) {
             // restore data
-            mFrameRect = savedInstanceState.getParcelable(Constants.FRAME_RECT)
-            qrUri = savedInstanceState.getParcelable(Constants.SOURCE_URI)!!
+            mFrameRect = savedInstanceState.getCheckedParcelable(RectF::class.java, Constants.FRAME_RECT)
+            qrUri = savedInstanceState.getCheckedParcelable(Uri::class.java, Constants.SOURCE_URI)!!
         }
     }
 

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/RecentTransactionsFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/RecentTransactionsFragment.kt
@@ -25,6 +25,7 @@ import org.mifos.mobile.ui.adapters.RecentTransactionListAdapter
 import org.mifos.mobile.ui.fragments.base.BaseFragment
 import org.mifos.mobile.utils.*
 import org.mifos.mobile.utils.Network.isConnected
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedArrayListFromParcelable
 import org.mifos.mobile.viewModels.RecentTransactionViewModel
 import javax.inject.Inject
 
@@ -116,7 +117,10 @@ class RecentTransactionsFragment : BaseFragment(), OnRefreshListener {
         super.onActivityCreated(savedInstanceState)
         if (savedInstanceState != null) {
             val transactions: List<Transaction?> =
-                savedInstanceState.getParcelableArrayList(Constants.RECENT_TRANSACTIONS) ?: listOf()
+                savedInstanceState.getCheckedArrayListFromParcelable(
+                    Transaction::class.java,
+                    Constants.RECENT_TRANSACTIONS,
+                ) ?: listOf()
             showRecentTransactions(transactions)
         }
     }

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/ReviewLoanApplicationFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/ReviewLoanApplicationFragment.kt
@@ -17,6 +17,8 @@ import org.mifos.mobile.ui.enums.LoanState
 import org.mifos.mobile.ui.fragments.base.BaseFragment
 import org.mifos.mobile.utils.MFErrorParser
 import org.mifos.mobile.utils.Network
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedParcelable
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedSerializable
 import org.mifos.mobile.utils.ReviewLoanApplicationUiState
 import org.mifos.mobile.utils.Toaster
 import org.mifos.mobile.viewModels.ReviewLoanApplicationViewModel
@@ -80,11 +82,11 @@ class ReviewLoanApplicationFragment : BaseFragment() {
         savedInstanceState: Bundle?,
     ): View {
         _binding = FragmentReviewLoanApplicationBinding.inflate(inflater, container, false)
-        val loanState = arguments?.getSerializable(LOAN_STATE) as LoanState
+        val loanState = arguments?.getCheckedSerializable(LoanState::class.java, LOAN_STATE) as LoanState
         if (loanState == LoanState.CREATE) {
             viewModel.insertData(
                 loanState,
-                arguments?.getParcelable(LOANS_PAYLOAD)!!,
+                arguments?.getCheckedParcelable(LoansPayload::class.java, LOANS_PAYLOAD)!!,
                 arguments?.getString(LOAN_NAME)!!,
                 arguments?.getString(ACCOUNT_NO)!!,
             )
@@ -92,7 +94,7 @@ class ReviewLoanApplicationFragment : BaseFragment() {
             viewModel.insertData(
                 loanState,
                 arguments?.getLong(LOAN_ID)!!,
-                arguments?.getParcelable(LOANS_PAYLOAD)!!,
+                arguments?.getCheckedParcelable(LoansPayload::class.java, LOANS_PAYLOAD)!!,
                 arguments?.getString(LOAN_NAME)!!,
                 arguments?.getString(ACCOUNT_NO)!!,
             )

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/SavingAccountsDetailFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/SavingAccountsDetailFragment.kt
@@ -32,6 +32,7 @@ import org.mifos.mobile.utils.Constants
 import org.mifos.mobile.utils.CurrencyUtil
 import org.mifos.mobile.utils.DateHelper
 import org.mifos.mobile.utils.Network
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedParcelable
 import org.mifos.mobile.utils.QrCodeGenerator
 import org.mifos.mobile.utils.SavingsAccountUiState
 import org.mifos.mobile.utils.SymbolsUtils
@@ -152,8 +153,12 @@ class SavingAccountsDetailFragment : BaseFragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         if (savedInstanceState != null) {
-            showSavingAccountsDetail(savedInstanceState.getParcelable<Parcelable>(Constants.SAVINGS_ACCOUNTS) as SavingsWithAssociations)
-        }
+            showSavingAccountsDetail(
+                savedInstanceState.getCheckedParcelable(
+                    SavingsWithAssociations::class.java,
+                    Constants.SAVINGS_ACCOUNTS
+                )
+            )        }
     }
 
     /**

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/SavingAccountsTransactionFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/SavingAccountsTransactionFragment.kt
@@ -39,6 +39,7 @@ import org.mifos.mobile.utils.DateHelper
 import org.mifos.mobile.utils.DatePick
 import org.mifos.mobile.utils.DividerItemDecoration
 import org.mifos.mobile.utils.Network
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedParcelable
 import org.mifos.mobile.utils.SavingsAccountUiState
 import org.mifos.mobile.utils.StatusUtils
 import org.mifos.mobile.utils.Toaster
@@ -155,8 +156,12 @@ class SavingAccountsTransactionFragment : BaseFragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         if (savedInstanceState != null) {
-            showSavingAccountsDetail(savedInstanceState.getParcelable<Parcelable>(Constants.SAVINGS_ACCOUNTS) as SavingsWithAssociations)
-        }
+            showSavingAccountsDetail(
+                savedInstanceState.getCheckedParcelable(
+                    SavingsWithAssociations::class.java,
+                    Constants.SAVINGS_ACCOUNTS
+                )
+            )        }
     }
 
     /**

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/SavingsAccountApplicationFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/SavingsAccountApplicationFragment.kt
@@ -23,6 +23,8 @@ import org.mifos.mobile.ui.enums.SavingsAccountState
 import org.mifos.mobile.ui.fragments.base.BaseFragment
 import org.mifos.mobile.utils.Constants
 import org.mifos.mobile.utils.DateHelper
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedParcelable
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedSerializable
 import org.mifos.mobile.utils.SavingsAccountUiState
 import org.mifos.mobile.utils.Toaster
 import org.mifos.mobile.utils.getTodayFormatted
@@ -51,9 +53,14 @@ class SavingsAccountApplicationFragment : BaseFragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         if (arguments != null) {
-            state = requireArguments()
-                .getSerializable(Constants.SAVINGS_ACCOUNT_STATE) as SavingsAccountState
-            savingsWithAssociations = arguments?.getParcelable(Constants.SAVINGS_ACCOUNTS)
+            state = requireArguments().getCheckedSerializable(
+                SavingsAccountState::class.java,
+                Constants.SAVINGS_ACCOUNT_STATE
+            ) as SavingsAccountState
+            savingsWithAssociations = arguments?.getCheckedParcelable(
+                SavingsWithAssociations::class.java,
+                Constants.SAVINGS_ACCOUNTS
+            )
         }
     }
 

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/SavingsAccountWithdrawFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/SavingsAccountWithdrawFragment.kt
@@ -16,6 +16,7 @@ import org.mifos.mobile.models.accounts.savings.SavingsAccountWithdrawPayload
 import org.mifos.mobile.models.accounts.savings.SavingsWithAssociations
 import org.mifos.mobile.ui.fragments.base.BaseFragment
 import org.mifos.mobile.utils.Constants
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedParcelable
 import org.mifos.mobile.utils.SavingsAccountUiState
 import org.mifos.mobile.utils.Toaster
 import org.mifos.mobile.utils.getTodayFormatted
@@ -35,8 +36,10 @@ class SavingsAccountWithdrawFragment : BaseFragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         if (arguments != null) {
-            savingsWithAssociations = arguments?.getParcelable(Constants.SAVINGS_ACCOUNTS)
-        }
+            savingsWithAssociations = arguments?.getCheckedParcelable(
+                SavingsWithAssociations::class.java,
+                Constants.SAVINGS_ACCOUNTS
+            )        }
     }
 
     override fun onCreateView(

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/SavingsMakeTransferFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/SavingsMakeTransferFragment.kt
@@ -29,6 +29,7 @@ import org.mifos.mobile.ui.fragments.base.BaseFragment
 import org.mifos.mobile.utils.Constants
 import org.mifos.mobile.utils.DateHelper
 import org.mifos.mobile.utils.Network
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedParcelable
 import org.mifos.mobile.utils.SavingsAccountUiState
 import org.mifos.mobile.utils.Toaster
 import org.mifos.mobile.utils.Utils
@@ -147,8 +148,12 @@ class SavingsMakeTransferFragment : BaseFragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         if (savedInstanceState != null) {
-            showSavingsAccountTemplate(savedInstanceState.getParcelable<Parcelable>(Constants.TEMPLATE) as AccountOptionsTemplate)
-        }
+            showSavingsAccountTemplate(
+                savedInstanceState.getCheckedParcelable(
+                    AccountOptionsTemplate::class.java,
+                    Constants.TEMPLATE
+                )
+            )        }
     }
 
     /**

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/ThirdPartyTransferFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/ThirdPartyTransferFragment.kt
@@ -35,6 +35,8 @@ import org.mifos.mobile.ui.fragments.base.BaseFragment
 import org.mifos.mobile.utils.Constants
 import org.mifos.mobile.utils.DateHelper
 import org.mifos.mobile.utils.Network
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedArrayListFromParcelable
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedParcelable
 import org.mifos.mobile.utils.ThirdPartyTransferUiState
 import org.mifos.mobile.utils.Toaster
 import org.mifos.mobile.utils.Utils
@@ -159,10 +161,17 @@ class ThirdPartyTransferFragment : BaseFragment(), OnItemSelectedListener {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         if (savedInstanceState != null) {
-            showThirdPartyTransferTemplate(savedInstanceState.getParcelable<Parcelable>(Constants.TEMPLATE) as AccountOptionsTemplate)
-            val tempBeneficiaries: List<Beneficiary?> = savedInstanceState.getParcelableArrayList(
-                Constants.BENEFICIARY,
-            ) ?: listOf()
+            showThirdPartyTransferTemplate(
+                savedInstanceState.getCheckedParcelable(
+                    AccountOptionsTemplate::class.java,
+                    Constants.TEMPLATE
+                )
+            )
+            val tempBeneficiaries: List<Beneficiary?> =
+                savedInstanceState.getCheckedArrayListFromParcelable(
+                    Beneficiary::class.java,
+                    Constants.BENEFICIARY,
+                ) ?: listOf()
             showBeneficiaryList(tempBeneficiaries)
         }
     }

--- a/app/src/main/java/org/mifos/mobile/ui/fragments/TransferProcessFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/fragments/TransferProcessFragment.kt
@@ -23,6 +23,8 @@ import org.mifos.mobile.utils.CurrencyUtil
 import org.mifos.mobile.utils.DateHelper
 import org.mifos.mobile.utils.MFErrorParser
 import org.mifos.mobile.utils.Network
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedParcelable
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedSerializable
 import org.mifos.mobile.utils.Toaster
 import org.mifos.mobile.utils.TransferUiState
 import org.mifos.mobile.utils.getTodayFormatted
@@ -48,8 +50,15 @@ class TransferProcessFragment : BaseFragment() {
         super.onCreate(savedInstanceState)
         if (activity != null) {
             payload = arguments?.getParcelable(Constants.PAYLOAD)
-            transferType = arguments?.getSerializable(Constants.TRANSFER_TYPE) as TransferType
-        }
+            payload =
+                arguments?.getCheckedParcelable(
+                    TransferPayload::class.java,
+                    Constants.PAYLOAD
+                )
+            transferType = arguments?.getCheckedSerializable(
+                TransferType::class.java,
+                Constants.TRANSFER_TYPE
+            ) as TransferType        }
     }
 
     override fun onCreateView(

--- a/app/src/main/java/org/mifos/mobile/ui/user_profile/UserProfileFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/user_profile/UserProfileFragment.kt
@@ -27,6 +27,7 @@ import org.mifos.mobile.ui.getThemeAttributeColor
 import org.mifos.mobile.utils.Constants
 import org.mifos.mobile.utils.DateHelper
 import org.mifos.mobile.utils.Network
+import org.mifos.mobile.utils.ParcelableAndSerializableUtils.getCheckedParcelable
 import org.mifos.mobile.utils.TextDrawable
 import org.mifos.mobile.utils.Toaster
 import org.mifos.mobile.utils.UserDetailUiState
@@ -116,7 +117,10 @@ class UserProfileFragment : BaseFragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         if (savedInstanceState != null) {
-            client = savedInstanceState.getParcelable(Constants.USER_DETAILS)
+            client = savedInstanceState.getCheckedParcelable(
+                Client::class.java,
+                Constants.USER_DETAILS
+            )
             viewModel.setUserProfile(preferencesHelper?.userProfileImage)
             showUserDetails(client)
         }

--- a/app/src/main/java/org/mifos/mobile/utils/ParcelableAndSerializableUtils.kt
+++ b/app/src/main/java/org/mifos/mobile/utils/ParcelableAndSerializableUtils.kt
@@ -1,0 +1,32 @@
+package org.mifos.mobile.utils
+
+import android.os.Build
+import android.os.Bundle
+import java.io.Serializable
+
+object ParcelableAndSerializableUtils {
+
+    fun <T> Bundle.getCheckedArrayListFromParcelable(classType: Class<T>, key: String): List<T>? {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            this.getParcelableArrayList(key, classType)
+        } else {
+            this.getParcelableArrayList(key)
+        }
+    }
+
+    fun <T> Bundle.getCheckedParcelable(classType: Class<T>, key: String): T? {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            this.getParcelable(key, classType)
+        } else {
+            this.getParcelable(key)
+        }
+    }
+
+    fun <T : Serializable> Bundle.getCheckedSerializable(classType: Class<T>, key: String): Any? {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            this.getSerializable(key, classType)
+        } else {
+            this.getSerializable(key)
+        }
+    }
+}


### PR DESCRIPTION
Fixes: #2395 

Added SDK Checks for the Deprecated Parcelable and Serializable Functions.

Made an Object Class ParcelableAndSerializableUtils to do all the work to reduce redundancy in the code and refactored the activities and fragments containing the deprecated  Parcelable and Serializable Functions.

```
object ParcelableAndSerializableUtils {

    fun <T> Bundle.getCheckedArrayListFromParcelable(classType: Class<T>, key: String): List<T>? {
        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
            this.getParcelableArrayList(key, classType)
        } else {
            this.getParcelableArrayList(key)
        }
    }

    fun <T> Bundle.getCheckedParcelable(classType: Class<T>, key: String): T? {
        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
            this.getParcelable(key, classType)
        } else {
            this.getParcelable(key)
        }
    }

    fun <T : Serializable> Bundle.getCheckedSerializable(classType: Class<T>, key: String): Any? {
        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
            this.getSerializable(key, classType)
        } else {
            this.getSerializable(key)
        }
    }

}
```