### PR TITLE
fix: Fix visibility issues in Saving Account Withdraw screen

### DIFF
--- a/feature/savings/src/main/java/org/mifos/mobile/feature/savings/savingsAccountWithdraw/SavingsAccountWithdrawScreen.kt
+++ b/feature/savings/src/main/java/org/mifos/mobile/feature/savings/savingsAccountWithdraw/SavingsAccountWithdrawScreen.kt
@@ -76,7 +76,11 @@ private fun SavingsAccountWithdrawScreen(
 ) {
     val context = LocalContext.current
 
-    Column(modifier = modifier.fillMaxSize()) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+    ) {
         MifosTopBar(
             navigateBack = { navigateBack(false) },
             title = { Text(text = stringResource(id = R.string.withdraw_savings_account)) },


### PR DESCRIPTION
Changed background color to make fields visible in dark mode.

<img width="421" alt="Screenshot 2024-12-24 at 10 56 43" src="https://github.com/user-attachments/assets/c0ed551b-6575-4774-bc91-5b03cf61e338" />
<img width="421" alt="Screenshot 2024-12-24 at 15 41 13" src="https://github.com/user-attachments/assets/1a7766ef-ed55-4af8-8c48-6f8c454362e4" />
