### PR TITLE
Fix: Update workflows to build androidApp module

### DIFF
--- a/fastlane/FastFile
+++ b/fastlane/FastFile
@@ -5,7 +5,7 @@ platform :android do
   lane :deploy_internal do
     supply(
       track: 'internal',
-      aab: 'app/build/outputs/bundle/prod/app-prod-release.aab',
+      aab: 'androidApp/build/outputs/bundle/androidApp-release.aab',
       skip_upload_metadata: true,
       skip_upload_images: true,
       skip_upload_screenshots: true,
@@ -34,27 +34,4 @@ platform :android do
     )
   end
 
-  desc "Prep Amazon Appstore submission"
-  lane :prep_amazon do
-    amazon_app_submission(
-        client_id: ENV["AMAZON_APPSTORE_CLIENT_ID"],
-        client_secret: ENV["AMAZON_APPSTORE_CLIENT_SECRET"],
-        app_id: ENV["AMAZON_APPSTORE_APP_ID"],
-        apk_path: "app/build/outputs/apk/prod/release/app-prod-release.apk",
-        upload_apk: true,
-        changelogs_path:  "fastlane/metadata/android/en-US/changelogs/",
-        upload_changelogs: true,
-        submit_for_review: false
-      )
-  end
-
-  desc "Submit to Amazon Appstore"
-  lane :submit_amazon do
-    amazon_app_submission(
-        client_id: ENV["AMAZON_APPSTORE_CLIENT_ID"],
-        client_secret: ENV["AMAZON_APPSTORE_CLIENT_SECRET"],
-        app_id: ENV["AMAZON_APPSTORE_APP_ID"],
-        submit_for_review: true
-      )
-  end
 end


### PR DESCRIPTION
This commit updates the workflows to build the androidApp module instead of the mifospay module.

The following
 changes were made:

- Updated the `onPush.yml` workflow to build and archive the `androidApp` module.
- Updated the `inflate-secrets` action to use the `androidApp` module.
- Updated the `AppFile` to use the correct package name and credentials file.

Fixes #Issue_Number

Please Add Screenshots If there are any UI changes.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Apply the `AndroidStyle.xml` style template to your code in Android Studio.

- [ ] Run the unit tests with `./gradlew check` to make sure you didn't break anything

- [ ] If you have multiple commits please combine them into one commit by squashing them.