### PR TITLE
fix: It will now show an error message for invalid phone numbers.

### DIFF
--- a/app/src/main/java/org/mifos/mobile/ui/registration/RegistrationFragment.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/registration/RegistrationFragment.kt
@@ -180,6 +180,14 @@ class RegistrationFragment : BaseFragment() {
                 false
             }
 
+            viewModel.isPhoneNumberNotValid(phoneNumberContent) ->{
+                Toaster.show(
+                    view,
+                    getString(R.string.invalid_phn_number),
+                )
+                false
+            }
+
             viewModel.isInputFieldBlank(emailContent) -> {
                 Toaster.show(
                     view,

--- a/app/src/main/java/org/mifos/mobile/ui/registration/RegistrationViewModel.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/registration/RegistrationViewModel.kt
@@ -37,6 +37,10 @@ class RegistrationViewModel @Inject constructor(private val userAuthRepositoryIm
         return fieldText.trim().contains(" ")
     }
 
+    fun isPhoneNumberNotValid(fieldText: String): Boolean{
+        return fieldText.toIntOrNull() == null
+    }
+
     fun hasLeadingTrailingSpaces(fieldText: String): Boolean {
         return fieldText.trim().length < fieldText.length
     }

--- a/app/src/main/java/org/mifos/mobile/ui/registration/RegistrationViewModel.kt
+++ b/app/src/main/java/org/mifos/mobile/ui/registration/RegistrationViewModel.kt
@@ -38,7 +38,7 @@ class RegistrationViewModel @Inject constructor(private val userAuthRepositoryIm
     }
 
     fun isPhoneNumberNotValid(fieldText: String): Boolean{
-        return fieldText.toIntOrNull() == null
+        return fieldText.trim().toIntOrNull() == null
     }
 
     fun hasLeadingTrailingSpaces(fieldText: String): Boolean {


### PR DESCRIPTION


![image](https://github.com/openMF/mifos-mobile/assets/78101731/a3f66d82-270e-4186-823a-9d0d61b3674b)

A phone number is invalid if it contains anything other than numbers



Please make sure these boxes are checked before submitting your pull request - thanks!
- [ ] Apply the AndroidStyle.xml style template to your code in Android Studio.
- [ ] Run the unit tests with ./gradlew check to make sure you didn't break anything
- [ ]  If you have multiple commits please combine them into one commit by squashing them