### PR TITLE
chore: update workflow for demo app upload

### DIFF
--- a/.github/workflows/upload-demo-app-on-firebase.yaml
+++ b/.github/workflows/upload-demo-app-on-firebase.yaml
@@ -3,11 +3,6 @@ name: Upload Demo App on Firebase
 on:
   workflow_dispatch:
     inputs:
-      label:
-        description: 'Run tests and upload demo app on Firebase'
-        required: true
-        default: 'firebase-test-on'
-        type: string
       tester_groups:
         description: 'Comma-separated list of tester groups'
         required: true
@@ -16,11 +11,18 @@ on:
 
   pull_request:
     types: [ synchronize, opened, reopened, edited, closed, labeled ]
+    branches:
+      - 'development'
+      - 'master'
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   upload_demo_app_on_firebase:
     runs-on: macos-latest
-    if: github.event.label.name == github.event.inputs.label
+    if: github.event.label.name == 'firebase-test-on'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/upload-demo-app-on-firebase.yaml
+++ b/.github/workflows/upload-demo-app-on-firebase.yaml
@@ -16,8 +16,8 @@ on:
       - 'master'
 
 concurrency:
-  group: build-${{ github.ref }}
-  cancel-in-progress: false
+  group: firebase-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   upload_demo_app_on_firebase:


### PR DESCRIPTION
Update the workflow to trigger on pull requests for development and master branches, and only run when the label 'firebase-test-on' is present. Remove the manual workflow dispatch input 'label'.

Fixes - [Jira-#Issue_Number](https://mifosforge.jira.com/browse/MM-)

Didn't create a Jira ticket, click [here](https://mifosforge.jira.com/jira/software/c/projects/MM/issues/) to create new.

Please Add Screenshots If there are any UI changes.

| Before                                     | After                                  |
|--------------------------------------------|----------------------------------------|
|                                            |                                        |


Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the static analysis check `./gradlew check` or `ci-prepush.sh` to make sure you didn't break anything

- [ ] If you have multiple commits please combine them into one commit by squashing them.