### PR TITLE
docs: Update slack invitation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ An Android Application built on top of the MifosX Self-Service platform for end-
 
 ## Join Us on Slack
 
-Mifos boasts an active and vibrant contributor community, Please join us on [slack](https://mifos.slack.com/). Once you've joined the mifos slack community, please join the `#mifos-mobile` channel to engage with mifos-mobile development. If you encounter any difficulties joining our Slack channel, please don't hesitate to open an issue. This will allow us to assist you promptly or send you an invitation.
+Mifos boasts an active and vibrant contributor community, Please join us on [slack](https://join.slack.com/t/mifos/shared_invite/zt-2f4nr6tk3-ZJlHMi1lc0R19FFEHxdvng). Once you've joined the mifos slack community, please join the `#mifos-mobile` channel to engage with mifos-mobile development. If you encounter any difficulties joining our Slack channel, please don't hesitate to open an issue. This will allow us to assist you promptly or send you an invitation.
 
 
 


### PR DESCRIPTION
Fixes #2535 
I see people are not able to join the slack community with https://mifos.slack.com/ because its not a invitation link and just a workspace link.
Updated the slack link to https://join.slack.com/t/mifos/shared_invite/zt-2f4nr6tk3-ZJlHMi1lc0R19FFEHxdvng which is a invitation link of workspace whose expiry sets to never.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [ ] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [ ] If you have multiple commits please combine them into one commit by squashing them.