### PR TITLE
 fix(#2466): background color of splash screen doesn't change with theme 

### DIFF
--- a/androidApp/src/main/res/drawable/splash_icon.xml
+++ b/androidApp/src/main/res/drawable/splash_icon.xml
@@ -10,12 +10,12 @@
 -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
-        <color android:color="@color/white" />
+        <color android:color="@color/splash_background" />
     </item>
 
     <item
-        android:width="160dp"
-        android:height="160dp"
+        android:width="80dp"
+        android:height="80dp"
         android:drawable="@drawable/mifos_splash_screen_logo"
         android:gravity="center" />
 </layer-list>

--- a/androidApp/src/main/res/values-night/colors.xml
+++ b/androidApp/src/main/res/values-night/colors.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2025 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+    <color name="splash_background">@color/splash_background_dark</color>
+    <color name="splash_background_dark" >#FF1A1A1A</color>
+</resources>

--- a/androidApp/src/main/res/values/colors.xml
+++ b/androidApp/src/main/res/values/colors.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
     Copyright 2024 Mifos Initiative
 
     This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
@@ -9,6 +8,12 @@
     See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
 -->
 <resources>
+
+    //fix : splash background
+    <color name="splash_background">@color/splash_background_light</color>
+    <color name="splash_background_light">#FFFDFDF5</color>
+    <color name="splash_background_dark">#FF1A1A1A</color>
+
     <color name="white">#ffffffff</color>
     <color name="black">#000000</color>
     <color name="background">#eaeaea</color>

--- a/androidApp/src/main/res/values/splash.xml
+++ b/androidApp/src/main/res/values/splash.xml
@@ -10,7 +10,7 @@
 -->
 <resources>
     <style name="Theme.MifosSplash" parent="Theme.SplashScreen">
-        <item name="windowSplashScreenBackground">#FFFDFDF5</item>
+        <item name="windowSplashScreenBackground">@color/splash_background</item>
         <item name="windowSplashScreenAnimatedIcon">@drawable/splash_icon</item>
         <item name="postSplashScreenTheme">@style/AppTheme</item>
         <item name="windowSplashScreenAnimationDuration">10</item>


### PR DESCRIPTION
* fix: background color of splash screen doesn't change with theme (#2466)

Changed splash background colour with  theme and fixed the splash icon size.

[mifos_splash_solved.webm](https://github.com/user-attachments/assets/85f2b492-1ce8-486b-a43c-fba37178be70)