### PR TITLE
Fix: Update workflows to build androidApp module

### DIFF
--- a/.github/actions/inflate-secrets/action.yml
+++ b/.github/actions/inflate-secrets/action.yml
@@ -16,26 +16,25 @@ runs:
     - name: Mock debug google-services.json
       shell: bash
       run: |
-        cp .github/mock-google-services.json androdiApp/src/demo/google-services.json
-        cp .github/mock-google-services.json androdiApp/src/prod/google-services.json
+        cp .github/mock-google-services.json androidApp/src/google-services.json
 
     - name: Inflate release_keystore.keystore
       shell: bash
       env:
         KEYSTORE: ${{ inputs.keystore }}
       run: | 
-        echo $KEYSTORE | base64 --decode > androdiApp/release_keystore.keystore
+        echo $KEYSTORE | androidApp/release_keystore.keystore
 
     - name: Inflate google-services.json
       shell: bash
       env:
         GOOGLE_SERVICES: ${{ inputs.google-services }}
       run: |
-        echo $GOOGLE_SERVICES > androdiApp/google-services.json
+        echo $GOOGLE_SERVICES > androidApp/google-services.json
 
     - name: Inflate playStorePublishServiceCredentialsFile.json
       shell: bash
       env:
         CREDS: ${{ inputs.playstore-creds }}
       run: |
-        echo $CREDS > androdiApp/playStorePublishServiceCredentialsFile.json
+        echo $CREDS > androidApp/playStorePublishServiceCredentialsFile.json

--- a/.github/workflows/onPush.yml
+++ b/.github/workflows/onPush.yml
@@ -63,7 +63,7 @@ jobs:
           KEYSTORE_ALIAS_PASSWORD: ${{ secrets.ORIGINAL_KEYSTORE_ALIAS_PASSWORD }}
           VERSION_CODE: ${{ steps.rel_number.outputs.version-code }}
         run: |
-          ./gradlew :mifospay:assembleRelease
+          ./gradlew :androidApp:assembleRelease
 
       - name: Archive Build
         uses: actions/upload-artifact@v4
@@ -76,20 +76,19 @@ jobs:
         env:
           VERSION_CODE: ${{ steps.rel_number.outputs.version-code }}
         run: |
-          echo $VERSION_CODE > ./app/build/outputs/version_code.txt
+          echo $VERSION_CODE > ./androidApp/build/outputs/version_code.txt
 
       - name: Create Github Pre-Release
         if: github.event.inputs.beta == 'true'
         uses: softprops/action-gh-release@v2.0.8
         with:
           tag_name: ${{ steps.rel_number.outputs.version }}
-          body_path: ./app/build/outputs/changelogGithub
+          body_path: ./androidApp/build/outputs/changelogGithub
           draft: false
           prerelease: true
           files: |
-            ./mifospay/build/outputs/apk/demo/release/mifospay-demo-release.apk
-            ./mifospay/build/outputs/apk/prod/release/mifospay-prod-release.apk
-            ./mifospay/build/outputs/version_code.txt
+            ./androidApp/build/outputs/apk/release/androidApp-release.apk
+            ./androidApp/build/outputs/version_code.txt
 
       - name: Print `git status`
         run: git status
@@ -144,7 +143,7 @@ jobs:
           KEYSTORE_ALIAS_PASSWORD: ${{ secrets.UPLOAD_KEYSTORE_ALIAS_PASSWORD }}
           VERSION_CODE: ${{ steps.rel_number.outputs.version-code }}
         run: |
-          ./gradlew :mifospay:bundleRelease
+          ./gradlew :androidApp:bundleRelease
 
       - name: Deploy to Playstore Internal
         run: bundle exec fastlane deploy_internal

--- a/fastlane/AppFile
+++ b/fastlane/AppFile
@@ -1,2 +1,2 @@
-json_key_file("") # Path to the json secret file - Follow https://docs.fastlane.tools/actions/supply/#setup to get one
-package_name(ENV["STAGING_PACKAGE_NAME"]) # e.g. org.mifospay.demo
+json_key_file("app/playStorePublishServiceCredentialsFile.json")
+package_name("org.mifos.mobile") # e.g. org.mifos.mobile


### PR DESCRIPTION
This commit updates the workflows to build the androidApp module instead of the mifospay module.

The following
 changes were made:

- Updated the `onPush.yml` workflow to build and archive the `androidApp` module.
- Updated the `inflate-secrets` action to use the `androidApp` module.
- Updated the `AppFile` to use the correct package name and credentials file.

Fixes #Issue_Number

Please Add Screenshots If there are any UI changes.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [ ] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [ ] If you have multiple commits please combine them into one commit by squashing them.