### PR TITLE
fix(home): Default isAccountsPresent to true

### DIFF
--- a/feature/home/src/commonMain/kotlin/org/mifos/mobile/feature/home/HomeViewModel.kt
+++ b/feature/home/src/commonMain/kotlin/org/mifos/mobile/feature/home/HomeViewModel.kt
@@ -401,7 +401,7 @@ internal data class HomeState(
     val firstName: String? = "",
     val currency: String? = "",
     val decimals: Int = 2,
-    val isAccountsPresent: Boolean = false,
+    val isAccountsPresent: Boolean = true,
     val username: String = "",
     val clientAccounts: ClientAccounts? = null,
     val notificationCount: Int = 0,


### PR DESCRIPTION
The `isAccountsPresent` flag in `HomeUiState` is now defaulted to `true`. This resolves an issue where the "No Accounts Found" message was briefly displayed even when accounts were present, due to the initial false value.

Fixes - [Jira-#423](https://mifosforge.jira.com/browse/MM-423)
