### PR TITLE
fix: #2708 adapt login screen background to dark mode

### DIFF
--- a/feature/auth/src/main/java/org/mifos/mobile/feature/auth/login/screens/LoginScreen.kt
+++ b/feature/auth/src/main/java/org/mifos/mobile/feature/auth/login/screens/LoginScreen.kt
@@ -11,6 +11,7 @@ package org.mifos.mobile.feature.auth.login.screens
 
 import android.content.Context
 import android.widget.Toast
+import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -111,7 +112,8 @@ private fun LoginScreen(
 
     Box(
         modifier = modifier
-            .fillMaxSize(),
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
     ) {
         LoginContent(
             login = login,


### PR DESCRIPTION
Resolved an issue where the login screen background did not change when dark mode was enabled. Now the background adapts correctly to the system theme, ensuring consistency in both light and dark modes.

Fixes #2708