### PR TITLE
fix: Resolve crash when accessing OSS license activity

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -59,11 +59,13 @@
         <activity
             android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity"
             android:configChanges="orientation|screenSize"
-            android:windowSoftInputMode="adjustResize" />
+            android:windowSoftInputMode="adjustResize"
+            android:theme="@style/Theme.AppCompat.DayNight" />
         <activity
             android:name="com.google.android.gms.oss.licenses.OssLicensesActivity"
             android:configChanges="orientation|screenSize"
-            android:windowSoftInputMode="adjustResize" />
+            android:windowSoftInputMode="adjustResize"
+            android:theme="@style/Theme.AppCompat.DayNight" />
 
         <provider
             android:name="androidx.core.content.FileProvider"


### PR DESCRIPTION

Added Theme.AppCompat.DayNight to OssLicensesActivity and 
OssLicensesMenuActivity in AndroidManifest to resolve the crash occurring 
when navigating to these activities. This ensures proper theme 
compatibility and prevents runtime issues.