### PR TITLE
refactor(feature): replace MaterialTheme with KptTheme

### DIFF
--- a/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/theme/DesignToken.kt
+++ b/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/theme/DesignToken.kt
@@ -49,6 +49,10 @@ object DesignToken {
     val sizes: AppSizes
         @Composable
         get() = LocalSizes.current
+
+    val strokes: AppStrokes
+        @Composable
+        get() = LocalStrokes.current
 }
 
 /**
@@ -92,6 +96,12 @@ data class AppSpacing(
     val extraLargeIncreased: Dp = 32.dp,
     val extraExtraLarge: Dp = 48.dp,
     val full: Dp = 1000.dp,
+    // custom spacings
+    val dp6: Dp = 6.dp,
+    val dp10: Dp = 10.dp,
+    val dp24: Dp = 24.dp,
+    val dp40: Dp = 40.dp,
+    val dp50: Dp = 50.dp,
 )
 
 /**
@@ -139,6 +149,11 @@ data class AppPadding(
     val extraLargeIncreased: Dp = 32.dp,
     val extraExtraLarge: Dp = 48.dp,
     val full: Dp = 1000.dp,
+    // custom paddings
+    val dp2: Dp = 2.dp,
+    val dp14: Dp = 14.dp,
+    val dp75: Dp = 75.dp,
+    val dp100: Dp = 100.dp,
 )
 
 /**
@@ -194,6 +209,10 @@ data class AppShapes(
     val circle: Shape = RoundedCornerShape(50),
     val bottomSheet: Shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
     val topBar: Shape = RoundedCornerShape(bottomStart = 16.dp, bottomEnd = 16.dp),
+    // custom shapes
+    val topCornerDp16: Shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
+    val dp25: Shape = RoundedCornerShape(25.dp),
+    val dp100: Shape = RoundedCornerShape(100.dp),
 )
 
 /**
@@ -232,6 +251,8 @@ data class AppShapes(
 data class AppElevation(
     val none: Dp = 0.dp,
     val elevation: Dp = 25.dp,
+    // custom elevation
+    val dp6: Dp = 6.dp,
 )
 
 /**
@@ -292,6 +313,29 @@ data class AppSizes(
     val cardMinHeight: Dp = 120.dp,
     val profile: Dp = 72.dp,
     val headerToContentHeight: Dp = 28.dp,
+    // custom sizes
+    val checkboxDp18: Dp = 18.dp,
+    val imageDp48: Dp = 48.dp,
+    val imageDp60: Dp = 60.dp,
+    val imageDp100: Dp = 100.dp,
+    val imageDp128: Dp = 128.dp,
+    val imageDp140: Dp = 140.dp,
+    val imageDp150: Dp = 150.dp,
+    val imageDp165: Dp = 165.dp,
+    val imageDp212: Dp = 212.dp,
+    val iconDp20: Dp = 20.dp,
+    val cardDp64: Dp = 64.dp,
+    val cardDp128: Dp = 128.dp,
+    val boxDp41: Dp = 41.dp,
+    val boxDp107: Dp = 107.33333.dp,
+    val buttonDp50: Dp = 50.dp,
+    val surfaceDp40: Dp = 40.dp,
+)
+
+@Immutable
+data class AppStrokes(
+    val thin: Dp = 1.dp,
+    val dp5: Dp = 5.dp,
 )
 
 /**
@@ -338,6 +382,8 @@ val LocalElevation = staticCompositionLocalOf { AppElevation() }
  * providing a different value through [DesignTokenTheme].
  */
 val LocalSizes = staticCompositionLocalOf { AppSizes() }
+
+val LocalStrokes = staticCompositionLocalOf { AppStrokes() }
 
 /**
  * Theme provider composable that establishes the design token context for

--- a/feature/accounts/src/commonMain/kotlin/org/mifos/mobile/feature/accounts/accountTransactions/TransactionScreen.kt
+++ b/feature/accounts/src/commonMain/kotlin/org/mifos/mobile/feature/accounts/accountTransactions/TransactionScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import mifos_mobile.feature.accounts.generated.resources.Res
 import mifos_mobile.feature.accounts.generated.resources.feature_duration
@@ -363,7 +362,7 @@ internal fun TransactionFilters(
 
             Spacer(Modifier.height(DesignToken.spacing.largeIncreased))
 
-            HorizontalDivider(modifier = Modifier.height(1.dp))
+            HorizontalDivider(modifier = Modifier.height(DesignToken.strokes.thin))
 
             FilterSection(
                 title = stringResource(Res.string.feature_transaction_type),

--- a/feature/accounts/src/commonMain/kotlin/org/mifos/mobile/feature/accounts/accountTransactions/TransactionScreen.kt
+++ b/feature/accounts/src/commonMain/kotlin/org/mifos/mobile/feature/accounts/accountTransactions/TransactionScreen.kt
@@ -168,7 +168,7 @@ internal fun TransactionScreenContent(
                 Column(
                     Modifier
                         .fillMaxSize()
-                        .padding(DesignToken.padding.large),
+                        .padding(KptTheme.spacing.md),
                 ) {
                     if (state.data.isNotEmpty()) {
                         ActionBar(
@@ -272,7 +272,7 @@ internal fun ActionBar(
 //            modifier = Modifier.clickable {
 //            },
 //            verticalAlignment = Alignment.CenterVertically,
-//            horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.extraSmall),
+//            horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.xs),
 //        ) {
 //            Text(
 //                text = stringResource(Res.string.feature_transaction_statement),
@@ -295,7 +295,7 @@ internal fun ActionBar(
                 onAction(AccountTransactionAction.ToggleFilter)
             },
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.extraSmall),
+            horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.xs),
         ) {
             Text(
                 text = stringResource(Res.string.feature_transaction_filter),
@@ -345,8 +345,8 @@ internal fun TransactionFilters(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(DesignToken.padding.large)
-                .padding(top = DesignToken.padding.large),
+                .padding(KptTheme.spacing.md)
+                .padding(top = KptTheme.spacing.md),
         ) {
             FilterTopSection(
                 isAnyFilterSelected = state.isAnyFilterSelected,

--- a/feature/accounts/src/commonMain/kotlin/org/mifos/mobile/feature/accounts/accountTransactions/TransactionScreen.kt
+++ b/feature/accounts/src/commonMain/kotlin/org/mifos/mobile/feature/accounts/accountTransactions/TransactionScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -66,6 +65,7 @@ import org.mifos.mobile.core.ui.utils.EventsEffect
 import org.mifos.mobile.core.ui.utils.ScreenUiState
 import org.mifos.mobile.feature.accounts.component.FilterSection
 import org.mifos.mobile.feature.accounts.model.TransactionFilterType
+import template.core.base.designsystem.theme.KptTheme
 /**
  * Composable function for the Account Transactions Screen.
  *
@@ -276,7 +276,7 @@ internal fun ActionBar(
 //        ) {
 //            Text(
 //                text = stringResource(Res.string.feature_transaction_statement),
-//                color = MaterialTheme.colorScheme.primary,
+//                color = KptTheme.colorScheme.primary,
 //                style = MifosTypography.bodySmallEmphasized,
 //            )
 //
@@ -284,7 +284,7 @@ internal fun ActionBar(
 //                modifier = Modifier.size(DesignToken.sizes.iconSmall),
 //                imageVector = MifosIcons.Download,
 //                contentDescription = stringResource(Res.string.feature_transaction_download_icon_description),
-//                tint = MaterialTheme.colorScheme.primary,
+//                tint = KptTheme.colorScheme.primary,
 //            )
 //        }
 
@@ -299,7 +299,7 @@ internal fun ActionBar(
         ) {
             Text(
                 text = stringResource(Res.string.feature_transaction_filter),
-                color = MaterialTheme.colorScheme.primary,
+                color = KptTheme.colorScheme.primary,
                 style = MifosTypography.bodySmallEmphasized,
             )
 
@@ -307,7 +307,7 @@ internal fun ActionBar(
                 modifier = Modifier.size(DesignToken.sizes.iconSmall),
                 imageVector = MifosIcons.Filter,
                 contentDescription = stringResource(Res.string.feature_transaction_filter_icon_description),
-                tint = MaterialTheme.colorScheme.primary,
+                tint = KptTheme.colorScheme.primary,
             )
         }
     }

--- a/feature/accounts/src/commonMain/kotlin/org/mifos/mobile/feature/accounts/accounts/AccountsScreen.kt
+++ b/feature/accounts/src/commonMain/kotlin/org/mifos/mobile/feature/accounts/accounts/AccountsScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import mifos_mobile.feature.accounts.generated.resources.Res
 import mifos_mobile.feature.accounts.generated.resources.feature_accounts_filter_status
@@ -165,7 +164,7 @@ internal fun SavingsAccountFilters(
 
         Spacer(Modifier.height(DesignToken.spacing.largeIncreased))
 
-        HorizontalDivider(modifier = Modifier.height(1.dp))
+        HorizontalDivider(modifier = Modifier.height(DesignToken.strokes.thin))
 
         FilterSection(
             title = stringResource(Res.string.feature_accounts_filter_type),

--- a/feature/accounts/src/commonMain/kotlin/org/mifos/mobile/feature/accounts/accounts/AccountsScreen.kt
+++ b/feature/accounts/src/commonMain/kotlin/org/mifos/mobile/feature/accounts/accounts/AccountsScreen.kt
@@ -53,6 +53,8 @@ import org.mifos.mobile.feature.accounts.model.FilterType
 import org.mifos.mobile.feature.loanaccount.loanAccount.LoanAccountScreen
 import org.mifos.mobile.feature.savingsaccount.savingsAccount.SavingsAccountScreen
 import org.mifos.mobile.feature.shareaccount.shareAccount.ShareAccountScreen
+import template.core.base.designsystem.theme.KptTheme
+
 /**
  * Composable function that displays the Accounts Screen.
  *
@@ -145,8 +147,8 @@ internal fun SavingsAccountFilters(
         modifier = modifier
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
-            .padding(DesignToken.padding.large)
-            .padding(top = DesignToken.padding.large),
+            .padding(KptTheme.spacing.md)
+            .padding(top = KptTheme.spacing.md),
     ) {
         FilterTopSection(
             isAnyFilterSelected = state.isAnyFilterSelected,

--- a/feature/accounts/src/commonMain/kotlin/org/mifos/mobile/feature/accounts/component/FilterSection.kt
+++ b/feature/accounts/src/commonMain/kotlin/org/mifos/mobile/feature/accounts/component/FilterSection.kt
@@ -32,7 +32,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import mifos_mobile.feature.accounts.generated.resources.Res
 import mifos_mobile.feature.accounts.generated.resources.feature_filters_count
 import org.jetbrains.compose.resources.StringResource
@@ -153,7 +152,7 @@ internal fun FilterSection(
         HorizontalDivider(
             modifier = Modifier
                 .padding(top = DesignToken.padding.medium)
-                .height(1.dp),
+                .height(DesignToken.strokes.thin),
         )
     }
 }

--- a/feature/accounts/src/commonMain/kotlin/org/mifos/mobile/feature/accounts/component/FilterSection.kt
+++ b/feature/accounts/src/commonMain/kotlin/org/mifos/mobile/feature/accounts/component/FilterSection.kt
@@ -27,7 +27,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -44,6 +43,7 @@ import org.mifos.mobile.core.designsystem.theme.MifosTypography
 import org.mifos.mobile.core.designsystem.utils.onClick
 import org.mifos.mobile.feature.accounts.model.CheckboxStatus
 import org.mifos.mobile.feature.accounts.model.TransactionCheckboxStatus
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * Composable function for the Filter Section.
@@ -92,7 +92,7 @@ internal fun FilterSection(
                 Text(
                     text = title,
                     style = MifosTypography.labelLargeEmphasized,
-                    color = MaterialTheme.colorScheme.onBackground,
+                    color = KptTheme.colorScheme.onBackground,
                 )
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.extraSmall),
@@ -102,7 +102,7 @@ internal fun FilterSection(
                         Text(
                             text = stringResource(Res.string.feature_filters_count, filtersSelected),
                             style = MifosTypography.labelSmall,
-                            color = MaterialTheme.colorScheme.secondary,
+                            color = KptTheme.colorScheme.secondary,
                         )
                     }
                     Icon(
@@ -202,7 +202,7 @@ fun FilterCheckboxUI(
         Text(
             text = stringResource(statusLabel),
             style = MifosTypography.labelMediumEmphasized,
-            color = MaterialTheme.colorScheme.secondary,
+            color = KptTheme.colorScheme.secondary,
         )
     }
 }

--- a/feature/accounts/src/commonMain/kotlin/org/mifos/mobile/feature/accounts/component/FilterSection.kt
+++ b/feature/accounts/src/commonMain/kotlin/org/mifos/mobile/feature/accounts/component/FilterSection.kt
@@ -76,8 +76,8 @@ internal fun FilterSection(
     ) {
         Column(
             modifier = Modifier.padding(
-                start = DesignToken.spacing.extraLargeIncreased,
-                end = DesignToken.spacing.small,
+                start = KptTheme.spacing.xl,
+                end = KptTheme.spacing.sm,
                 top = DesignToken.padding.medium,
             ),
             verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.medium),
@@ -95,7 +95,7 @@ internal fun FilterSection(
                     color = KptTheme.colorScheme.onBackground,
                 )
                 Row(
-                    horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.extraSmall),
+                    horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.xs),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     if (filtersSelected != 0) {
@@ -198,7 +198,7 @@ fun FilterCheckboxUI(
             )
         }
 
-        Spacer(modifier = Modifier.width(DesignToken.spacing.small))
+        Spacer(modifier = Modifier.width(KptTheme.spacing.sm))
         Text(
             text = stringResource(statusLabel),
             style = MifosTypography.labelMediumEmphasized,

--- a/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/login/LoginScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/login/LoginScreen.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.launch
 import mifos_mobile.core.ui.generated.resources.ic_icon_logo_1
@@ -176,7 +175,7 @@ private fun LoginScreenContent(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(top = 100.dp)
+            .padding(top = DesignToken.padding.dp100)
             .padding(KptTheme.spacing.md)
             .pointerInput(Unit) {
                 detectTapGestures(
@@ -204,14 +203,14 @@ fun LogoBox(
         modifier = modifier,
     ) {
         Image(
-            modifier = Modifier.height(DesignToken.sizes.avatarMedium).width(165.dp),
+            modifier = Modifier.height(DesignToken.sizes.imageDp48).width(DesignToken.sizes.imageDp165),
             painter = painterResource(
                 mifos_mobile.core.ui.generated.resources.Res.drawable.ic_icon_logo_1,
             ),
             contentDescription = null,
         )
 
-        Spacer(modifier = Modifier.height(50.dp))
+        Spacer(modifier = Modifier.height(DesignToken.spacing.dp50))
 
         Text(
             text = stringResource(Res.string.feature_sign_in_title),

--- a/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/login/LoginScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/login/LoginScreen.kt
@@ -204,7 +204,7 @@ fun LogoBox(
         modifier = modifier,
     ) {
         Image(
-            modifier = Modifier.height(48.dp).width(165.dp),
+            modifier = Modifier.height(DesignToken.sizes.avatarMedium).width(165.dp),
             painter = painterResource(
                 mifos_mobile.core.ui.generated.resources.Res.drawable.ic_icon_logo_1,
             ),

--- a/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/login/LoginScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/login/LoginScreen.kt
@@ -177,7 +177,7 @@ private fun LoginScreenContent(
         modifier = modifier
             .fillMaxSize()
             .padding(top = 100.dp)
-            .padding(DesignToken.padding.large)
+            .padding(KptTheme.spacing.md)
             .pointerInput(Unit) {
                 detectTapGestures(
                     onTap = {
@@ -245,7 +245,7 @@ fun InputBox(
                 onAction(LoginAction.UsernameChanged(it))
             },
             label = stringResource(Res.string.feature_sign_in_username_label),
-            shape = DesignToken.shapes.medium,
+            shape = KptTheme.shapes.medium,
             textStyle = MifosTypography.bodyLarge,
             config = MifosTextFieldConfig(
                 isError = state.isError,
@@ -270,7 +270,7 @@ fun InputBox(
             onValueChange = {
                 onAction(LoginAction.PasswordChanged(it))
             },
-            shape = DesignToken.shapes.medium,
+            shape = KptTheme.shapes.medium,
             modifier = Modifier.fillMaxWidth(),
             showPassword = state.isPasswordVisible,
             showPasswordChange = {
@@ -297,7 +297,7 @@ fun InputBox(
             onClick = {
                 onAction(LoginAction.LoginClicked)
             },
-            shape = DesignToken.shapes.medium,
+            shape = KptTheme.shapes.medium,
         ) {
             Text(
                 text = stringResource(Res.string.feature_sign_in_Sign_in),
@@ -316,7 +316,7 @@ fun InputBox(
             )
 
             Spacer(
-                modifier = Modifier.width(DesignToken.spacing.extraSmall),
+                modifier = Modifier.width(KptTheme.spacing.xs),
             )
 
             Text(

--- a/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/login/LoginScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/login/LoginScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -69,6 +68,7 @@ import org.mifos.mobile.core.ui.component.MifosPoweredCard
 import org.mifos.mobile.core.ui.component.MifosProgressIndicatorOverlay
 import org.mifos.mobile.core.ui.utils.EventsEffect
 import org.mifos.mobile.core.ui.utils.ScreenUiState
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 internal fun LoginScreen(
@@ -216,7 +216,7 @@ fun LogoBox(
         Text(
             text = stringResource(Res.string.feature_sign_in_title),
             style = MifosTypography.headlineMedium,
-            color = MaterialTheme.colorScheme.onSurface,
+            color = KptTheme.colorScheme.onSurface,
         )
 
         Spacer(modifier = Modifier.height(DesignToken.spacing.medium))
@@ -224,7 +224,7 @@ fun LogoBox(
         Text(
             text = stringResource(Res.string.feature_sign_in_sub_title),
             style = MifosTypography.bodySmall,
-            color = MaterialTheme.colorScheme.secondary,
+            color = KptTheme.colorScheme.secondary,
         )
     }
 }
@@ -255,7 +255,7 @@ fun InputBox(
                         Icon(
                             imageVector = MifosIcons.ErrorCircle,
                             contentDescription = "Error",
-                            tint = MaterialTheme.colorScheme.error,
+                            tint = KptTheme.colorScheme.error,
                         )
                     }
                 } else {
@@ -288,7 +288,7 @@ fun InputBox(
                 },
             text = stringResource(Res.string.feature_sign_in_forgot_password),
             style = MifosTypography.labelMedium,
-            color = MaterialTheme.colorScheme.primary,
+            color = KptTheme.colorScheme.primary,
         )
 
         MifosButton(
@@ -325,7 +325,7 @@ fun InputBox(
                 },
                 text = stringResource(Res.string.feature_sign_in_sign_up),
                 style = MifosTypography.labelMediumEmphasized,
-                color = MaterialTheme.colorScheme.primary,
+                color = KptTheme.colorScheme.primary,
             )
         }
     }

--- a/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/otpAuthentication/OtpAuthenticationScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/otpAuthentication/OtpAuthenticationScreen.kt
@@ -149,8 +149,8 @@ internal fun OptAuthScreenContent(
             ScreenUiState.Success -> {
                 Column(
                     modifier = Modifier.fillMaxSize()
-                        .padding(DesignToken.padding.large)
-                        .padding(top = DesignToken.padding.large)
+                        .padding(KptTheme.spacing.md)
+                        .padding(top = KptTheme.spacing.md)
                         .statusBarsPadding(),
 
                 ) {
@@ -202,7 +202,7 @@ internal fun OtpInputForm(
 ) {
     Column(
         modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.large),
+        verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.md),
     ) {
         if (state.nextRoute != Constants.SET_PASSWORD) {
             MifosOutlinedTextField(
@@ -211,7 +211,7 @@ internal fun OtpInputForm(
                     onAction(OtpAuthAction.OnRequestIdChange(it))
                 },
                 label = stringResource(Res.string.feature_otp_request_id_label),
-                shape = DesignToken.shapes.medium,
+                shape = KptTheme.shapes.medium,
                 textStyle = MifosTypography.bodyLarge,
                 config = MifosTextFieldConfig(
                     keyboardOptions = KeyboardOptions(
@@ -240,7 +240,7 @@ internal fun OtpInputForm(
                 onAction(OtpAuthAction.OnOtpChange(it))
             },
             label = stringResource(Res.string.feature_otp_authentication_code_label),
-            shape = DesignToken.shapes.medium,
+            shape = KptTheme.shapes.medium,
             textStyle = MifosTypography.bodyLarge,
             config = MifosTextFieldConfig(
                 keyboardOptions = KeyboardOptions(
@@ -276,7 +276,7 @@ internal fun OtpInputForm(
                 onClick = {
                     onAction(OtpAuthAction.OnCancelClick)
                 },
-                shape = DesignToken.shapes.medium,
+                shape = KptTheme.shapes.medium,
             ) {
                 Text(
                     text = stringResource(Res.string.feature_common_cancel),
@@ -292,7 +292,7 @@ internal fun OtpInputForm(
                     onAction(OtpAuthAction.OnNextClick)
                 },
                 enabled = state.isNextButtonEnabled,
-                shape = DesignToken.shapes.medium,
+                shape = KptTheme.shapes.medium,
             ) {
                 Text(
                     text = stringResource(Res.string.feature_common_next),
@@ -312,7 +312,7 @@ internal fun OtpInputForm(
             )
 
             Spacer(
-                modifier = Modifier.width(DesignToken.spacing.extraSmall),
+                modifier = Modifier.width(KptTheme.spacing.xs),
             )
 
             Text(
@@ -332,7 +332,7 @@ internal fun OtpInputForm(
 internal fun Otp_Auth_Preview() {
     MifosMobileTheme {
         Column(
-            modifier = Modifier.padding(DesignToken.padding.large),
+            modifier = Modifier.padding(KptTheme.spacing.md),
         ) {
             OptAuthScreenContent(
                 state = OtpAuthState(dialogState = null),

--- a/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/otpAuthentication/OtpAuthenticationScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/otpAuthentication/OtpAuthenticationScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -64,6 +63,7 @@ import org.mifos.mobile.core.ui.component.MifosPoweredCard
 import org.mifos.mobile.core.ui.component.MifosProgressIndicatorOverlay
 import org.mifos.mobile.core.ui.utils.EventsEffect
 import org.mifos.mobile.core.ui.utils.ScreenUiState
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 internal fun OtpAuthenticationScreen(
@@ -156,7 +156,7 @@ internal fun OptAuthScreenContent(
                 ) {
                     Text(
                         text = stringResource(Res.string.feature_otp_title),
-                        color = MaterialTheme.colorScheme.onBackground,
+                        color = KptTheme.colorScheme.onBackground,
                         style = MifosTypography.headlineMedium,
                     )
 
@@ -164,7 +164,7 @@ internal fun OptAuthScreenContent(
 
                     Text(
                         text = stringResource(Res.string.feature_otp_subtitle),
-                        color = MaterialTheme.colorScheme.onBackground,
+                        color = KptTheme.colorScheme.onBackground,
                         style = MifosTypography.titleSmallEmphasized,
                     )
 
@@ -172,7 +172,7 @@ internal fun OptAuthScreenContent(
 
                     Text(
                         text = stringResource(Res.string.feature_otp_message),
-                        color = MaterialTheme.colorScheme.secondary,
+                        color = KptTheme.colorScheme.secondary,
                         style = MifosTypography.bodySmall,
                     )
 
@@ -224,7 +224,7 @@ internal fun OtpInputForm(
                             Icon(
                                 imageVector = MifosIcons.ErrorCircle,
                                 contentDescription = "Error",
-                                tint = MaterialTheme.colorScheme.error,
+                                tint = KptTheme.colorScheme.error,
                             )
                         }
                     } else {
@@ -253,7 +253,7 @@ internal fun OtpInputForm(
                         Icon(
                             imageVector = MifosIcons.ErrorCircle,
                             contentDescription = "Error",
-                            tint = MaterialTheme.colorScheme.error,
+                            tint = KptTheme.colorScheme.error,
                         )
                     }
                 } else {
@@ -270,8 +270,8 @@ internal fun OtpInputForm(
                     .fillMaxWidth()
                     .height(DesignToken.sizes.buttonHeight),
                 colors = ButtonDefaults.outlinedButtonColors(
-                    containerColor = MaterialTheme.colorScheme.onPrimary,
-                    contentColor = MaterialTheme.colorScheme.primary,
+                    containerColor = KptTheme.colorScheme.onPrimary,
+                    contentColor = KptTheme.colorScheme.primary,
                 ),
                 onClick = {
                     onAction(OtpAuthAction.OnCancelClick)
@@ -280,7 +280,7 @@ internal fun OtpInputForm(
             ) {
                 Text(
                     text = stringResource(Res.string.feature_common_cancel),
-                    style = MaterialTheme.typography.labelLarge,
+                    style = KptTheme.typography.labelLarge,
                 )
             }
 
@@ -321,7 +321,7 @@ internal fun OtpInputForm(
                 },
                 text = stringResource(Res.string.feature_otp_action_tip),
                 style = MifosTypography.labelMediumEmphasized,
-                color = MaterialTheme.colorScheme.primary,
+                color = KptTheme.colorScheme.primary,
             )
         }
     }

--- a/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/otpAuthentication/OtpAuthenticationScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/otpAuthentication/OtpAuthenticationScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import mifos_mobile.feature.auth.generated.resources.Res
 import mifos_mobile.feature.auth.generated.resources.feature_common_cancel
@@ -176,7 +175,7 @@ internal fun OptAuthScreenContent(
                         style = MifosTypography.bodySmall,
                     )
 
-                    Spacer(modifier = Modifier.height(24.dp))
+                    Spacer(modifier = Modifier.height(DesignToken.spacing.dp24))
 
                     OtpInputForm(
                         state = state,

--- a/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/recoverPassword/RecoverPasswordScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/recoverPassword/RecoverPasswordScreen.kt
@@ -120,8 +120,8 @@ internal fun RecoverPasswordScreen(
                     modifier = Modifier
                         .fillMaxSize()
                         .verticalScroll(rememberScrollState())
-                        .padding(DesignToken.padding.large)
-                        .padding(top = DesignToken.padding.large)
+                        .padding(KptTheme.spacing.md)
+                        .padding(top = KptTheme.spacing.md)
                         .statusBarsPadding(),
                 ) {
                     Text(
@@ -162,7 +162,7 @@ internal fun ForgotPasswordInputBox(
     onAction: (RecoverPasswordAction) -> Unit,
 ) {
     Column(
-        verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.large),
+        verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.md),
     ) {
         MifosOutlinedTextField(
             value = state.phoneNumber,
@@ -170,7 +170,7 @@ internal fun ForgotPasswordInputBox(
                 onAction(RecoverPasswordAction.OnPhoneNumberChange(it))
             },
             label = stringResource(Res.string.feature_recover_now_phone_number_label),
-            shape = DesignToken.shapes.medium,
+            shape = KptTheme.shapes.medium,
             textStyle = MifosTypography.bodyLarge,
             config = MifosTextFieldConfig(
                 keyboardOptions = KeyboardOptions(
@@ -198,7 +198,7 @@ internal fun ForgotPasswordInputBox(
                 onAction(RecoverPasswordAction.OnEmailChange(it))
             },
             label = stringResource(Res.string.feature_recover_now_email_label),
-            shape = DesignToken.shapes.medium,
+            shape = KptTheme.shapes.medium,
             textStyle = MifosTypography.bodyLarge,
             config = MifosTextFieldConfig(
                 isError = state.emailError != null,
@@ -223,7 +223,7 @@ internal fun ForgotPasswordInputBox(
             onClick = {
                 onAction(RecoverPasswordAction.OnRecoverClicked)
             },
-            shape = DesignToken.shapes.medium,
+            shape = KptTheme.shapes.medium,
         ) {
             Text(
                 text = stringResource(Res.string.feature_recover_now_title),

--- a/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/recoverPassword/RecoverPasswordScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/recoverPassword/RecoverPasswordScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import mifos_mobile.feature.auth.generated.resources.Res
 import mifos_mobile.feature.auth.generated.resources.feature_recover_now_email_label
@@ -138,7 +137,7 @@ internal fun RecoverPasswordScreen(
                         color = KptTheme.colorScheme.secondary,
                     )
 
-                    Spacer(modifier = Modifier.height(24.dp))
+                    Spacer(modifier = Modifier.height(DesignToken.spacing.dp24))
 
                     ForgotPasswordInputBox(
                         state = state,
@@ -241,7 +240,7 @@ internal fun ForgotPasswordInputBox(
                 color = KptTheme.colorScheme.secondary,
             )
 
-            Spacer(modifier = Modifier.width(6.dp))
+            Spacer(modifier = Modifier.width(DesignToken.spacing.dp6))
 
             Text(
                 modifier = Modifier.clickable { onAction.invoke(RecoverPasswordAction.OnLogin) },

--- a/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/recoverPassword/RecoverPasswordScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/recoverPassword/RecoverPasswordScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -58,6 +57,7 @@ import org.mifos.mobile.core.ui.component.MifosPoweredCard
 import org.mifos.mobile.core.ui.component.MifosProgressIndicatorOverlay
 import org.mifos.mobile.core.ui.utils.EventsEffect
 import org.mifos.mobile.core.ui.utils.ScreenUiState
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 internal fun RecoverPasswordScreen(
@@ -127,7 +127,7 @@ internal fun RecoverPasswordScreen(
                     Text(
                         text = stringResource(Res.string.feature_recover_now_title),
                         style = MifosTypography.headlineMedium,
-                        color = MaterialTheme.colorScheme.onBackground,
+                        color = KptTheme.colorScheme.onBackground,
                     )
 
                     Spacer(modifier = Modifier.height(12.dp))
@@ -135,7 +135,7 @@ internal fun RecoverPasswordScreen(
                     Text(
                         text = stringResource(Res.string.feature_recover_now_message),
                         style = MifosTypography.bodySmall,
-                        color = MaterialTheme.colorScheme.secondary,
+                        color = KptTheme.colorScheme.secondary,
                     )
 
                     Spacer(modifier = Modifier.height(24.dp))
@@ -183,7 +183,7 @@ internal fun ForgotPasswordInputBox(
                         Icon(
                             imageVector = MifosIcons.ErrorCircle,
                             contentDescription = "Error",
-                            tint = MaterialTheme.colorScheme.error,
+                            tint = KptTheme.colorScheme.error,
                         )
                     }
                 } else {
@@ -208,7 +208,7 @@ internal fun ForgotPasswordInputBox(
                         Icon(
                             imageVector = MifosIcons.ErrorCircle,
                             contentDescription = "Error",
-                            tint = MaterialTheme.colorScheme.error,
+                            tint = KptTheme.colorScheme.error,
                         )
                     }
                 } else {
@@ -238,7 +238,7 @@ internal fun ForgotPasswordInputBox(
             Text(
                 text = stringResource(Res.string.feature_recover_now_remember_your_password),
                 style = MifosTypography.labelMedium,
-                color = MaterialTheme.colorScheme.secondary,
+                color = KptTheme.colorScheme.secondary,
             )
 
             Spacer(modifier = Modifier.width(6.dp))
@@ -247,7 +247,7 @@ internal fun ForgotPasswordInputBox(
                 modifier = Modifier.clickable { onAction.invoke(RecoverPasswordAction.OnLogin) },
                 text = stringResource(Res.string.feature_recover_now_log_in),
                 style = MifosTypography.labelMediumEmphasized,
-                color = MaterialTheme.colorScheme.primary,
+                color = KptTheme.colorScheme.primary,
             )
         }
     }

--- a/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/recoverPassword/RecoverPasswordScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/recoverPassword/RecoverPasswordScreen.kt
@@ -130,7 +130,7 @@ internal fun RecoverPasswordScreen(
                         color = KptTheme.colorScheme.onBackground,
                     )
 
-                    Spacer(modifier = Modifier.height(12.dp))
+                    Spacer(modifier = Modifier.height(DesignToken.spacing.medium))
 
                     Text(
                         text = stringResource(Res.string.feature_recover_now_message),

--- a/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/registration/RegistrationScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/registration/RegistrationScreen.kt
@@ -198,8 +198,8 @@ private fun RegistrationScreenContent(
                     keyboardController?.hide()
                 }
             }
-            .padding(DesignToken.padding.large)
-            .padding(top = DesignToken.padding.large)
+            .padding(KptTheme.spacing.md)
+            .padding(top = KptTheme.spacing.md)
             .statusBarsPadding(),
         verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.medium),
         contentPadding = PaddingValues(
@@ -229,13 +229,13 @@ private fun RegistrationScreenContent(
         }
 
         item {
-            Spacer(modifier = Modifier.height(DesignToken.spacing.small))
+            Spacer(modifier = Modifier.height(KptTheme.spacing.sm))
             MifosButton(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(DesignToken.sizes.inputHeight),
                 onClick = { onAction(SignUpAction.SubmitClick) },
-                shape = DesignToken.shapes.medium,
+                shape = KptTheme.shapes.medium,
                 enabled = state.isSubmitButtonEnabled,
             ) {
                 Text(
@@ -246,7 +246,7 @@ private fun RegistrationScreenContent(
         }
 
         item {
-            Spacer(modifier = Modifier.height(DesignToken.spacing.small))
+            Spacer(modifier = Modifier.height(KptTheme.spacing.sm))
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.Center,
@@ -256,7 +256,7 @@ private fun RegistrationScreenContent(
                     text = stringResource(Res.string.feature_signup_already_have_an_account),
                     style = MifosTypography.labelMedium,
                 )
-                Spacer(modifier = Modifier.width(DesignToken.spacing.extraSmall))
+                Spacer(modifier = Modifier.width(KptTheme.spacing.xs))
                 Text(
                     modifier = Modifier.clickable {
                         onAction(SignUpAction.OnNavigateToLogin)
@@ -331,13 +331,13 @@ fun MifosInputField(
     if (config.fieldType == InputFieldType.PASSWORD) {
         Column(
             modifier = modifier,
-            verticalArrangement = Arrangement.spacedBy(DesignToken.padding.small),
+            verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.sm),
         ) {
             MifosPasswordField(
                 label = stringResource(config.labelRes),
                 value = config.value,
                 onValueChange = config.onValueChange,
-                shape = DesignToken.shapes.medium,
+                shape = KptTheme.shapes.medium,
                 modifier = Modifier.fillMaxWidth(),
                 showPassword = config.isPasswordVisible,
                 showPasswordChange = {
@@ -374,7 +374,7 @@ fun MifosInputField(
             value = config.value,
             onValueChange = config.onValueChange,
             label = stringResource(config.labelRes),
-            shape = DesignToken.shapes.medium,
+            shape = KptTheme.shapes.medium,
             textStyle = MifosTypography.bodyLarge,
             config = MifosTextFieldConfig(
                 isError = config.errorText != null,

--- a/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/registration/RegistrationScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/registration/RegistrationScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -84,6 +83,7 @@ import org.mifos.mobile.core.ui.component.MifosPoweredCard
 import org.mifos.mobile.core.ui.component.MifosProgressIndicatorOverlay
 import org.mifos.mobile.core.ui.utils.EventsEffect
 import org.mifos.mobile.core.ui.utils.ScreenUiState
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 internal fun RegistrationScreen(
@@ -211,7 +211,7 @@ private fun RegistrationScreenContent(
             Text(
                 text = stringResource(Res.string.feature_signup_title),
                 style = MifosTypography.headlineMedium,
-                color = MaterialTheme.colorScheme.onSurface,
+                color = KptTheme.colorScheme.onSurface,
             )
         }
 
@@ -219,7 +219,7 @@ private fun RegistrationScreenContent(
             Text(
                 text = stringResource(Res.string.feature_signup_sub_title),
                 style = MifosTypography.bodySmall,
-                color = MaterialTheme.colorScheme.secondary,
+                color = KptTheme.colorScheme.secondary,
             )
         }
 
@@ -264,7 +264,7 @@ private fun RegistrationScreenContent(
                     },
                     text = stringResource(Res.string.feature_signup_log_in),
                     style = MifosTypography.labelMedium,
-                    color = MaterialTheme.colorScheme.primary,
+                    color = KptTheme.colorScheme.primary,
                 )
             }
         }
@@ -307,9 +307,9 @@ fun MifosInputField(
                         imageVector = if (config.isPasswordVisible) MifosIcons.EyeOff else MifosIcons.Eye,
                         contentDescription = "Toggle password visibility",
                         tint = if (config.errorText != null) {
-                            MaterialTheme.colorScheme.error
+                            KptTheme.colorScheme.error
                         } else {
-                            MaterialTheme.colorScheme.onSurface
+                            KptTheme.colorScheme.onSurface
                         },
                     )
                 }
@@ -320,7 +320,7 @@ fun MifosInputField(
                 Icon(
                     imageVector = MifosIcons.ErrorCircle,
                     contentDescription = "Error",
-                    tint = MaterialTheme.colorScheme.error,
+                    tint = KptTheme.colorScheme.error,
                 )
             }
         }

--- a/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/registration/RegistrationScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/registration/RegistrationScreen.kt
@@ -45,7 +45,6 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.launch
 import mifos_mobile.feature.auth.generated.resources.Res
@@ -332,7 +331,7 @@ fun MifosInputField(
     if (config.fieldType == InputFieldType.PASSWORD) {
         Column(
             modifier = modifier,
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(DesignToken.padding.small),
         ) {
             MifosPasswordField(
                 label = stringResource(config.labelRes),

--- a/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/setNewPassword/SetPasswordScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/setNewPassword/SetPasswordScreen.kt
@@ -147,7 +147,7 @@ internal fun SetPasswordScreen(
                         color = KptTheme.colorScheme.onBackground,
                     )
 
-                    Spacer(modifier = Modifier.height(12.dp))
+                    Spacer(modifier = Modifier.height(DesignToken.spacing.medium))
 
                     Text(
                         text = stringResource(Res.string.feature_set_new_password_message),

--- a/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/setNewPassword/SetPasswordScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/setNewPassword/SetPasswordScreen.kt
@@ -137,8 +137,8 @@ internal fun SetPasswordScreen(
                     modifier = Modifier
                         .fillMaxSize()
                         .verticalScroll(rememberScrollState())
-                        .padding(top = DesignToken.padding.large)
-                        .padding(DesignToken.padding.large)
+                        .padding(top = KptTheme.spacing.md)
+                        .padding(KptTheme.spacing.md)
                         .statusBarsPadding(),
                 ) {
                     Text(
@@ -186,13 +186,13 @@ internal fun SetPasswordInputBox(
         verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.largeIncreased),
     ) {
         Column(
-            verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.extraSmall),
+            verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.xs),
         ) {
             MifosPasswordField(
                 label = stringResource(Res.string.feature_set_new_password_new_password_label),
                 value = state.password,
                 onValueChange = { onAction(SetPasswordAction.OnPasswordChange(it)) },
-                shape = DesignToken.shapes.medium,
+                shape = KptTheme.shapes.medium,
                 modifier = Modifier.fillMaxWidth(),
                 showPassword = state.isPasswordVisible,
                 showPasswordChange = {
@@ -228,7 +228,7 @@ internal fun SetPasswordInputBox(
             label = stringResource(Res.string.feature_set_new_password_confirm_password_label),
             value = state.confirmPassword,
             onValueChange = { onAction(SetPasswordAction.OnConfirmPasswordChange(it)) },
-            shape = DesignToken.shapes.medium,
+            shape = KptTheme.shapes.medium,
             modifier = Modifier.fillMaxWidth(),
             showPassword = state.isConfirmPasswordVisible,
             showPasswordChange = {
@@ -245,7 +245,7 @@ internal fun SetPasswordInputBox(
             onClick = {
                 onAction(SetPasswordAction.OnSubmit)
             },
-            shape = DesignToken.shapes.medium,
+            shape = KptTheme.shapes.medium,
         ) {
             Text(
                 text = stringResource(Res.string.feature_set_new_password_submit),
@@ -263,7 +263,7 @@ internal fun SetPasswordInputBox(
                 color = KptTheme.colorScheme.secondary,
             )
 
-            Spacer(modifier = Modifier.width(DesignToken.spacing.small))
+            Spacer(modifier = Modifier.width(KptTheme.spacing.sm))
 
             Text(
                 modifier = Modifier.clickable { onAction.invoke(SetPasswordAction.OnLogIn) },

--- a/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/setNewPassword/SetPasswordScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/setNewPassword/SetPasswordScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import mifos_mobile.feature.auth.generated.resources.Res
 import mifos_mobile.feature.auth.generated.resources.feature_set_new_password_action_tip
@@ -155,7 +154,7 @@ internal fun SetPasswordScreen(
                         color = KptTheme.colorScheme.secondary,
                     )
 
-                    Spacer(modifier = Modifier.height(24.dp))
+                    Spacer(modifier = Modifier.height(DesignToken.spacing.dp24))
 
                     SetPasswordInputBox(
                         state = state,

--- a/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/setNewPassword/SetPasswordScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/setNewPassword/SetPasswordScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -58,6 +57,7 @@ import org.mifos.mobile.core.ui.component.MifosPoweredCard
 import org.mifos.mobile.core.ui.component.MifosProgressIndicatorOverlay
 import org.mifos.mobile.core.ui.utils.EventsEffect
 import org.mifos.mobile.core.ui.utils.ScreenUiState
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 internal fun SetPasswordScreen(
@@ -144,7 +144,7 @@ internal fun SetPasswordScreen(
                     Text(
                         text = stringResource(Res.string.feature_set_new_password_title),
                         style = MifosTypography.headlineMedium,
-                        color = MaterialTheme.colorScheme.onBackground,
+                        color = KptTheme.colorScheme.onBackground,
                     )
 
                     Spacer(modifier = Modifier.height(12.dp))
@@ -152,7 +152,7 @@ internal fun SetPasswordScreen(
                     Text(
                         text = stringResource(Res.string.feature_set_new_password_message),
                         style = MifosTypography.bodySmall,
-                        color = MaterialTheme.colorScheme.secondary,
+                        color = KptTheme.colorScheme.secondary,
                     )
 
                     Spacer(modifier = Modifier.height(24.dp))
@@ -260,7 +260,7 @@ internal fun SetPasswordInputBox(
             Text(
                 text = stringResource(Res.string.feature_set_new_password_tip),
                 style = MifosTypography.labelMedium,
-                color = MaterialTheme.colorScheme.secondary,
+                color = KptTheme.colorScheme.secondary,
             )
 
             Spacer(modifier = Modifier.width(DesignToken.spacing.small))
@@ -269,7 +269,7 @@ internal fun SetPasswordInputBox(
                 modifier = Modifier.clickable { onAction.invoke(SetPasswordAction.OnLogIn) },
                 text = stringResource(Res.string.feature_set_new_password_action_tip),
                 style = MifosTypography.labelMediumEmphasized,
-                color = MaterialTheme.colorScheme.primary,
+                color = KptTheme.colorScheme.primary,
             )
         }
     }

--- a/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/uploadId/UploadIdScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/uploadId/UploadIdScreen.kt
@@ -152,8 +152,8 @@ internal fun UploadIdScreenContent(
             modifier
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState())
-                .padding(top = DesignToken.padding.large)
-                .padding(DesignToken.padding.large)
+                .padding(top = KptTheme.spacing.md)
+                .padding(KptTheme.spacing.md)
                 .statusBarsPadding(),
         ) {
             Text(
@@ -247,7 +247,7 @@ internal fun InputForm(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(DesignToken.sizes.buttonHeight),
-            shape = DesignToken.shapes.medium,
+            shape = KptTheme.shapes.medium,
             text = {
                 Text(
                     text = stringResource(Res.string.feature_common_submit),
@@ -263,7 +263,7 @@ internal fun InputForm(
             modifier = Modifier
                 .align(Alignment.CenterHorizontally)
                 .padding(bottom = DesignToken.padding.medium),
-            horizontalArrangement = Arrangement.spacedBy(DesignToken.padding.small),
+            horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.sm),
         ) {
             Text(
                 text = stringResource(Res.string.feature_upload_id_edit_prompt),
@@ -331,7 +331,7 @@ private fun MifosTextFieldWithError(
         value = value,
         label = label,
         onValueChange = onValueChange,
-        shape = DesignToken.shapes.medium,
+        shape = KptTheme.shapes.medium,
         textStyle = MifosTypography.bodyLarge,
         colors = OutlinedTextFieldDefaults.colors(
             focusedBorderColor = KptTheme.colorScheme.secondaryContainer,

--- a/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/uploadId/UploadIdScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/uploadId/UploadIdScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.SelectableDates
 import androidx.compose.material3.Surface
@@ -74,6 +73,7 @@ import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
 import org.mifos.mobile.core.ui.component.MifosPoweredCard
 import org.mifos.mobile.core.ui.utils.EventsEffect
+import template.core.base.designsystem.theme.KptTheme
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
@@ -159,7 +159,7 @@ internal fun UploadIdScreenContent(
             Text(
                 text = stringResource(Res.string.feature_upload_id_title),
                 style = MifosTypography.headlineMedium,
-                color = MaterialTheme.colorScheme.onBackground,
+                color = KptTheme.colorScheme.onBackground,
             )
 
             Spacer(modifier = Modifier.height(DesignToken.spacing.medium))
@@ -167,7 +167,7 @@ internal fun UploadIdScreenContent(
             Text(
                 text = stringResource(Res.string.feature_upload_id_subtitle),
                 style = MifosTypography.bodySmall,
-                color = MaterialTheme.colorScheme.secondary,
+                color = KptTheme.colorScheme.secondary,
             )
 
             Spacer(modifier = Modifier.height(DesignToken.spacing.largeIncreased))
@@ -272,7 +272,7 @@ internal fun InputForm(
             Text(
                 text = stringResource(Res.string.feature_upload_id_take_me_back),
                 style = MifosTypography.labelMediumEmphasized,
-                color = MaterialTheme.colorScheme.primary,
+                color = KptTheme.colorScheme.primary,
                 modifier = Modifier.clickable(
                     onClick = {
                         onAction(UploadIdAction.OnBackClick)
@@ -334,9 +334,9 @@ private fun MifosTextFieldWithError(
         shape = DesignToken.shapes.medium,
         textStyle = MifosTypography.bodyLarge,
         colors = OutlinedTextFieldDefaults.colors(
-            focusedBorderColor = MaterialTheme.colorScheme.secondaryContainer,
-            unfocusedBorderColor = MaterialTheme.colorScheme.secondaryContainer,
-            errorBorderColor = MaterialTheme.colorScheme.error,
+            focusedBorderColor = KptTheme.colorScheme.secondaryContainer,
+            unfocusedBorderColor = KptTheme.colorScheme.secondaryContainer,
+            errorBorderColor = KptTheme.colorScheme.error,
         ),
         config = MifosTextFieldConfig(
             isError = isError,

--- a/feature/beneficiary/src/commonMain/kotlin/org/mifos/mobile/feature/beneficiary/beneficiaryApplication/BeneficiaryApplicationContent.kt
+++ b/feature/beneficiary/src/commonMain/kotlin/org/mifos/mobile/feature/beneficiary/beneficiaryApplication/BeneficiaryApplicationContent.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -49,6 +48,7 @@ import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
 import org.mifos.mobile.core.model.enums.BeneficiaryState
 import org.mifos.mobile.core.ui.component.MifosDropDownTextField
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * Composable function to display a beneficiary application form.
@@ -172,7 +172,7 @@ internal fun BeneficiaryApplicationContent(
             Text(
                 text = buildAnnotatedString {
                     append(stringResource(Res.string.skip_the_form))
-                    withStyle(style = SpanStyle(color = MaterialTheme.colorScheme.primary)) {
+                    withStyle(style = SpanStyle(color = KptTheme.colorScheme.primary)) {
                         append(stringResource(Res.string.upload_or_scan_qr_code))
                     }
                 },

--- a/feature/beneficiary/src/commonMain/kotlin/org/mifos/mobile/feature/beneficiary/beneficiaryApplication/BeneficiaryApplicationContent.kt
+++ b/feature/beneficiary/src/commonMain/kotlin/org/mifos/mobile/feature/beneficiary/beneficiaryApplication/BeneficiaryApplicationContent.kt
@@ -69,8 +69,8 @@ internal fun BeneficiaryApplicationContent(
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
             .padding(
-                horizontal = DesignToken.padding.large,
-                vertical = DesignToken.padding.extraLargeIncreased,
+                horizontal = KptTheme.spacing.md,
+                vertical = KptTheme.spacing.xl,
             ),
     ) {
         MifosOutlinedTextField(
@@ -151,7 +151,7 @@ internal fun BeneficiaryApplicationContent(
             ),
         )
 
-        Spacer(Modifier.height(DesignToken.padding.large))
+        Spacer(Modifier.height(KptTheme.spacing.md))
 
         MifosButton(
             modifier = Modifier
@@ -166,7 +166,7 @@ internal fun BeneficiaryApplicationContent(
             enabled = state.isEnabled,
         )
 
-        Spacer(Modifier.height(DesignToken.padding.extraLargeIncreased))
+        Spacer(Modifier.height(KptTheme.spacing.xl))
 
         if (state.beneficiaryState == BeneficiaryState.CREATE_MANUAL) {
             Text(

--- a/feature/beneficiary/src/commonMain/kotlin/org/mifos/mobile/feature/beneficiary/beneficiaryApplicationConfirmation/BeneficiaryApplicationConfirmationScreen.kt
+++ b/feature/beneficiary/src/commonMain/kotlin/org/mifos/mobile/feature/beneficiary/beneficiaryApplicationConfirmation/BeneficiaryApplicationConfirmationScreen.kt
@@ -37,6 +37,7 @@ import org.mifos.mobile.core.ui.component.MifosProgressIndicator
 import org.mifos.mobile.core.ui.component.MifosProgressIndicatorOverlay
 import org.mifos.mobile.core.ui.utils.EventsEffect
 import org.mifos.mobile.core.ui.utils.ScreenUiState
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * Composable function to render the beneficiary application confirmation screen.
@@ -145,7 +146,7 @@ fun BeneficiaryApplicationConfirmationScreenContent(
 
             ScreenUiState.Success -> {
                 Column(
-                    Modifier.padding(DesignToken.padding.large),
+                    Modifier.padding(KptTheme.spacing.md),
                     verticalArrangement = Arrangement.spacedBy(DesignToken.padding.largeIncreased),
                 ) {
                     Text(

--- a/feature/beneficiary/src/commonMain/kotlin/org/mifos/mobile/feature/beneficiary/beneficiaryDetail/BeneficiaryDetailContent.kt
+++ b/feature/beneficiary/src/commonMain/kotlin/org/mifos/mobile/feature/beneficiary/beneficiaryDetail/BeneficiaryDetailContent.kt
@@ -59,7 +59,7 @@ internal fun BeneficiaryDetailContent(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(DesignToken.padding.large)
+            .padding(KptTheme.spacing.md)
             .verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.largeIncreased),
     ) {
@@ -145,7 +145,7 @@ internal fun ActionBar(
                 onAction(BeneficiaryDetailAction.ShowDeleteConfirmation)
             },
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.extraSmall),
+            horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.xs),
         ) {
             Text(
                 text = "Delete",
@@ -168,7 +168,7 @@ internal fun ActionBar(
                 onAction(BeneficiaryDetailAction.OnUpdateBeneficiary)
             },
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.extraSmall),
+            horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.xs),
         ) {
             Text(
                 text = "Update",

--- a/feature/beneficiary/src/commonMain/kotlin/org/mifos/mobile/feature/beneficiary/beneficiaryDetail/BeneficiaryDetailContent.kt
+++ b/feature/beneficiary/src/commonMain/kotlin/org/mifos/mobile/feature/beneficiary/beneficiaryDetail/BeneficiaryDetailContent.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -42,6 +41,7 @@ import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
 import org.mifos.mobile.core.ui.component.MifosBeneficiaryTopCard
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * Composable function to display beneficiary details.
@@ -149,7 +149,7 @@ internal fun ActionBar(
         ) {
             Text(
                 text = "Delete",
-                color = MaterialTheme.colorScheme.primary,
+                color = KptTheme.colorScheme.primary,
                 style = MifosTypography.bodySmallEmphasized,
             )
 
@@ -157,7 +157,7 @@ internal fun ActionBar(
                 modifier = Modifier.size(DesignToken.sizes.iconSmall),
                 imageVector = MifosIcons.Delete,
                 contentDescription = "",
-                tint = MaterialTheme.colorScheme.primary,
+                tint = KptTheme.colorScheme.primary,
             )
         }
 
@@ -172,7 +172,7 @@ internal fun ActionBar(
         ) {
             Text(
                 text = "Update",
-                color = MaterialTheme.colorScheme.primary,
+                color = KptTheme.colorScheme.primary,
                 style = MifosTypography.bodySmallEmphasized,
             )
 
@@ -180,7 +180,7 @@ internal fun ActionBar(
                 modifier = Modifier.size(DesignToken.sizes.iconSmall),
                 imageVector = MifosIcons.Edit,
                 contentDescription = "",
-                tint = MaterialTheme.colorScheme.primary,
+                tint = KptTheme.colorScheme.primary,
             )
         }
     }

--- a/feature/beneficiary/src/commonMain/kotlin/org/mifos/mobile/feature/beneficiary/beneficiaryList/BeneficiaryListScreen.kt
+++ b/feature/beneficiary/src/commonMain/kotlin/org/mifos/mobile/feature/beneficiary/beneficiaryList/BeneficiaryListScreen.kt
@@ -198,8 +198,8 @@ fun BeneficiaryListContent(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(top = DesignToken.padding.small),
-        verticalArrangement = Arrangement.spacedBy(DesignToken.padding.small),
+            .padding(top = KptTheme.spacing.sm),
+        verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.sm),
     ) {
         when (state.uiState) {
             is ScreenUiState.Loading -> {
@@ -224,7 +224,7 @@ fun BeneficiaryListContent(
 
             is ScreenUiState.Empty -> {
                 Box(
-                    Modifier.fillMaxSize().padding(horizontal = DesignToken.padding.large),
+                    Modifier.fillMaxSize().padding(horizontal = KptTheme.spacing.md),
                     contentAlignment = Alignment.Center,
                 ) {
                     Column {
@@ -233,13 +233,13 @@ fun BeneficiaryListContent(
                             image = Res.drawable.ic_error_black_24dp,
                             error = Res.string.no_beneficiary_found_please_add,
                         )
-                        Spacer(Modifier.padding(DesignToken.padding.large))
+                        Spacer(Modifier.padding(KptTheme.spacing.md))
                         MifosButton(
                             modifier = Modifier.fillMaxWidth(),
                             onClick = {
                                 onAction(BeneficiaryListAction.OnAddBeneficiaryClicked)
                             },
-                            shape = DesignToken.shapes.medium,
+                            shape = KptTheme.shapes.medium,
                         ) {
                             Text(stringResource(Res.string.add_beneficiary))
                         }
@@ -249,7 +249,7 @@ fun BeneficiaryListContent(
 
             is ScreenUiState.Success -> {
                 Column(
-                    verticalArrangement = Arrangement.spacedBy(DesignToken.padding.small),
+                    verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.sm),
                 ) {
                     if (state.beneficiaries.isNotEmpty()) {
                         ActionBar(onAction = onAction)
@@ -300,7 +300,7 @@ internal fun ActionBar(
             .fillMaxWidth()
             .padding(
                 vertical = DesignToken.padding.medium,
-                horizontal = DesignToken.padding.large,
+                horizontal = KptTheme.spacing.md,
             ),
         horizontalArrangement = Arrangement.End,
     ) {
@@ -309,7 +309,7 @@ internal fun ActionBar(
                 onAction(BeneficiaryListAction.OnAddBeneficiaryClicked)
             },
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.extraSmall),
+            horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.xs),
         ) {
             Text(
                 text = stringResource(Res.string.add),
@@ -332,7 +332,7 @@ internal fun ActionBar(
                 onAction(BeneficiaryListAction.ToggleFilter)
             },
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.extraSmall),
+            horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.xs),
         ) {
             Text(
                 text = stringResource(Res.string.filter),
@@ -382,8 +382,8 @@ internal fun BeneficiaryFilters(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(DesignToken.padding.large)
-                .padding(top = DesignToken.padding.large),
+                .padding(KptTheme.spacing.md)
+                .padding(top = KptTheme.spacing.md),
         ) {
             FilterTopSection(
                 isAnyFilterSelected = state.isAnyFilterSelected,
@@ -454,8 +454,8 @@ internal fun FilterSection(
     ) {
         Column(
             modifier = Modifier.padding(
-                start = DesignToken.spacing.extraLargeIncreased,
-                end = DesignToken.spacing.small,
+                start = KptTheme.spacing.xl,
+                end = KptTheme.spacing.sm,
                 top = DesignToken.padding.medium,
             ),
             verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.medium),
@@ -473,7 +473,7 @@ internal fun FilterSection(
                     color = KptTheme.colorScheme.onBackground,
                 )
                 Row(
-                    horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.extraSmall),
+                    horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.xs),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     if (selectedFilters.isNotEmpty()) {
@@ -520,7 +520,7 @@ internal fun FilterSection(
                                 },
                             )
 
-                            Spacer(modifier = Modifier.width(DesignToken.spacing.small))
+                            Spacer(modifier = Modifier.width(KptTheme.spacing.sm))
                             Text(
                                 text = filter ?: "",
                                 style = MifosTypography.labelMediumEmphasized,

--- a/feature/beneficiary/src/commonMain/kotlin/org/mifos/mobile/feature/beneficiary/beneficiaryList/BeneficiaryListScreen.kt
+++ b/feature/beneficiary/src/commonMain/kotlin/org/mifos/mobile/feature/beneficiary/beneficiaryList/BeneficiaryListScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -75,6 +74,8 @@ import org.mifos.mobile.core.ui.component.MifosPoweredCard
 import org.mifos.mobile.core.ui.component.MifosProgressIndicator
 import org.mifos.mobile.core.ui.utils.EventsEffect
 import org.mifos.mobile.core.ui.utils.ScreenUiState
+import template.core.base.designsystem.theme.KptTheme
+
 /**
  * Composable function to display the beneficiary list screen.
  *
@@ -312,7 +313,7 @@ internal fun ActionBar(
         ) {
             Text(
                 text = stringResource(Res.string.add),
-                color = MaterialTheme.colorScheme.primary,
+                color = KptTheme.colorScheme.primary,
                 style = MifosTypography.bodySmallEmphasized,
             )
 
@@ -320,7 +321,7 @@ internal fun ActionBar(
                 modifier = Modifier.size(DesignToken.sizes.iconSmall),
                 imageVector = MifosIcons.Add,
                 contentDescription = null,
-                tint = MaterialTheme.colorScheme.primary,
+                tint = KptTheme.colorScheme.primary,
             )
         }
 
@@ -335,7 +336,7 @@ internal fun ActionBar(
         ) {
             Text(
                 text = stringResource(Res.string.filter),
-                color = MaterialTheme.colorScheme.primary,
+                color = KptTheme.colorScheme.primary,
                 style = MifosTypography.bodySmallEmphasized,
             )
 
@@ -343,7 +344,7 @@ internal fun ActionBar(
                 modifier = Modifier.size(DesignToken.sizes.iconSmall),
                 imageVector = MifosIcons.Filter,
                 contentDescription = stringResource(Res.string.filter),
-                tint = MaterialTheme.colorScheme.primary,
+                tint = KptTheme.colorScheme.primary,
             )
         }
     }
@@ -469,7 +470,7 @@ internal fun FilterSection(
                 Text(
                     text = title,
                     style = MifosTypography.labelLargeEmphasized,
-                    color = MaterialTheme.colorScheme.onBackground,
+                    color = KptTheme.colorScheme.onBackground,
                 )
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.extraSmall),
@@ -479,7 +480,7 @@ internal fun FilterSection(
                         Text(
                             text = "${selectedFilters.size} selected",
                             style = MifosTypography.labelSmall,
-                            color = MaterialTheme.colorScheme.secondary,
+                            color = KptTheme.colorScheme.secondary,
                         )
                     }
                     Icon(
@@ -523,7 +524,7 @@ internal fun FilterSection(
                             Text(
                                 text = filter ?: "",
                                 style = MifosTypography.labelMediumEmphasized,
-                                color = MaterialTheme.colorScheme.secondary,
+                                color = KptTheme.colorScheme.secondary,
                             )
                         }
                     }

--- a/feature/beneficiary/src/commonMain/kotlin/org/mifos/mobile/feature/beneficiary/beneficiaryList/BeneficiaryListScreen.kt
+++ b/feature/beneficiary/src/commonMain/kotlin/org/mifos/mobile/feature/beneficiary/beneficiaryList/BeneficiaryListScreen.kt
@@ -43,7 +43,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import mifos_mobile.feature.beneficiary.generated.resources.Res
 import mifos_mobile.feature.beneficiary.generated.resources.add
@@ -400,7 +399,7 @@ internal fun BeneficiaryFilters(
 
             Spacer(Modifier.height(DesignToken.spacing.largeIncreased))
 
-            HorizontalDivider(modifier = Modifier.height(1.dp))
+            HorizontalDivider(modifier = Modifier.height(DesignToken.strokes.thin))
 
             FilterSection(
                 title = stringResource(Res.string.linked_with),
@@ -535,7 +534,7 @@ internal fun FilterSection(
         HorizontalDivider(
             modifier = Modifier
                 .padding(top = DesignToken.padding.medium)
-                .height(1.dp),
+                .height(DesignToken.strokes.thin),
         )
     }
 }

--- a/feature/client-charge/src/commonMain/kotlin/org/mifos/mobile/feature/charge/chargeDetails/ChargeDetailScreen.kt
+++ b/feature/client-charge/src/commonMain/kotlin/org/mifos/mobile/feature/charge/chargeDetails/ChargeDetailScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -48,6 +47,7 @@ import org.mifos.mobile.core.designsystem.theme.MifosTypography
 import org.mifos.mobile.core.ui.component.MifosDetailsCard
 import org.mifos.mobile.core.ui.component.MifosPoweredCard
 import org.mifos.mobile.core.ui.utils.EventsEffect
+import template.core.base.designsystem.theme.KptTheme
 import mifos_mobile.core.ui.generated.resources.Res as uiRes
 
 /**
@@ -138,7 +138,7 @@ fun ChargeDetailsPaidComponent(
     ) {
         Text(
             text = stringResource(Res.string.paid_success_message),
-            style = MaterialTheme.typography.bodySmall,
+            style = KptTheme.typography.bodySmall,
             textAlign = TextAlign.Center,
         )
         Spacer(Modifier.height(DesignToken.padding.medium))
@@ -152,7 +152,7 @@ fun ChargeDetailsPaidComponent(
         Spacer(Modifier.height(DesignToken.padding.medium))
         Text(
             text = stringResource(Res.string.ref_no, refNo),
-            style = MaterialTheme.typography.bodySmall,
+            style = KptTheme.typography.bodySmall,
             textAlign = TextAlign.Center,
         )
         Spacer(Modifier.height(DesignToken.padding.small))
@@ -161,7 +161,7 @@ fun ChargeDetailsPaidComponent(
                 text = stringResource(Res.string.paid_on, paidOn),
                 style = MifosTypography.bodySmallEmphasized,
                 textAlign = TextAlign.Center,
-                color = MaterialTheme.colorScheme.primary,
+                color = KptTheme.colorScheme.primary,
             )
         }
     }
@@ -198,7 +198,7 @@ fun ChargeDetailsUnPaidComponent(
         if (amountPaidOn.isNotEmpty()) {
             Text(
                 text = stringResource(Res.string.partial_amount_paid_on, amountPaidOn),
-                style = MaterialTheme.typography.bodySmall,
+                style = KptTheme.typography.bodySmall,
             )
         }
     }

--- a/feature/client-charge/src/commonMain/kotlin/org/mifos/mobile/feature/charge/chargeDetails/ChargeDetailScreen.kt
+++ b/feature/client-charge/src/commonMain/kotlin/org/mifos/mobile/feature/charge/chargeDetails/ChargeDetailScreen.kt
@@ -93,7 +93,7 @@ internal fun ChargeDetailScreen(
                     .verticalScroll(rememberScrollState())
                     .padding(
                         vertical = DesignToken.padding.extraLarge,
-                        horizontal = DesignToken.padding.large,
+                        horizontal = KptTheme.spacing.md,
                     ),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
@@ -155,7 +155,7 @@ fun ChargeDetailsPaidComponent(
             style = KptTheme.typography.bodySmall,
             textAlign = TextAlign.Center,
         )
-        Spacer(Modifier.height(DesignToken.padding.small))
+        Spacer(Modifier.height(KptTheme.spacing.sm))
         if (paidOn.isNotEmpty()) {
             Text(
                 text = stringResource(Res.string.paid_on, paidOn),
@@ -189,12 +189,12 @@ fun ChargeDetailsUnPaidComponent(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(DesignToken.sizes.buttonHeight),
-            shape = DesignToken.shapes.medium,
+            shape = KptTheme.shapes.medium,
             onClick = onPayOutStanding,
         ) {
             Text(stringResource(Res.string.pay_outstanding))
         }
-        Spacer(Modifier.height(DesignToken.padding.large))
+        Spacer(Modifier.height(KptTheme.spacing.md))
         if (amountPaidOn.isNotEmpty()) {
             Text(
                 text = stringResource(Res.string.partial_amount_paid_on, amountPaidOn),

--- a/feature/client-charge/src/commonMain/kotlin/org/mifos/mobile/feature/charge/chargeDetails/ChargeDetailScreen.kt
+++ b/feature/client-charge/src/commonMain/kotlin/org/mifos/mobile/feature/charge/chargeDetails/ChargeDetailScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import mifos_mobile.core.ui.generated.resources.ic_icon_success
 import mifos_mobile.feature.client_charge.generated.resources.Res
@@ -144,8 +143,8 @@ fun ChargeDetailsPaidComponent(
         Spacer(Modifier.height(DesignToken.padding.medium))
         Image(
             modifier = Modifier
-                .height(60.dp)
-                .width(60.dp),
+                .height(DesignToken.sizes.imageDp60)
+                .width(DesignToken.sizes.imageDp60),
             painter = painterResource(uiRes.drawable.ic_icon_success),
             contentDescription = "Status icon",
         )

--- a/feature/client-charge/src/commonMain/kotlin/org/mifos/mobile/feature/charge/charges/ClientChargeScreen.kt
+++ b/feature/client-charge/src/commonMain/kotlin/org/mifos/mobile/feature/charge/charges/ClientChargeScreen.kt
@@ -33,7 +33,6 @@ import org.koin.compose.viewmodel.koinViewModel
 import org.mifos.mobile.core.designsystem.component.BasicDialogState
 import org.mifos.mobile.core.designsystem.component.MifosBasicDialog
 import org.mifos.mobile.core.designsystem.component.MifosElevatedScaffold
-import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.model.entity.Charge
 import org.mifos.mobile.core.model.enums.ChargeType
@@ -44,6 +43,8 @@ import org.mifos.mobile.core.ui.component.MifosProgressIndicator
 import org.mifos.mobile.core.ui.utils.EventsEffect
 import org.mifos.mobile.core.ui.utils.ScreenUiState
 import org.mifos.mobile.feature.charge.components.ClientChargeItem
+import template.core.base.designsystem.theme.KptTheme
+
 /**
  * Composable function that displays the Client Charges Screen.
  *
@@ -151,7 +152,7 @@ private fun ClientChargeScreen(
 
             ScreenUiState.Success -> {
                 ClientChargeContent(
-                    modifier = Modifier.padding(DesignToken.padding.large),
+                    modifier = Modifier.padding(KptTheme.spacing.md),
                     chargesList = state.charges,
                     onChargeClick = {
                         onAction(ClientChargeAction.OnChargeClick(it))

--- a/feature/client-charge/src/commonMain/kotlin/org/mifos/mobile/feature/charge/components/ClientChargeItem.kt
+++ b/feature/client-charge/src/commonMain/kotlin/org/mifos/mobile/feature/charge/components/ClientChargeItem.kt
@@ -74,7 +74,7 @@ fun ClientChargeItem(
             contentDescription = "Charges Symbol",
             tint = KptTheme.colorScheme.onBackground.copy(alpha = 0.7f),
             modifier = Modifier
-                .size(36.dp)
+                .size(DesignToken.sizes.iconExtraLarge)
                 .background(
                     color = KptTheme.colorScheme.background.copy(alpha = 0.3f),
                     shape = CircleShape,

--- a/feature/client-charge/src/commonMain/kotlin/org/mifos/mobile/feature/charge/components/ClientChargeItem.kt
+++ b/feature/client-charge/src/commonMain/kotlin/org/mifos/mobile/feature/charge/components/ClientChargeItem.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import mifos_mobile.feature.client_charge.generated.resources.Res
 import mifos_mobile.feature.client_charge.generated.resources.database_checkmark
 import mifos_mobile.feature.client_charge.generated.resources.database_warning
@@ -154,7 +153,7 @@ fun ClientChargeItem(
             Icon(
                 imageVector = MifosIcons.ChevronRight,
                 contentDescription = "",
-                modifier = Modifier.size(20.dp),
+                modifier = Modifier.size(DesignToken.sizes.iconDp20),
             )
         }
     }

--- a/feature/client-charge/src/commonMain/kotlin/org/mifos/mobile/feature/charge/components/ClientChargeItem.kt
+++ b/feature/client-charge/src/commonMain/kotlin/org/mifos/mobile/feature/charge/components/ClientChargeItem.kt
@@ -61,7 +61,7 @@ fun ClientChargeItem(
             .clickable {
                 onChargeClick()
             }
-            .padding(vertical = DesignToken.padding.large),
+            .padding(vertical = KptTheme.spacing.md),
         horizontalArrangement = Arrangement.SpaceEvenly,
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -79,7 +79,7 @@ fun ClientChargeItem(
                     color = KptTheme.colorScheme.background.copy(alpha = 0.3f),
                     shape = CircleShape,
                 )
-                .padding(DesignToken.padding.small),
+                .padding(KptTheme.spacing.sm),
 
         )
         Spacer(Modifier.width(DesignToken.padding.medium))
@@ -107,7 +107,7 @@ fun ClientChargeItem(
         Spacer(Modifier.width(DesignToken.padding.medium))
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.extraSmall),
+            horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.xs),
         ) {
             Column(
                 horizontalAlignment = Alignment.End,

--- a/feature/client-charge/src/commonMain/kotlin/org/mifos/mobile/feature/charge/components/ClientChargeItem.kt
+++ b/feature/client-charge/src/commonMain/kotlin/org/mifos/mobile/feature/charge/components/ClientChargeItem.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -40,6 +39,7 @@ import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
 import org.mifos.mobile.core.model.entity.Charge
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * Composable function that displays a charge item.
@@ -72,11 +72,11 @@ fun ClientChargeItem(
                 painterResource(Res.drawable.database_warning)
             },
             contentDescription = "Charges Symbol",
-            tint = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
+            tint = KptTheme.colorScheme.onBackground.copy(alpha = 0.7f),
             modifier = Modifier
                 .size(36.dp)
                 .background(
-                    color = MaterialTheme.colorScheme.background.copy(alpha = 0.3f),
+                    color = KptTheme.colorScheme.background.copy(alpha = 0.3f),
                     shape = CircleShape,
                 )
                 .padding(DesignToken.padding.small),
@@ -122,7 +122,7 @@ fun ClientChargeItem(
                     color = if (charge.isChargePaid) {
                         AppColors.customEnable
                     } else {
-                        MaterialTheme.colorScheme.error
+                        KptTheme.colorScheme.error
                     },
                 )
                 Text(
@@ -147,7 +147,7 @@ fun ClientChargeItem(
                     color = if (charge.isChargePaid) {
                         AppColors.customEnable
                     } else {
-                        MaterialTheme.colorScheme.error
+                        KptTheme.colorScheme.error
                     },
                 )
             }

--- a/feature/guarantor/src/commonMain/kotlin/org/mifos/mobile/feature/guarantor/screens/guarantorAdd/AddGuarantorScreen.kt
+++ b/feature/guarantor/src/commonMain/kotlin/org/mifos/mobile/feature/guarantor/screens/guarantorAdd/AddGuarantorScreen.kt
@@ -46,12 +46,12 @@ import org.mifos.mobile.core.designsystem.component.MifosButton
 import org.mifos.mobile.core.designsystem.component.MifosLoadingDialog
 import org.mifos.mobile.core.designsystem.component.MifosScaffold
 import org.mifos.mobile.core.designsystem.component.MifosTextField
-import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.model.entity.guarantor.GuarantorApplicationPayload
 import org.mifos.mobile.core.model.entity.guarantor.GuarantorPayload
 import org.mifos.mobile.core.model.entity.guarantor.GuarantorType
 import org.mifos.mobile.core.ui.component.MifosDropDownTextField
 import org.mifos.mobile.core.ui.utils.EventsEffect
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 internal fun AddGuarantorScreen(
@@ -149,8 +149,8 @@ private fun AddGuarantorContent(
     Column(
         modifier = modifier
             .verticalScroll(state = scrollState)
-            .padding(horizontal = DesignToken.padding.large)
-            .padding(bottom = DesignToken.padding.large),
+            .padding(horizontal = KptTheme.spacing.md)
+            .padding(bottom = KptTheme.spacing.md),
     ) {
         MifosDropDownTextField(
             optionsList = guarantorTypeOptions.filter { it.id == 3L }.mapNotNull { it.value },

--- a/feature/guarantor/src/commonMain/kotlin/org/mifos/mobile/feature/guarantor/screens/guarantorAdd/AddGuarantorScreen.kt
+++ b/feature/guarantor/src/commonMain/kotlin/org/mifos/mobile/feature/guarantor/screens/guarantorAdd/AddGuarantorScreen.kt
@@ -46,6 +46,7 @@ import org.mifos.mobile.core.designsystem.component.MifosButton
 import org.mifos.mobile.core.designsystem.component.MifosLoadingDialog
 import org.mifos.mobile.core.designsystem.component.MifosScaffold
 import org.mifos.mobile.core.designsystem.component.MifosTextField
+import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.model.entity.guarantor.GuarantorApplicationPayload
 import org.mifos.mobile.core.model.entity.guarantor.GuarantorPayload
 import org.mifos.mobile.core.model.entity.guarantor.GuarantorType
@@ -148,8 +149,8 @@ private fun AddGuarantorContent(
     Column(
         modifier = modifier
             .verticalScroll(state = scrollState)
-            .padding(horizontal = 16.dp)
-            .padding(bottom = 16.dp),
+            .padding(horizontal = DesignToken.padding.large)
+            .padding(bottom = DesignToken.padding.large),
     ) {
         MifosDropDownTextField(
             optionsList = guarantorTypeOptions.filter { it.id == 3L }.mapNotNull { it.value },

--- a/feature/guarantor/src/commonMain/kotlin/org/mifos/mobile/feature/guarantor/screens/guarantorAdd/AddGuarantorScreen.kt
+++ b/feature/guarantor/src/commonMain/kotlin/org/mifos/mobile/feature/guarantor/screens/guarantorAdd/AddGuarantorScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.launch
 import mifos_mobile.feature.guarantor.generated.resources.Res
@@ -46,6 +45,7 @@ import org.mifos.mobile.core.designsystem.component.MifosButton
 import org.mifos.mobile.core.designsystem.component.MifosLoadingDialog
 import org.mifos.mobile.core.designsystem.component.MifosScaffold
 import org.mifos.mobile.core.designsystem.component.MifosTextField
+import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.model.entity.guarantor.GuarantorApplicationPayload
 import org.mifos.mobile.core.model.entity.guarantor.GuarantorPayload
 import org.mifos.mobile.core.model.entity.guarantor.GuarantorType
@@ -187,7 +187,7 @@ private fun AddGuarantorContent(
             label = stringResource(Res.string.city),
         )
 
-        Spacer(modifier = Modifier.height(10.dp))
+        Spacer(modifier = Modifier.height(DesignToken.spacing.dp10))
 
         MifosButton(
             content = { Text(stringResource(Res.string.submit)) },

--- a/feature/guarantor/src/commonMain/kotlin/org/mifos/mobile/feature/guarantor/screens/guarantorDetails/GuarantorDetailContent.kt
+++ b/feature/guarantor/src/commonMain/kotlin/org/mifos/mobile/feature/guarantor/screens/guarantorDetails/GuarantorDetailContent.kt
@@ -21,7 +21,6 @@ import mifos_mobile.feature.guarantor.generated.resources.first_name
 import mifos_mobile.feature.guarantor.generated.resources.guarantor_type
 import mifos_mobile.feature.guarantor.generated.resources.last_name
 import org.jetbrains.compose.resources.stringResource
-import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.model.entity.guarantor.GuarantorPayload
 import org.mifos.mobile.core.ui.component.MifosTextTitleDescDoubleLine
 import template.core.base.designsystem.theme.KptTheme
@@ -34,7 +33,7 @@ internal fun GuarantorDetailContent(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(DesignToken.padding.large),
+            .padding(KptTheme.spacing.md),
     ) {
         MifosTextTitleDescDoubleLine(
             title = stringResource(Res.string.first_name),
@@ -42,7 +41,7 @@ internal fun GuarantorDetailContent(
             descriptionStyle = KptTheme.typography.bodyLarge,
         )
 
-        HorizontalDivider(modifier = Modifier.padding(vertical = DesignToken.padding.small))
+        HorizontalDivider(modifier = Modifier.padding(vertical = KptTheme.spacing.sm))
 
         MifosTextTitleDescDoubleLine(
             title = stringResource(Res.string.last_name),
@@ -50,7 +49,7 @@ internal fun GuarantorDetailContent(
             descriptionStyle = KptTheme.typography.bodyLarge,
         )
 
-        HorizontalDivider(modifier = Modifier.padding(vertical = DesignToken.padding.small))
+        HorizontalDivider(modifier = Modifier.padding(vertical = KptTheme.spacing.sm))
 
         MifosTextTitleDescDoubleLine(
             title = stringResource(Res.string.city),
@@ -58,7 +57,7 @@ internal fun GuarantorDetailContent(
             descriptionStyle = KptTheme.typography.bodyLarge,
         )
 
-        HorizontalDivider(modifier = Modifier.padding(vertical = DesignToken.padding.small))
+        HorizontalDivider(modifier = Modifier.padding(vertical = KptTheme.spacing.sm))
 
         MifosTextTitleDescDoubleLine(
             title = stringResource(Res.string.guarantor_type),
@@ -66,6 +65,6 @@ internal fun GuarantorDetailContent(
             descriptionStyle = KptTheme.typography.bodyLarge,
         )
 
-        HorizontalDivider(modifier = Modifier.padding(vertical = DesignToken.padding.small))
+        HorizontalDivider(modifier = Modifier.padding(vertical = KptTheme.spacing.sm))
     }
 }

--- a/feature/guarantor/src/commonMain/kotlin/org/mifos/mobile/feature/guarantor/screens/guarantorDetails/GuarantorDetailContent.kt
+++ b/feature/guarantor/src/commonMain/kotlin/org/mifos/mobile/feature/guarantor/screens/guarantorDetails/GuarantorDetailContent.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -25,6 +24,7 @@ import mifos_mobile.feature.guarantor.generated.resources.last_name
 import org.jetbrains.compose.resources.stringResource
 import org.mifos.mobile.core.model.entity.guarantor.GuarantorPayload
 import org.mifos.mobile.core.ui.component.MifosTextTitleDescDoubleLine
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 internal fun GuarantorDetailContent(
@@ -39,7 +39,7 @@ internal fun GuarantorDetailContent(
         MifosTextTitleDescDoubleLine(
             title = stringResource(Res.string.first_name),
             description = data.firstname ?: "",
-            descriptionStyle = MaterialTheme.typography.bodyLarge,
+            descriptionStyle = KptTheme.typography.bodyLarge,
         )
 
         HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
@@ -47,7 +47,7 @@ internal fun GuarantorDetailContent(
         MifosTextTitleDescDoubleLine(
             title = stringResource(Res.string.last_name),
             description = data.lastname ?: "",
-            descriptionStyle = MaterialTheme.typography.bodyLarge,
+            descriptionStyle = KptTheme.typography.bodyLarge,
         )
 
         HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
@@ -55,7 +55,7 @@ internal fun GuarantorDetailContent(
         MifosTextTitleDescDoubleLine(
             title = stringResource(Res.string.city),
             description = data.city ?: "",
-            descriptionStyle = MaterialTheme.typography.bodyLarge,
+            descriptionStyle = KptTheme.typography.bodyLarge,
         )
 
         HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
@@ -63,7 +63,7 @@ internal fun GuarantorDetailContent(
         MifosTextTitleDescDoubleLine(
             title = stringResource(Res.string.guarantor_type),
             description = data.guarantorType?.value ?: "",
-            descriptionStyle = MaterialTheme.typography.bodyLarge,
+            descriptionStyle = KptTheme.typography.bodyLarge,
         )
 
         HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))

--- a/feature/guarantor/src/commonMain/kotlin/org/mifos/mobile/feature/guarantor/screens/guarantorDetails/GuarantorDetailContent.kt
+++ b/feature/guarantor/src/commonMain/kotlin/org/mifos/mobile/feature/guarantor/screens/guarantorDetails/GuarantorDetailContent.kt
@@ -15,13 +15,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import mifos_mobile.feature.guarantor.generated.resources.Res
 import mifos_mobile.feature.guarantor.generated.resources.city
 import mifos_mobile.feature.guarantor.generated.resources.first_name
 import mifos_mobile.feature.guarantor.generated.resources.guarantor_type
 import mifos_mobile.feature.guarantor.generated.resources.last_name
 import org.jetbrains.compose.resources.stringResource
+import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.model.entity.guarantor.GuarantorPayload
 import org.mifos.mobile.core.ui.component.MifosTextTitleDescDoubleLine
 import template.core.base.designsystem.theme.KptTheme
@@ -34,7 +34,7 @@ internal fun GuarantorDetailContent(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(16.dp),
+            .padding(DesignToken.padding.large),
     ) {
         MifosTextTitleDescDoubleLine(
             title = stringResource(Res.string.first_name),
@@ -42,7 +42,7 @@ internal fun GuarantorDetailContent(
             descriptionStyle = KptTheme.typography.bodyLarge,
         )
 
-        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+        HorizontalDivider(modifier = Modifier.padding(vertical = DesignToken.padding.small))
 
         MifosTextTitleDescDoubleLine(
             title = stringResource(Res.string.last_name),
@@ -50,7 +50,7 @@ internal fun GuarantorDetailContent(
             descriptionStyle = KptTheme.typography.bodyLarge,
         )
 
-        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+        HorizontalDivider(modifier = Modifier.padding(vertical = DesignToken.padding.small))
 
         MifosTextTitleDescDoubleLine(
             title = stringResource(Res.string.city),
@@ -58,7 +58,7 @@ internal fun GuarantorDetailContent(
             descriptionStyle = KptTheme.typography.bodyLarge,
         )
 
-        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+        HorizontalDivider(modifier = Modifier.padding(vertical = DesignToken.padding.small))
 
         MifosTextTitleDescDoubleLine(
             title = stringResource(Res.string.guarantor_type),
@@ -66,6 +66,6 @@ internal fun GuarantorDetailContent(
             descriptionStyle = KptTheme.typography.bodyLarge,
         )
 
-        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+        HorizontalDivider(modifier = Modifier.padding(vertical = DesignToken.padding.small))
     }
 }

--- a/feature/guarantor/src/commonMain/kotlin/org/mifos/mobile/feature/guarantor/screens/guarantorList/GuarantorListScreen.kt
+++ b/feature/guarantor/src/commonMain/kotlin/org/mifos/mobile/feature/guarantor/screens/guarantorList/GuarantorListScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
@@ -42,6 +41,7 @@ import org.mifos.mobile.core.model.entity.guarantor.GuarantorPayload
 import org.mifos.mobile.core.ui.component.MifosErrorComponent
 import org.mifos.mobile.core.ui.component.MifosProgressIndicator
 import org.mifos.mobile.core.ui.utils.EventsEffect
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 internal fun GuarantorListScreen(
@@ -100,7 +100,7 @@ private fun GuarantorListScreen(
                     contentDescription = null,
                 )
             },
-            contentColor = MaterialTheme.colorScheme.primary,
+            contentColor = KptTheme.colorScheme.primary,
         ),
         content = {
             if (state.guarantorList == null) {
@@ -148,7 +148,7 @@ private fun GuarantorListItem(
     guarantor: GuarantorPayload = GuarantorPayload(),
 ) {
     OutlinedCard(
-        colors = CardDefaults.outlinedCardColors(containerColor = MaterialTheme.colorScheme.background),
+        colors = CardDefaults.outlinedCardColors(containerColor = KptTheme.colorScheme.background),
         modifier = modifier
             .padding(horizontal = 16.dp, vertical = 8.dp)
             .fillMaxWidth(),
@@ -157,11 +157,11 @@ private fun GuarantorListItem(
             Column(modifier = Modifier.padding(8.dp)) {
                 Text(
                     text = guarantor.firstname + " " + guarantor.lastname,
-                    style = MaterialTheme.typography.bodyMedium,
+                    style = KptTheme.typography.bodyMedium,
                 )
                 Text(
                     text = guarantor.guarantorType?.value ?: "",
-                    style = MaterialTheme.typography.labelMedium,
+                    style = KptTheme.typography.labelMedium,
                 )
             }
         },

--- a/feature/guarantor/src/commonMain/kotlin/org/mifos/mobile/feature/guarantor/screens/guarantorList/GuarantorListScreen.kt
+++ b/feature/guarantor/src/commonMain/kotlin/org/mifos/mobile/feature/guarantor/screens/guarantorList/GuarantorListScreen.kt
@@ -23,9 +23,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.launch
 import mifos_mobile.feature.guarantor.generated.resources.Res
@@ -37,6 +35,7 @@ import org.mifos.mobile.core.designsystem.component.FloatingActionButtonContent
 import org.mifos.mobile.core.designsystem.component.MifosBasicDialog
 import org.mifos.mobile.core.designsystem.component.MifosScaffold
 import org.mifos.mobile.core.designsystem.icon.MifosIcons
+import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.model.entity.guarantor.GuarantorPayload
 import org.mifos.mobile.core.ui.component.MifosErrorComponent
 import org.mifos.mobile.core.ui.component.MifosProgressIndicator
@@ -150,11 +149,11 @@ private fun GuarantorListItem(
     OutlinedCard(
         colors = CardDefaults.outlinedCardColors(containerColor = KptTheme.colorScheme.background),
         modifier = modifier
-            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .padding(horizontal = DesignToken.padding.large, vertical = DesignToken.padding.small)
             .fillMaxWidth(),
         onClick = { onGuarantorClicked.invoke() },
         content = {
-            Column(modifier = Modifier.padding(8.dp)) {
+            Column(modifier = Modifier.padding(DesignToken.padding.small)) {
                 Text(
                     text = guarantor.firstname + " " + guarantor.lastname,
                     style = KptTheme.typography.bodyMedium,

--- a/feature/guarantor/src/commonMain/kotlin/org/mifos/mobile/feature/guarantor/screens/guarantorList/GuarantorListScreen.kt
+++ b/feature/guarantor/src/commonMain/kotlin/org/mifos/mobile/feature/guarantor/screens/guarantorList/GuarantorListScreen.kt
@@ -35,7 +35,6 @@ import org.mifos.mobile.core.designsystem.component.FloatingActionButtonContent
 import org.mifos.mobile.core.designsystem.component.MifosBasicDialog
 import org.mifos.mobile.core.designsystem.component.MifosScaffold
 import org.mifos.mobile.core.designsystem.icon.MifosIcons
-import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.model.entity.guarantor.GuarantorPayload
 import org.mifos.mobile.core.ui.component.MifosErrorComponent
 import org.mifos.mobile.core.ui.component.MifosProgressIndicator
@@ -149,11 +148,11 @@ private fun GuarantorListItem(
     OutlinedCard(
         colors = CardDefaults.outlinedCardColors(containerColor = KptTheme.colorScheme.background),
         modifier = modifier
-            .padding(horizontal = DesignToken.padding.large, vertical = DesignToken.padding.small)
+            .padding(horizontal = KptTheme.spacing.md, vertical = KptTheme.spacing.sm)
             .fillMaxWidth(),
         onClick = { onGuarantorClicked.invoke() },
         content = {
-            Column(modifier = Modifier.padding(DesignToken.padding.small)) {
+            Column(modifier = Modifier.padding(KptTheme.spacing.sm)) {
                 Text(
                     text = guarantor.firstname + " " + guarantor.lastname,
                     style = KptTheme.typography.bodyMedium,

--- a/feature/home/src/commonMain/kotlin/org/mifos/mobile/feature/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/org/mifos/mobile/feature/home/HomeScreen.kt
@@ -130,7 +130,7 @@ internal fun HomeContent(
         onNavigateBack = {},
         actions = {
             Row(
-                horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.large),
+                horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.md),
             ) {
                 // TODO : once ui/ux team gives this flow uncomment and implement
 //                Image(
@@ -171,9 +171,9 @@ internal fun HomeContent(
                 Column(
                     modifier = Modifier
                         .verticalScroll(rememberScrollState())
-                        .padding(DesignToken.padding.large),
+                        .padding(KptTheme.spacing.md),
                 ) {
-                    Spacer(modifier = Modifier.height(DesignToken.spacing.small))
+                    Spacer(modifier = Modifier.height(KptTheme.spacing.sm))
                     Text(
                         text = stringResource(
                             Res.string.feature_home_greet,
@@ -183,7 +183,7 @@ internal fun HomeContent(
                         color = KptTheme.colorScheme.onSurface,
                     )
 
-                    Spacer(modifier = Modifier.height(DesignToken.spacing.large))
+                    Spacer(modifier = Modifier.height(KptTheme.spacing.md))
 
                     if (state.isAccountsPresent) {
                         MifosDashboardCard(
@@ -209,7 +209,7 @@ internal fun HomeContent(
                         color = KptTheme.colorScheme.onSurface,
                     )
 
-                    Spacer(modifier = Modifier.height(DesignToken.spacing.large))
+                    Spacer(modifier = Modifier.height(KptTheme.spacing.md))
 
                     ServiceBox(
                         items = state.items,
@@ -261,8 +261,8 @@ internal fun ServiceItemCard(
 ) {
     Column(
         modifier = modifier
-            .padding(vertical = DesignToken.padding.small),
-        verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.small),
+            .padding(vertical = KptTheme.spacing.sm),
+        verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.sm),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Box(
@@ -276,7 +276,7 @@ internal fun ServiceItemCard(
                     .border(
                         1.dp,
                         KptTheme.colorScheme.secondaryContainer,
-                        DesignToken.shapes.medium,
+                        KptTheme.shapes.medium,
                     )
                     .padding(DesignToken.padding.medium + 2.dp),
                 imageVector = icon,

--- a/feature/home/src/commonMain/kotlin/org/mifos/mobile/feature/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/org/mifos/mobile/feature/home/HomeScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -68,6 +67,7 @@ import org.mifos.mobile.core.ui.utils.EventsEffect
 import org.mifos.mobile.feature.home.components.BottomSheetContent
 import org.mifos.mobile.feature.home.navigation.HomeNavigationDestination
 import org.mifos.mobile.feature.home.navigation.HomeNavigator
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 internal fun HomeScreen(
@@ -140,7 +140,7 @@ internal fun HomeContent(
                 Image(
                     imageVector = MifosIcons.Alert,
                     contentDescription = null,
-                    colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onSurface),
+                    colorFilter = ColorFilter.tint(KptTheme.colorScheme.onSurface),
                     modifier = Modifier.clickable {
                         onAction(HomeAction.OnNotificationClick)
                     },
@@ -180,7 +180,7 @@ internal fun HomeContent(
                             state.firstName.toString(),
                         ),
                         style = MifosTypography.titleLarge,
-                        color = MaterialTheme.colorScheme.onSurface,
+                        color = KptTheme.colorScheme.onSurface,
                     )
 
                     Spacer(modifier = Modifier.height(DesignToken.spacing.large))
@@ -206,7 +206,7 @@ internal fun HomeContent(
                     Text(
                         text = stringResource(Res.string.feature_home_services),
                         style = MifosTypography.titleMediumEmphasized,
-                        color = MaterialTheme.colorScheme.onSurface,
+                        color = KptTheme.colorScheme.onSurface,
                     )
 
                     Spacer(modifier = Modifier.height(DesignToken.spacing.large))
@@ -275,20 +275,20 @@ internal fun ServiceItemCard(
                 modifier = Modifier
                     .border(
                         1.dp,
-                        MaterialTheme.colorScheme.secondaryContainer,
+                        KptTheme.colorScheme.secondaryContainer,
                         DesignToken.shapes.medium,
                     )
                     .padding(DesignToken.padding.medium + 2.dp),
                 imageVector = icon,
                 contentDescription = null,
-                colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.tertiary),
+                colorFilter = ColorFilter.tint(KptTheme.colorScheme.tertiary),
             )
         }
 
         Text(
             text = stringResource(title),
             style = MifosTypography.bodySmallEmphasized,
-            color = MaterialTheme.colorScheme.onSurface,
+            color = KptTheme.colorScheme.onSurface,
             textAlign = TextAlign.Center,
         )
     }
@@ -325,7 +325,7 @@ private fun HomeScreenDialog(
                     onAction(HomeAction.OnDismissDialog)
                 },
                 sheetState = sheetState,
-                containerColor = MaterialTheme.colorScheme.surface,
+                containerColor = KptTheme.colorScheme.surface,
                 contentWindowInsets = {
                     BottomSheetDefaults.windowInsets
                 },

--- a/feature/home/src/commonMain/kotlin/org/mifos/mobile/feature/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/org/mifos/mobile/feature/home/HomeScreen.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.collections.immutable.ImmutableList
 import mifos_mobile.core.ui.generated.resources.ic_icon_logo_1
@@ -274,11 +273,11 @@ internal fun ServiceItemCard(
             Image(
                 modifier = Modifier
                     .border(
-                        1.dp,
+                        DesignToken.strokes.thin,
                         KptTheme.colorScheme.secondaryContainer,
                         KptTheme.shapes.medium,
                     )
-                    .padding(DesignToken.padding.medium + 2.dp),
+                    .padding(DesignToken.padding.dp14),
                 imageVector = icon,
                 contentDescription = null,
                 colorFilter = ColorFilter.tint(KptTheme.colorScheme.tertiary),

--- a/feature/home/src/commonMain/kotlin/org/mifos/mobile/feature/home/components/BottomSheetContent.kt
+++ b/feature/home/src/commonMain/kotlin/org/mifos/mobile/feature/home/components/BottomSheetContent.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -45,6 +44,7 @@ import org.mifos.mobile.core.designsystem.icon.MifosIcons
 import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
 import org.mifos.mobile.feature.home.HomeAction
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 internal fun BottomSheetContent(
@@ -95,7 +95,7 @@ internal fun BottomSheetIconContainer(
                 .fillMaxWidth()
                 .border(
                     1.dp,
-                    MaterialTheme.colorScheme.secondaryContainer,
+                    KptTheme.colorScheme.secondaryContainer,
                     DesignToken.shapes.medium,
                 ),
             onClick = { onClick(it) },
@@ -109,7 +109,7 @@ internal fun BottomSheetIconContainer(
                     modifier = Modifier.size(DesignToken.sizes.inputHeight)
                         .border(
                             1.dp,
-                            MaterialTheme.colorScheme.secondaryContainer,
+                            KptTheme.colorScheme.secondaryContainer,
                             DesignToken.shapes.medium,
                         ),
                     contentAlignment = Alignment.Center,
@@ -134,7 +134,7 @@ internal fun BottomSheetIconContainer(
                             BottomSheetItemType.SAVINGS -> stringResource(Res.string.feature_home_saving_account)
                         },
                         style = MifosTypography.bodyMediumEmphasized,
-                        color = MaterialTheme.colorScheme.onSurface,
+                        color = KptTheme.colorScheme.onSurface,
                     )
 
                     Text(
@@ -143,7 +143,7 @@ internal fun BottomSheetIconContainer(
                             BottomSheetItemType.SAVINGS -> stringResource(Res.string.feature_home_savings_tip)
                         },
                         style = MifosTypography.bodySmallEmphasized,
-                        color = MaterialTheme.colorScheme.secondary,
+                        color = KptTheme.colorScheme.secondary,
                     )
                 }
             }

--- a/feature/home/src/commonMain/kotlin/org/mifos/mobile/feature/home/components/BottomSheetContent.kt
+++ b/feature/home/src/commonMain/kotlin/org/mifos/mobile/feature/home/components/BottomSheetContent.kt
@@ -30,7 +30,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import mifos_mobile.feature.home.generated.resources.Res
 import mifos_mobile.feature.home.generated.resources.feature_home_loan_account
 import mifos_mobile.feature.home.generated.resources.feature_home_loan_tip
@@ -94,7 +93,7 @@ internal fun BottomSheetIconContainer(
             modifier = Modifier
                 .fillMaxWidth()
                 .border(
-                    1.dp,
+                    DesignToken.strokes.thin,
                     KptTheme.colorScheme.secondaryContainer,
                     KptTheme.shapes.medium,
                 ),
@@ -108,7 +107,7 @@ internal fun BottomSheetIconContainer(
                 Box(
                     modifier = Modifier.size(DesignToken.sizes.inputHeight)
                         .border(
-                            1.dp,
+                            DesignToken.strokes.thin,
                             KptTheme.colorScheme.secondaryContainer,
                             KptTheme.shapes.medium,
                         ),

--- a/feature/home/src/commonMain/kotlin/org/mifos/mobile/feature/home/components/BottomSheetContent.kt
+++ b/feature/home/src/commonMain/kotlin/org/mifos/mobile/feature/home/components/BottomSheetContent.kt
@@ -70,7 +70,7 @@ internal fun BottomSheetContent(
         modifier = modifier,
     ) {
         Column(
-            modifier = Modifier.padding(horizontal = DesignToken.padding.large),
+            modifier = Modifier.padding(horizontal = KptTheme.spacing.md),
             verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.medium),
         ) {
             BottomSheetIconContainer(
@@ -96,21 +96,21 @@ internal fun BottomSheetIconContainer(
                 .border(
                     1.dp,
                     KptTheme.colorScheme.secondaryContainer,
-                    DesignToken.shapes.medium,
+                    KptTheme.shapes.medium,
                 ),
             onClick = { onClick(it) },
             variant = CardVariant.OUTLINED,
         ) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.padding(DesignToken.padding.large),
+                modifier = Modifier.padding(KptTheme.spacing.md),
             ) {
                 Box(
                     modifier = Modifier.size(DesignToken.sizes.inputHeight)
                         .border(
                             1.dp,
                             KptTheme.colorScheme.secondaryContainer,
-                            DesignToken.shapes.medium,
+                            KptTheme.shapes.medium,
                         ),
                     contentAlignment = Alignment.Center,
                 ) {
@@ -125,8 +125,8 @@ internal fun BottomSheetIconContainer(
                 }
                 Column(
                     horizontalAlignment = Alignment.Start,
-                    verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.small),
-                    modifier = Modifier.padding(horizontal = DesignToken.padding.large),
+                    verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.sm),
+                    modifier = Modifier.padding(horizontal = KptTheme.spacing.md),
                 ) {
                     Text(
                         text = when (it) {

--- a/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/component/AccountSummaryCard.kt
+++ b/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/component/AccountSummaryCard.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -49,6 +48,7 @@ import org.mifos.mobile.core.designsystem.theme.AppColors
 import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
+import template.core.base.designsystem.theme.KptTheme
 import kotlin.collections.component1
 import kotlin.collections.component2
 
@@ -75,7 +75,7 @@ fun AccountSummaryCard(
             .fillMaxWidth()
             .border(
                 1.dp,
-                MaterialTheme.colorScheme.secondaryContainer,
+                KptTheme.colorScheme.secondaryContainer,
                 DesignToken.shapes.medium,
             ),
         shape = DesignToken.shapes.medium,
@@ -95,13 +95,13 @@ fun AccountSummaryCard(
                 Text(
                     text = title,
                     style = MifosTypography.titleSmallEmphasized,
-                    color = MaterialTheme.colorScheme.onSurface,
+                    color = KptTheme.colorScheme.onSurface,
                 )
                 Icon(
                     modifier = Modifier.size(DesignToken.sizes.iconSmall),
                     imageVector = if (isExpanded) MifosIcons.CaretUp else MifosIcons.CaretDown,
                     contentDescription = if (isExpanded) "Collapse" else "Expand",
-                    tint = MaterialTheme.colorScheme.onSurface,
+                    tint = KptTheme.colorScheme.onSurface,
                 )
             }
 
@@ -121,7 +121,7 @@ fun AccountSummaryCard(
                             Text(
                                 text = "${stringResource(key)} :",
                                 style = MifosTypography.labelMediumEmphasized,
-                                color = MaterialTheme.colorScheme.secondary,
+                                color = KptTheme.colorScheme.secondary,
                             )
                             Text(
                                 text = value ?: "",
@@ -130,7 +130,7 @@ fun AccountSummaryCard(
                                 color = if (key == Res.string.feature_loan_account_status_label) {
                                     AppColors.customEnable
                                 } else {
-                                    MaterialTheme.colorScheme.secondary
+                                    KptTheme.colorScheme.secondary
                                 },
                             )
                         }

--- a/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/component/AccountSummaryCard.kt
+++ b/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/component/AccountSummaryCard.kt
@@ -76,15 +76,15 @@ fun AccountSummaryCard(
             .border(
                 1.dp,
                 KptTheme.colorScheme.secondaryContainer,
-                DesignToken.shapes.medium,
+                KptTheme.shapes.medium,
             ),
-        shape = DesignToken.shapes.medium,
+        shape = KptTheme.shapes.medium,
     ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
                 .clickable { isExpanded = !isExpanded }
-                .padding(DesignToken.padding.large),
+                .padding(KptTheme.spacing.md),
         ) {
             Row(
                 modifier = Modifier
@@ -115,7 +115,7 @@ fun AccountSummaryCard(
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .padding(vertical = DesignToken.padding.small),
+                                .padding(vertical = KptTheme.spacing.sm),
                             horizontalArrangement = Arrangement.SpaceBetween,
                         ) {
                             Text(
@@ -148,7 +148,7 @@ private fun Account_Card_Preview() {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(DesignToken.padding.large),
+                .padding(KptTheme.spacing.md),
         ) {
             AccountSummaryCard(
                 keyValuePairs = mapOf(

--- a/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/component/AccountSummaryCard.kt
+++ b/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/component/AccountSummaryCard.kt
@@ -32,7 +32,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import mifos_mobile.feature.loan_account.generated.resources.Res
 import mifos_mobile.feature.loan_account.generated.resources.feature_loan_account_number_label
 import mifos_mobile.feature.loan_account.generated.resources.feature_loan_account_status_label
@@ -74,7 +73,7 @@ fun AccountSummaryCard(
         modifier = modifier
             .fillMaxWidth()
             .border(
-                1.dp,
+                DesignToken.strokes.thin,
                 KptTheme.colorScheme.secondaryContainer,
                 KptTheme.shapes.medium,
             ),

--- a/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/component/RepaymentPeriodCard.kt
+++ b/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/component/RepaymentPeriodCard.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -46,6 +45,7 @@ import org.mifos.mobile.core.designsystem.theme.AppColors
 import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
 import org.mifos.mobile.core.model.entity.accounts.loan.Periods
+import template.core.base.designsystem.theme.KptTheme
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
@@ -83,7 +83,7 @@ fun RepaymentScheduleItem(
             .fillMaxWidth()
             .border(
                 1.dp,
-                MaterialTheme.colorScheme.secondaryContainer,
+                KptTheme.colorScheme.secondaryContainer,
                 DesignToken.shapes.medium,
             ),
     ) {
@@ -98,7 +98,7 @@ fun RepaymentScheduleItem(
                 modifier = Modifier
                     .size(36.dp)
                     .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.primary),
+                    .background(KptTheme.colorScheme.primary),
                 contentAlignment = Alignment.Center,
             ) {
                 Text(
@@ -128,14 +128,14 @@ fun RepaymentScheduleItem(
                             }}"
                         } ?: "-",
                     ),
-                    color = MaterialTheme.colorScheme.outline,
+                    color = KptTheme.colorScheme.outline,
                     style = MifosTypography.labelMediumEmphasized,
                 )
 
                 Text(
                     text = dueDate,
                     style = MifosTypography.labelLargeEmphasized,
-                    color = MaterialTheme.colorScheme.onSurface,
+                    color = KptTheme.colorScheme.onSurface,
                 )
             }
             if (canPay) {
@@ -163,13 +163,13 @@ fun RepaymentScheduleItem(
                             stringResource(Res.string.feature_loan_due)
                         },
                         style = MifosTypography.labelSmall.copy(
-                            color = if (isPaid) AppColors.customEnable else MaterialTheme.colorScheme.error,
+                            color = if (isPaid) AppColors.customEnable else KptTheme.colorScheme.error,
                         ),
                     )
                     Text(
                         text = amount,
                         style = MifosTypography.titleSmallEmphasized,
-                        color = if (isPaid) AppColors.customEnable else MaterialTheme.colorScheme.error,
+                        color = if (isPaid) AppColors.customEnable else KptTheme.colorScheme.error,
                     )
                 }
             }

--- a/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/component/RepaymentPeriodCard.kt
+++ b/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/component/RepaymentPeriodCard.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
 import mifos_mobile.feature.loan_account.generated.resources.Res
 import mifos_mobile.feature.loan_account.generated.resources.feature_loan_due
 import mifos_mobile.feature.loan_account.generated.resources.feature_loan_installment_number
@@ -82,7 +81,7 @@ fun RepaymentScheduleItem(
         modifier = modifier
             .fillMaxWidth()
             .border(
-                1.dp,
+                DesignToken.strokes.thin,
                 KptTheme.colorScheme.secondaryContainer,
                 KptTheme.shapes.medium,
             ),

--- a/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/component/RepaymentPeriodCard.kt
+++ b/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/component/RepaymentPeriodCard.kt
@@ -96,7 +96,7 @@ fun RepaymentScheduleItem(
         ) {
             Box(
                 modifier = Modifier
-                    .size(36.dp)
+                    .size(DesignToken.sizes.iconExtraLarge)
                     .clip(CircleShape)
                     .background(KptTheme.colorScheme.primary),
                 contentAlignment = Alignment.Center,

--- a/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/component/RepaymentPeriodCard.kt
+++ b/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/component/RepaymentPeriodCard.kt
@@ -84,12 +84,12 @@ fun RepaymentScheduleItem(
             .border(
                 1.dp,
                 KptTheme.colorScheme.secondaryContainer,
-                DesignToken.shapes.medium,
+                KptTheme.shapes.medium,
             ),
     ) {
         Row(
             modifier = Modifier
-                .padding(DesignToken.padding.large)
+                .padding(KptTheme.spacing.md)
                 .fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween,

--- a/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/loanAccount/LoanAccountScreen.kt
+++ b/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/loanAccount/LoanAccountScreen.kt
@@ -173,7 +173,7 @@ internal fun LoanAccountContent(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(DesignToken.padding.large),
+            .padding(KptTheme.spacing.md),
     ) {
         when (state.uiState) {
             ScreenUiState.Loading -> {
@@ -204,7 +204,7 @@ internal fun LoanAccountContent(
             }
 
             ScreenUiState.Success -> {
-                Spacer(modifier = Modifier.height(DesignToken.spacing.large))
+                Spacer(modifier = Modifier.height(KptTheme.spacing.md))
 
                 MifosDashboardCard(
                     isVisible = state.isAmountVisible,
@@ -281,7 +281,7 @@ internal fun LoanAccountContent(
                             .fillMaxSize()
                             .weight(1f),
                     ) {
-                        item { Spacer(modifier = Modifier.height(DesignToken.spacing.small)) }
+                        item { Spacer(modifier = Modifier.height(KptTheme.spacing.sm)) }
                         items(state.loanAccounts.orEmpty()) { account ->
                             val color = when (account.status?.value) {
                                 LoanStatus.ACTIVE.status -> AppColors.customEnable

--- a/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/loanAccount/LoanAccountScreen.kt
+++ b/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/loanAccount/LoanAccountScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import mifos_mobile.feature.loan_account.generated.resources.Res
 import mifos_mobile.feature.loan_account.generated.resources.feature_account_empty_filtered_loan_accounts
@@ -248,7 +247,7 @@ internal fun LoanAccountContent(
                         Icon(
                             modifier = Modifier
                                 .clickable { filtersClicked() }
-                                .size(20.dp),
+                                .size(DesignToken.sizes.iconDp20),
                             imageVector = MifosIcons.Filter,
                             contentDescription = null,
                         )
@@ -260,7 +259,7 @@ internal fun LoanAccountContent(
                 HorizontalDivider(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(0.99997.dp),
+                        .height(DesignToken.strokes.thin),
                 )
 
                 if (state.isFilteredEmpty) {

--- a/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/loanAccount/LoanAccountScreen.kt
+++ b/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/loanAccount/LoanAccountScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -59,6 +58,7 @@ import org.mifos.mobile.core.ui.component.MifosErrorComponent
 import org.mifos.mobile.core.ui.component.MifosProgressIndicator
 import org.mifos.mobile.core.ui.utils.EventsEffect
 import org.mifos.mobile.core.ui.utils.ScreenUiState
+import template.core.base.designsystem.theme.KptTheme
 import kotlin.collections.orEmpty
 
 /**
@@ -228,7 +228,7 @@ internal fun LoanAccountContent(
                         Text(
                             text = stringResource(Res.string.feature_loan_account),
                             style = MifosTypography.titleMediumEmphasized,
-                            color = MaterialTheme.colorScheme.onBackground,
+                            color = KptTheme.colorScheme.onBackground,
                         )
                         Text(
                             text = stringResource(
@@ -236,7 +236,7 @@ internal fun LoanAccountContent(
                                 state.items ?: 0,
                             ),
                             style = MifosTypography.labelMedium,
-                            color = MaterialTheme.colorScheme.secondary,
+                            color = KptTheme.colorScheme.secondary,
                         )
                     }
 
@@ -288,9 +288,9 @@ internal fun LoanAccountContent(
                                 LoanStatus.SUBMIT_AND_PENDING_APPROVAL.status -> AppColors.customYellow
                                 LoanStatus.WITHDRAWN.status,
                                 LoanStatus.MATURED.status,
-                                -> MaterialTheme.colorScheme.error
+                                -> KptTheme.colorScheme.error
 
-                                else -> MaterialTheme.colorScheme.onSurface
+                                else -> KptTheme.colorScheme.onSurface
                             }
 
                             MifosAccountCard(

--- a/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/loanAccountDetails/LoanAccountDetailsScreen.kt
+++ b/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/loanAccountDetails/LoanAccountDetailsScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import mifos_mobile.feature.loan_account.generated.resources.Res
 import mifos_mobile.feature.loan_account.generated.resources.feature_account_details_action
@@ -248,7 +247,7 @@ internal fun AccountDetailsGrid(
                 details.forEach { item ->
                     MifosLabelValueCard(
                         modifier = Modifier
-                            .height(64.dp)
+                            .height(DesignToken.sizes.cardDp64)
                             .weight(1f),
                         label = stringResource(item.label),
                         value = item.value,

--- a/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/loanAccountDetails/LoanAccountDetailsScreen.kt
+++ b/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/loanAccountDetails/LoanAccountDetailsScreen.kt
@@ -186,8 +186,8 @@ internal fun LoanAccountDetailsContent(
                     modifier = Modifier
                         .fillMaxSize()
                         .verticalScroll(rememberScrollState())
-                        .padding(DesignToken.padding.large),
-                    verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.large),
+                        .padding(KptTheme.spacing.md),
+                    verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.md),
                 ) {
                     AccountDetailsGrid(
                         details = state.displayItems,
@@ -277,7 +277,7 @@ internal fun SavingsAccountActions(
     onActionClick: (String) -> Unit,
 ) {
     Column(
-        verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.large),
+        verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.md),
     ) {
         Text(
             text = stringResource(Res.string.feature_account_details_action),

--- a/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/loanAccountDetails/LoanAccountDetailsScreen.kt
+++ b/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/loanAccountDetails/LoanAccountDetailsScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -57,6 +56,7 @@ import org.mifos.mobile.core.ui.utils.EventsEffect
 import org.mifos.mobile.core.ui.utils.ScreenUiState
 import org.mifos.mobile.feature.loanaccount.component.LoanActionItems
 import org.mifos.mobile.feature.loanaccount.component.loanAccountActions
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * The main composable for the loan account details screen.
@@ -235,7 +235,7 @@ internal fun AccountDetailsGrid(
             Text(
                 text = label,
                 style = MifosTypography.labelLargeEmphasized,
-                color = MaterialTheme.colorScheme.onSurface,
+                color = KptTheme.colorScheme.onSurface,
             )
         }
         if (details != null) {
@@ -256,7 +256,7 @@ internal fun AccountDetailsGrid(
                             AppColors
                                 .customEnable
                         } else {
-                            MaterialTheme.colorScheme.onBackground
+                            KptTheme.colorScheme.onBackground
                         },
                     )
                 }
@@ -282,7 +282,7 @@ internal fun SavingsAccountActions(
         Text(
             text = stringResource(Res.string.feature_account_details_action),
             style = MifosTypography.labelLargeEmphasized,
-            color = MaterialTheme.colorScheme.onSurface,
+            color = KptTheme.colorScheme.onSurface,
         )
         FlowRow(
             modifier = Modifier.fillMaxWidth(),

--- a/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/loanAccountRepaymentSchedule/RepaymentScheduleScreen.kt
+++ b/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/loanAccountRepaymentSchedule/RepaymentScheduleScreen.kt
@@ -46,6 +46,7 @@ import org.mifos.mobile.core.ui.component.MifosProgressIndicator
 import org.mifos.mobile.core.ui.utils.EventsEffect
 import org.mifos.mobile.core.ui.utils.ScreenUiState
 import org.mifos.mobile.feature.loanaccount.component.RepaymentScheduleItem
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * The main composable for the repayment schedule screen.
@@ -152,13 +153,13 @@ internal fun RepaymentScreenContent(
                         .verticalScroll(rememberScrollState())
                         .padding(
                             vertical = DesignToken.padding.extraLarge,
-                            horizontal = DesignToken.padding.large,
+                            horizontal = KptTheme.spacing.md,
                         ),
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     MifosDetailsCard(keyValuePairs = state.basicDetails)
 
-                    Spacer(Modifier.height(DesignToken.padding.large))
+                    Spacer(Modifier.height(KptTheme.spacing.md))
 
                     RepaymentScheduleList(
                         periods = state.getPeriods,
@@ -247,7 +248,7 @@ internal fun RepaymentDialogs(
 private fun Repayment_Preview() {
     MifosMobileTheme {
         Column(
-            modifier = Modifier.padding(DesignToken.padding.large),
+            modifier = Modifier.padding(KptTheme.spacing.md),
         ) {
             RepaymentScreenContent(
                 state = RepaymentScheduleState(dialogState = null),

--- a/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/loanAccountSummary/AccountSummaryScreen.kt
+++ b/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/loanAccountSummary/AccountSummaryScreen.kt
@@ -46,6 +46,7 @@ import org.mifos.mobile.core.ui.component.MifosProgressIndicator
 import org.mifos.mobile.core.ui.utils.EventsEffect
 import org.mifos.mobile.core.ui.utils.ScreenUiState
 import org.mifos.mobile.feature.loanaccount.component.AccountSummaryCard
+import template.core.base.designsystem.theme.KptTheme
 import kotlin.collections.orEmpty
 
 /**
@@ -158,7 +159,7 @@ internal fun LoanAccountSummaryContent(
                 Column(
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(DesignToken.padding.large)
+                        .padding(KptTheme.spacing.md)
                         .verticalScroll(rememberScrollState()),
                     verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.largeIncreased),
                 ) {

--- a/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/component/ApplyLoanBottomBar.kt
+++ b/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/component/ApplyLoanBottomBar.kt
@@ -21,7 +21,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import mifos_mobile.feature.loan_application.generated.resources.Res
 import mifos_mobile.feature.loan_application.generated.resources.feature_apply_loan_title
 import mifos_mobile.feature.loan_application.generated.resources.feature_loan_product_details_terms
@@ -54,7 +53,7 @@ fun ApplyLoanBottomBar(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Checkbox(
-                modifier = Modifier.height(18.dp),
+                modifier = Modifier.height(DesignToken.sizes.checkboxDp18),
                 checked = checked,
                 onCheckedChange = onCheckedChange,
                 colors = CheckboxDefaults.colors(

--- a/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/component/ApplyLoanBottomBar.kt
+++ b/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/component/ApplyLoanBottomBar.kt
@@ -31,6 +31,7 @@ import org.mifos.mobile.core.designsystem.theme.AppColors
 import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
 import org.mifos.mobile.core.designsystem.utils.onClick
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun ApplyLoanBottomBar(
@@ -43,8 +44,8 @@ fun ApplyLoanBottomBar(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .padding(DesignToken.padding.large),
-        verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.large),
+            .padding(KptTheme.spacing.md),
+        verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.md),
     ) {
         Row(
             modifier = Modifier
@@ -70,7 +71,7 @@ fun ApplyLoanBottomBar(
             modifier = Modifier.fillMaxWidth().height(DesignToken.sizes.inputHeight),
             onClick = onApplyClick,
             enabled = isEnabled,
-            shape = DesignToken.shapes.medium,
+            shape = KptTheme.shapes.medium,
         ) {
             Text(
                 text = stringResource(Res.string.feature_apply_loan_title),

--- a/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/component/ConfirmDetailsCard.kt
+++ b/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/component/ConfirmDetailsCard.kt
@@ -24,7 +24,6 @@ import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 import org.mifos.mobile.core.designsystem.component.CardVariant
 import org.mifos.mobile.core.designsystem.component.MifosCustomCard
-import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
 import template.core.base.designsystem.theme.KptTheme
 import kotlin.collections.component1
@@ -42,16 +41,16 @@ fun ConfirmDetailsCard(
             .border(
                 1.dp,
                 KptTheme.colorScheme.secondaryContainer,
-                DesignToken.shapes.medium,
+                KptTheme.shapes.medium,
             ),
-        shape = DesignToken.shapes.medium,
+        shape = KptTheme.shapes.medium,
     ) {
-        Column(modifier = Modifier.padding(DesignToken.padding.large)) {
+        Column(modifier = Modifier.padding(KptTheme.spacing.md)) {
             keyValuePairs.forEach { (key, value) ->
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(vertical = DesignToken.padding.small),
+                        .padding(vertical = KptTheme.spacing.sm),
                     horizontalArrangement = Arrangement.SpaceBetween,
                 ) {
                     Text(

--- a/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/component/ConfirmDetailsCard.kt
+++ b/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/component/ConfirmDetailsCard.kt
@@ -19,11 +19,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 import org.mifos.mobile.core.designsystem.component.CardVariant
 import org.mifos.mobile.core.designsystem.component.MifosCustomCard
+import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
 import template.core.base.designsystem.theme.KptTheme
 import kotlin.collections.component1
@@ -39,7 +39,7 @@ fun ConfirmDetailsCard(
         modifier = modifier
             .fillMaxWidth()
             .border(
-                1.dp,
+                DesignToken.strokes.thin,
                 KptTheme.colorScheme.secondaryContainer,
                 KptTheme.shapes.medium,
             ),

--- a/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/component/ConfirmDetailsCard.kt
+++ b/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/component/ConfirmDetailsCard.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -27,6 +26,7 @@ import org.mifos.mobile.core.designsystem.component.CardVariant
 import org.mifos.mobile.core.designsystem.component.MifosCustomCard
 import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
+import template.core.base.designsystem.theme.KptTheme
 import kotlin.collections.component1
 import kotlin.collections.component2
 
@@ -41,7 +41,7 @@ fun ConfirmDetailsCard(
             .fillMaxWidth()
             .border(
                 1.dp,
-                MaterialTheme.colorScheme.secondaryContainer,
+                KptTheme.colorScheme.secondaryContainer,
                 DesignToken.shapes.medium,
             ),
         shape = DesignToken.shapes.medium,

--- a/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/component/LoanCard.kt
+++ b/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/component/LoanCard.kt
@@ -59,7 +59,7 @@ fun LoanCard(
                     Modifier
                 },
             ),
-        shape = DesignToken.shapes.medium,
+        shape = KptTheme.shapes.medium,
         variant = CardVariant.ELEVATED,
         elevation = CardDefaults.cardElevation(defaultElevation = DesignToken.elevation.elevation),
     ) {
@@ -70,7 +70,7 @@ fun LoanCard(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(128.dp)
-                    .clip(DesignToken.shapes.medium),
+                    .clip(KptTheme.shapes.medium),
                 painter = painterResource(cardImage),
                 contentDescription = null,
                 contentScale = ContentScale.Crop,
@@ -89,7 +89,7 @@ fun LoanCard(
                         color = AppColors.customWhite,
                     )
 
-                    Spacer(modifier = Modifier.height(DesignToken.spacing.extraSmall))
+                    Spacer(modifier = Modifier.height(KptTheme.spacing.xs))
 
                     Text(
                         text = amount,
@@ -98,7 +98,7 @@ fun LoanCard(
                     )
                 }
 
-                Spacer(modifier = Modifier.height(DesignToken.spacing.extraLargeIncreased))
+                Spacer(modifier = Modifier.height(KptTheme.spacing.xl))
 
                 Text(
                     text = interestRate,
@@ -115,7 +115,7 @@ fun LoanCard(
 @Composable
 fun LoanCardPreview() {
     LoanCard(
-        modifier = Modifier.padding(DesignToken.padding.large),
+        modifier = Modifier.padding(KptTheme.spacing.md),
         cardImage = UiRes.drawable.ic_icon_dashboard,
         onClick = {},
         title = "title",
@@ -145,7 +145,7 @@ fun LoanCardCustom(
                     Modifier
                 },
             ),
-        shape = DesignToken.shapes.medium,
+        shape = KptTheme.shapes.medium,
         colors = CardDefaults.cardColors(containerColor = backgroundColor),
         elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
     ) {
@@ -175,7 +175,7 @@ fun LoanCardCustom(
                     color = contentColor,
                 )
 
-                Spacer(modifier = Modifier.height(DesignToken.spacing.small))
+                Spacer(modifier = Modifier.height(KptTheme.spacing.sm))
 
                 Text(
                     text = amount,
@@ -183,7 +183,7 @@ fun LoanCardCustom(
                     color = contentColor,
                 )
 
-                Spacer(modifier = Modifier.height(DesignToken.spacing.large))
+                Spacer(modifier = Modifier.height(KptTheme.spacing.md))
 
                 Text(
                     text = interestRate,
@@ -199,7 +199,7 @@ fun LoanCardCustom(
 @Composable
 fun LoanCardPreviewCustom() {
     LoanCardCustom(
-        modifier = Modifier.padding(DesignToken.padding.large),
+        modifier = Modifier.padding(KptTheme.spacing.md),
         cardImage = UiRes.drawable.ic_icon_dashboard,
         onClick = {},
         title = "title",

--- a/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/component/LoanCard.kt
+++ b/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/component/LoanCard.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -26,7 +25,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.unit.dp
 import mifos_mobile.core.ui.generated.resources.ic_icon_dashboard
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.painterResource
@@ -51,7 +49,7 @@ fun LoanCard(
     MifosCustomCard(
         modifier = modifier
             .fillMaxWidth()
-            .height(128.dp)
+            .height(DesignToken.sizes.cardDp128)
             .then(
                 if (onClick != null) {
                     Modifier.clickable { onClick() }
@@ -69,7 +67,7 @@ fun LoanCard(
             Image(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(128.dp)
+                    .height(DesignToken.sizes.imageDp128)
                     .clip(KptTheme.shapes.medium),
                 painter = painterResource(cardImage),
                 contentDescription = null,
@@ -147,7 +145,7 @@ fun LoanCardCustom(
             ),
         shape = KptTheme.shapes.medium,
         colors = CardDefaults.cardColors(containerColor = backgroundColor),
-        elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = DesignToken.elevation.dp6),
     ) {
         Column(
             modifier = Modifier.fillMaxWidth(),
@@ -156,8 +154,8 @@ fun LoanCardCustom(
             Image(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(140.dp)
-                    .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)),
+                    .height(DesignToken.sizes.imageDp140)
+                    .clip(DesignToken.shapes.topCornerDp16),
                 painter = painterResource(cardImage),
                 contentDescription = null,
                 contentScale = ContentScale.Crop,

--- a/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/component/LoanCard.kt
+++ b/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/component/LoanCard.kt
@@ -89,7 +89,7 @@ fun LoanCard(
                         color = AppColors.customWhite,
                     )
 
-                    Spacer(modifier = Modifier.height(4.dp))
+                    Spacer(modifier = Modifier.height(DesignToken.spacing.extraSmall))
 
                     Text(
                         text = amount,
@@ -98,7 +98,7 @@ fun LoanCard(
                     )
                 }
 
-                Spacer(modifier = Modifier.height(32.dp))
+                Spacer(modifier = Modifier.height(DesignToken.spacing.extraLargeIncreased))
 
                 Text(
                     text = interestRate,
@@ -115,7 +115,7 @@ fun LoanCard(
 @Composable
 fun LoanCardPreview() {
     LoanCard(
-        modifier = Modifier.padding(16.dp),
+        modifier = Modifier.padding(DesignToken.padding.large),
         cardImage = UiRes.drawable.ic_icon_dashboard,
         onClick = {},
         title = "title",
@@ -167,7 +167,7 @@ fun LoanCardCustom(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(20.dp),
+                    .padding(DesignToken.padding.largeIncreased),
             ) {
                 Text(
                     text = title,
@@ -175,7 +175,7 @@ fun LoanCardCustom(
                     color = contentColor,
                 )
 
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(DesignToken.spacing.small))
 
                 Text(
                     text = amount,
@@ -183,7 +183,7 @@ fun LoanCardCustom(
                     color = contentColor,
                 )
 
-                Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(DesignToken.spacing.large))
 
                 Text(
                     text = interestRate,
@@ -199,7 +199,7 @@ fun LoanCardCustom(
 @Composable
 fun LoanCardPreviewCustom() {
     LoanCardCustom(
-        modifier = Modifier.padding(16.dp),
+        modifier = Modifier.padding(DesignToken.padding.large),
         cardImage = UiRes.drawable.ic_icon_dashboard,
         onClick = {},
         title = "title",

--- a/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/component/LoanCard.kt
+++ b/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/component/LoanCard.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -37,6 +36,7 @@ import org.mifos.mobile.core.designsystem.component.MifosCustomCard
 import org.mifos.mobile.core.designsystem.theme.AppColors
 import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
+import template.core.base.designsystem.theme.KptTheme
 import mifos_mobile.core.ui.generated.resources.Res as UiRes
 
 @Composable
@@ -131,7 +131,7 @@ fun LoanCardCustom(
     amount: String,
     interestRate: String,
     modifier: Modifier = Modifier,
-    backgroundColor: Color = MaterialTheme.colorScheme.primary,
+    backgroundColor: Color = KptTheme.colorScheme.primary,
     contentColor: Color = Color.White,
     onClick: (() -> Unit)? = null,
 ) {

--- a/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/component/TermsAndConditionItem.kt
+++ b/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/component/TermsAndConditionItem.kt
@@ -18,8 +18,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
-import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun TermsAndConditionItem(
@@ -29,7 +29,7 @@ fun TermsAndConditionItem(
 ) {
     Column(
         modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.small),
+        verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.sm),
     ) {
         Text(
             text = stringResource(title),
@@ -40,6 +40,6 @@ fun TermsAndConditionItem(
             text = stringResource(description),
             style = MifosTypography.bodySmall,
         )
-        Spacer(modifier = Modifier.height(DesignToken.spacing.small))
+        Spacer(modifier = Modifier.height(KptTheme.spacing.sm))
     }
 }

--- a/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/confirmDetails/ConfirmDetailsScreen.kt
+++ b/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/confirmDetails/ConfirmDetailsScreen.kt
@@ -43,6 +43,7 @@ import org.mifos.mobile.core.ui.component.MifosProgressIndicator
 import org.mifos.mobile.core.ui.component.MifosProgressIndicatorOverlay
 import org.mifos.mobile.core.ui.utils.EventsEffect
 import org.mifos.mobile.core.ui.utils.ScreenUiState
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 internal fun ConfirmDetailsScreen(
@@ -144,7 +145,7 @@ internal fun ConfirmDetailsScreenContent(
             ScreenUiState.Success -> {
                 Column(
                     modifier = modifier
-                        .padding(DesignToken.padding.large)
+                        .padding(KptTheme.spacing.md)
                         .padding(top = DesignToken.padding.medium)
                         .verticalScroll(rememberScrollState()),
                     verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.extraLarge),
@@ -156,7 +157,7 @@ internal fun ConfirmDetailsScreenContent(
                         onClick = {
                             onAction(ConfirmDetailsAction.NavigateToAuthenticate)
                         },
-                        shape = DesignToken.shapes.medium,
+                        shape = KptTheme.shapes.medium,
                     ) {
                         Text(
                             text = stringResource(Res.string.feature_apply_loan_title),

--- a/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/loanApplication/LoanApplyScreen.kt
+++ b/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/loanApplication/LoanApplyScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SelectableDates
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -64,6 +63,7 @@ import org.mifos.mobile.core.ui.component.MifosPoweredCard
 import org.mifos.mobile.core.ui.component.MifosProgressIndicator
 import org.mifos.mobile.core.ui.utils.EventsEffect
 import org.mifos.mobile.core.ui.utils.ScreenUiState
+import template.core.base.designsystem.theme.KptTheme
 import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 
@@ -259,7 +259,7 @@ internal fun LoanAccountContent(
                     ) {
                         Text(
                             text = stringResource(Res.string.feature_apply_loan_button_continue),
-                            style = MaterialTheme.typography.labelLarge,
+                            style = KptTheme.typography.labelLarge,
                         )
                     }
 

--- a/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/loanApplication/LoanApplyScreen.kt
+++ b/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/loanApplication/LoanApplyScreen.kt
@@ -179,15 +179,15 @@ internal fun LoanAccountContent(
             ScreenUiState.Success -> {
                 Column(
                     modifier = Modifier
-                        .padding(DesignToken.padding.large)
+                        .padding(KptTheme.spacing.md)
                         .verticalScroll(rememberScrollState()),
-                    verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.large),
+                    verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.md),
                 ) {
                     MifosOutlinedTextField(
                         value = state.applicantName,
                         onValueChange = { onAction(LoanApplicationAction.ApplicantNameChange(it)) },
                         label = stringResource(Res.string.feature_apply_loan_label_applicant_name),
-                        shape = DesignToken.shapes.medium,
+                        shape = KptTheme.shapes.medium,
                         textStyle = MifosTypography.bodyLarge,
                         config = MifosTextFieldConfig(
                             isError = state.applicantNameError != null,
@@ -231,7 +231,7 @@ internal fun LoanAccountContent(
                                 )
                             },
                         ),
-                        shape = DesignToken.shapes.medium,
+                        shape = KptTheme.shapes.medium,
                     )
 
                     MifosOutlinedTextField(
@@ -246,7 +246,7 @@ internal fun LoanAccountContent(
                                 imeAction = ImeAction.Done,
                             ),
                         ),
-                        shape = DesignToken.shapes.medium,
+                        shape = KptTheme.shapes.medium,
                     )
 
                     MifosButton(
@@ -255,7 +255,7 @@ internal fun LoanAccountContent(
                         onClick = {
                             onAction(LoanApplicationAction.NavigateToConfirmDetails)
                         },
-                        shape = DesignToken.shapes.medium,
+                        shape = KptTheme.shapes.medium,
                     ) {
                         Text(
                             text = stringResource(Res.string.feature_apply_loan_button_continue),

--- a/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/loanProductDescription/LoanProductDetailsScren.kt
+++ b/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/loanProductDescription/LoanProductDetailsScren.kt
@@ -67,6 +67,7 @@ import org.mifos.mobile.core.ui.utils.ScreenUiState
 import org.mifos.mobile.feature.loan.application.component.ApplyLoanBottomBar
 import org.mifos.mobile.feature.loan.application.component.LoanCard
 import org.mifos.mobile.feature.loan.application.component.TermsAndConditionItem
+import template.core.base.designsystem.theme.KptTheme
 import mifos_mobile.core.ui.generated.resources.Res as UiRes
 
 @Composable
@@ -185,8 +186,8 @@ internal fun LoanProductDetailsScreenContent(
                 LazyColumn(
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(DesignToken.padding.large)
-                        .padding(top = DesignToken.padding.large),
+                        .padding(KptTheme.spacing.md)
+                        .padding(top = KptTheme.spacing.md),
                     verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.largeIncreased),
                 ) {
                     item {
@@ -210,7 +211,7 @@ internal fun LoanProductDetailsScreenContent(
                         Spacer(modifier = Modifier.height(DesignToken.spacing.largeIncreased))
                         Column(
                             modifier = Modifier.fillMaxWidth(),
-                            verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.extraSmall),
+                            verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.xs),
                         ) {
                             TermsAndConditionItem(
                                 title = Res.string.feature_loan_sanction_and_disbursement,

--- a/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/loanType/SelectLoanTypeSceen.kt
+++ b/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/loanType/SelectLoanTypeSceen.kt
@@ -43,6 +43,7 @@ import org.mifos.mobile.core.ui.component.MifosPoweredCard
 import org.mifos.mobile.core.ui.component.MifosProgressIndicator
 import org.mifos.mobile.core.ui.utils.EventsEffect
 import org.mifos.mobile.core.ui.utils.ScreenUiState
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 internal fun SelectLoanTypeScreen(
@@ -149,8 +150,8 @@ internal fun SelectLoanTypeScreenContent(
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(DesignToken.padding.large)
-                        .padding(top = DesignToken.padding.large),
+                        .padding(KptTheme.spacing.md)
+                        .padding(top = KptTheme.spacing.md),
                 ) {
                     Column(
                         verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.medium),

--- a/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/uploadDocs/UploadDocsScreen.kt
+++ b/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/uploadDocs/UploadDocsScreen.kt
@@ -177,10 +177,10 @@ internal fun UploadDocsScreenContent(
             Modifier
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState())
-                .padding(top = DesignToken.padding.large)
-                .padding(DesignToken.padding.large)
+                .padding(top = KptTheme.spacing.md)
+                .padding(KptTheme.spacing.md)
                 .statusBarsPadding(),
-            verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.large),
+            verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.md),
         ) {
             UploadDocumentsSection(
                 state = state,
@@ -191,7 +191,7 @@ internal fun UploadDocsScreenContent(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(DesignToken.sizes.buttonHeight),
-                shape = DesignToken.shapes.medium,
+                shape = KptTheme.shapes.medium,
                 onClick = {
                     onAction(UploadDocsAction.NavigateToNextScreen)
                 },

--- a/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/uploadDocs/UploadDocsScreen.kt
+++ b/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/uploadDocs/UploadDocsScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -51,6 +50,7 @@ import org.mifos.mobile.core.ui.component.MifosPoweredCard
 import org.mifos.mobile.core.ui.utils.EventsEffect
 import org.mifos.mobile.feature.loan.application.component.UploadDocumentsSection
 import org.mifos.mobile.feature.loan.application.uploadDocs.component.BottomSheetContent
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 internal fun UploadDocsScreen(
@@ -199,7 +199,7 @@ internal fun UploadDocsScreenContent(
             ) {
                 Text(
                     text = stringResource(Res.string.feature_button_next),
-                    style = MaterialTheme.typography.labelLarge,
+                    style = KptTheme.typography.labelLarge,
                 )
             }
         }

--- a/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/uploadDocs/component/BottomSheetContent.kt
+++ b/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/uploadDocs/component/BottomSheetContent.kt
@@ -44,7 +44,6 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
 import com.niyajali.compose.sign.ComposeSign
 import com.niyajali.compose.sign.exportSignature
@@ -148,7 +147,7 @@ internal fun BottomSheetIconContainer(
         Box(
             modifier = Modifier.size(DesignToken.sizes.inputHeight)
                 .border(
-                    1.dp,
+                    DesignToken.strokes.thin,
                     KptTheme.colorScheme.secondaryContainer,
                     KptTheme.shapes.medium,
                 )
@@ -216,7 +215,7 @@ private fun SignatureContent(
                     modifier = modifier
                         .fillMaxWidth()
                         .border(
-                            1.dp,
+                            DesignToken.strokes.thin,
                             KptTheme.colorScheme.secondaryContainer,
                             KptTheme.shapes.medium,
                         ),

--- a/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/uploadDocs/component/BottomSheetContent.kt
+++ b/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/uploadDocs/component/BottomSheetContent.kt
@@ -33,7 +33,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -72,6 +71,7 @@ import org.mifos.mobile.core.designsystem.theme.MifosTypography
 import org.mifos.mobile.core.ui.component.MifosPoweredCard
 import org.mifos.mobile.feature.loan.application.component.SignatureUploadType
 import org.mifos.mobile.feature.loan.application.uploadDocs.UploadDocsAction
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 internal fun BottomSheetContent(
@@ -149,7 +149,7 @@ internal fun BottomSheetIconContainer(
             modifier = Modifier.size(DesignToken.sizes.inputHeight)
                 .border(
                     1.dp,
-                    MaterialTheme.colorScheme.secondaryContainer,
+                    KptTheme.colorScheme.secondaryContainer,
                     DesignToken.shapes.medium,
                 )
                 .clickable { onClick() },
@@ -167,7 +167,7 @@ internal fun BottomSheetIconContainer(
         Text(
             text = stringResource(text),
             style = MifosTypography.bodySmallEmphasized,
-            color = MaterialTheme.colorScheme.onBackground,
+            color = KptTheme.colorScheme.onBackground,
         )
     }
 }
@@ -217,7 +217,7 @@ private fun SignatureContent(
                         .fillMaxWidth()
                         .border(
                             1.dp,
-                            MaterialTheme.colorScheme.secondaryContainer,
+                            KptTheme.colorScheme.secondaryContainer,
                             DesignToken.shapes.medium,
                         ),
                     shape = DesignToken.shapes.medium,

--- a/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/uploadDocs/component/BottomSheetContent.kt
+++ b/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/uploadDocs/component/BottomSheetContent.kt
@@ -102,7 +102,7 @@ internal fun BottomSheetContent(
             )
         } else {
             Column(
-                modifier = Modifier.padding(horizontal = DesignToken.padding.large),
+                modifier = Modifier.padding(horizontal = KptTheme.spacing.md),
             ) {
                 Row {
                     BottomSheetIconContainer(
@@ -143,14 +143,14 @@ internal fun BottomSheetIconContainer(
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = modifier.padding(horizontal = DesignToken.padding.large),
+        modifier = modifier.padding(horizontal = KptTheme.spacing.md),
     ) {
         Box(
             modifier = Modifier.size(DesignToken.sizes.inputHeight)
                 .border(
                     1.dp,
                     KptTheme.colorScheme.secondaryContainer,
-                    DesignToken.shapes.medium,
+                    KptTheme.shapes.medium,
                 )
                 .clickable { onClick() },
             contentAlignment = Alignment.Center,
@@ -162,7 +162,7 @@ internal fun BottomSheetIconContainer(
             )
         }
 
-        Spacer(modifier = Modifier.height(DesignToken.spacing.small))
+        Spacer(modifier = Modifier.height(KptTheme.spacing.sm))
 
         Text(
             text = stringResource(text),
@@ -195,8 +195,8 @@ private fun SignatureContent(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(DesignToken.padding.large),
-            verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.large),
+                .padding(KptTheme.spacing.md),
+            verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.md),
         ) {
             val signatureState = rememberSignatureState()
             var size = remember { Size.Zero }
@@ -218,9 +218,9 @@ private fun SignatureContent(
                         .border(
                             1.dp,
                             KptTheme.colorScheme.secondaryContainer,
-                            DesignToken.shapes.medium,
+                            KptTheme.shapes.medium,
                         ),
-                    shape = DesignToken.shapes.medium,
+                    shape = KptTheme.shapes.medium,
                 ) {
                     ComposeSign(
                         modifier = Modifier
@@ -251,7 +251,7 @@ private fun SignatureContent(
                 ) {
                     MifosButton(
                         modifier = Modifier.weight(0.4f),
-                        shape = DesignToken.shapes.medium,
+                        shape = KptTheme.shapes.medium,
                         onClick = signatureState::clear,
                     ) {
                         Text(
@@ -263,7 +263,7 @@ private fun SignatureContent(
                     val scope = rememberCoroutineScope()
                     MifosButton(
                         modifier = Modifier.weight(0.4f),
-                        shape = DesignToken.shapes.medium,
+                        shape = KptTheme.shapes.medium,
                         onClick = {
                             scope.launch {
                                 val data = signatureState.exportSignature(

--- a/feature/location/src/commonMain/kotlin/org/mifos/mobile/feature/location/LocationScreen.kt
+++ b/feature/location/src/commonMain/kotlin/org/mifos/mobile/feature/location/LocationScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -22,6 +21,7 @@ import mifos_mobile.feature.location.generated.resources.Res
 import mifos_mobile.feature.location.generated.resources.mifos_initiative
 import mifos_mobile.feature.location.generated.resources.mifos_location
 import org.jetbrains.compose.resources.stringResource
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * A composable function that displays the location of the Mifos Initiative.
@@ -41,11 +41,11 @@ internal fun LocationsScreen(
     ) {
         Text(
             text = stringResource(Res.string.mifos_initiative),
-            style = MaterialTheme.typography.bodyLarge,
+            style = KptTheme.typography.bodyLarge,
         )
         Text(
             text = stringResource(Res.string.mifos_location),
-            style = MaterialTheme.typography.bodyMedium,
+            style = KptTheme.typography.bodyMedium,
         )
         RenderMap(modifier = Modifier.fillMaxSize())
     }

--- a/feature/location/src/commonMain/kotlin/org/mifos/mobile/feature/location/LocationScreen.kt
+++ b/feature/location/src/commonMain/kotlin/org/mifos/mobile/feature/location/LocationScreen.kt
@@ -20,7 +20,6 @@ import mifos_mobile.feature.location.generated.resources.Res
 import mifos_mobile.feature.location.generated.resources.mifos_initiative
 import mifos_mobile.feature.location.generated.resources.mifos_location
 import org.jetbrains.compose.resources.stringResource
-import org.mifos.mobile.core.designsystem.theme.DesignToken
 import template.core.base.designsystem.theme.KptTheme
 
 /**
@@ -36,8 +35,8 @@ internal fun LocationsScreen(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(DesignToken.padding.large),
-        verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.large),
+            .padding(KptTheme.spacing.md),
+        verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.md),
     ) {
         Text(
             text = stringResource(Res.string.mifos_initiative),

--- a/feature/location/src/commonMain/kotlin/org/mifos/mobile/feature/location/LocationScreen.kt
+++ b/feature/location/src/commonMain/kotlin/org/mifos/mobile/feature/location/LocationScreen.kt
@@ -16,11 +16,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import mifos_mobile.feature.location.generated.resources.Res
 import mifos_mobile.feature.location.generated.resources.mifos_initiative
 import mifos_mobile.feature.location.generated.resources.mifos_location
 import org.jetbrains.compose.resources.stringResource
+import org.mifos.mobile.core.designsystem.theme.DesignToken
 import template.core.base.designsystem.theme.KptTheme
 
 /**
@@ -36,8 +36,8 @@ internal fun LocationsScreen(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
+            .padding(DesignToken.padding.large),
+        verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.large),
     ) {
         Text(
             text = stringResource(Res.string.mifos_initiative),

--- a/feature/notification/src/commonMain/kotlin/org/mifos/mobile/feature/notification/NotificationScreen.kt
+++ b/feature/notification/src/commonMain/kotlin/org/mifos/mobile/feature/notification/NotificationScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import mifos_mobile.feature.notification.generated.resources.Res
 import mifos_mobile.feature.notification.generated.resources.dialog_action_ok
@@ -45,6 +44,7 @@ import org.mifos.mobile.core.common.DateHelper
 import org.mifos.mobile.core.designsystem.component.MifosElevatedScaffold
 import org.mifos.mobile.core.designsystem.component.MifosTextButton
 import org.mifos.mobile.core.designsystem.icon.MifosIcons
+import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.model.entity.MifosNotification
 import org.mifos.mobile.core.ui.component.EmptyDataView
 import org.mifos.mobile.core.ui.component.MifosErrorComponent
@@ -215,8 +215,8 @@ private fun NotificationItem(
 
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier.padding(8.dp),
-        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        modifier = modifier.padding(DesignToken.padding.small),
+        horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.large),
     ) {
         Icon(
             painter = painterResource(Res.drawable.ic_notifications),

--- a/feature/notification/src/commonMain/kotlin/org/mifos/mobile/feature/notification/NotificationScreen.kt
+++ b/feature/notification/src/commonMain/kotlin/org/mifos/mobile/feature/notification/NotificationScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
@@ -50,6 +49,7 @@ import org.mifos.mobile.core.model.entity.MifosNotification
 import org.mifos.mobile.core.ui.component.EmptyDataView
 import org.mifos.mobile.core.ui.component.MifosErrorComponent
 import org.mifos.mobile.core.ui.component.MifosProgressIndicatorOverlay
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * This is the main entry point for the Notification Screen feature. It's a composable function
@@ -188,7 +188,7 @@ private fun NotificationContent(
                     dismissNotification = dismissNotification,
                 )
                 if (index < notifications.lastIndex) {
-                    HorizontalDivider(color = MaterialTheme.colorScheme.surfaceDim)
+                    HorizontalDivider(color = KptTheme.colorScheme.surfaceDim)
                 }
             }
         }
@@ -222,9 +222,9 @@ private fun NotificationItem(
             painter = painterResource(Res.drawable.ic_notifications),
             contentDescription = "Notifications Icon",
             tint = if (isRead.value) {
-                MaterialTheme.colorScheme.onSurfaceVariant
+                KptTheme.colorScheme.onSurfaceVariant
             } else {
-                MaterialTheme.colorScheme.primary
+                KptTheme.colorScheme.primary
             },
         )
         Column(
@@ -233,12 +233,12 @@ private fun NotificationItem(
             Text(
                 modifier = Modifier.fillMaxWidth(),
                 text = notification.msg ?: "",
-                style = MaterialTheme.typography.bodyMedium,
+                style = KptTheme.typography.bodyMedium,
             )
             Text(
                 modifier = Modifier.alpha(0.7f),
                 text = DateHelper.getDateAsStringFromLong(notification.timeStamp),
-                style = MaterialTheme.typography.labelMedium,
+                style = KptTheme.typography.labelMedium,
             )
             if (!isRead.value) {
                 MifosTextButton(

--- a/feature/notification/src/commonMain/kotlin/org/mifos/mobile/feature/notification/NotificationScreen.kt
+++ b/feature/notification/src/commonMain/kotlin/org/mifos/mobile/feature/notification/NotificationScreen.kt
@@ -44,7 +44,6 @@ import org.mifos.mobile.core.common.DateHelper
 import org.mifos.mobile.core.designsystem.component.MifosElevatedScaffold
 import org.mifos.mobile.core.designsystem.component.MifosTextButton
 import org.mifos.mobile.core.designsystem.icon.MifosIcons
-import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.model.entity.MifosNotification
 import org.mifos.mobile.core.ui.component.EmptyDataView
 import org.mifos.mobile.core.ui.component.MifosErrorComponent
@@ -215,8 +214,8 @@ private fun NotificationItem(
 
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = modifier.padding(DesignToken.padding.small),
-        horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.large),
+        modifier = modifier.padding(KptTheme.spacing.sm),
+        horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.md),
     ) {
         Icon(
             painter = painterResource(Res.drawable.ic_notifications),

--- a/feature/onboarding-language/src/commonMain/kotlin/org/mifos/mobile/feature/onboarding/language/SetOnboardingLanguageScreen.kt
+++ b/feature/onboarding-language/src/commonMain/kotlin/org/mifos/mobile/feature/onboarding/language/SetOnboardingLanguageScreen.kt
@@ -85,9 +85,9 @@ internal fun OnboardingLanguageScreenContent(
                 MifosButton(
                     modifier = modifier
                         .fillMaxWidth()
-                        .padding(DesignToken.padding.large)
+                        .padding(KptTheme.spacing.md)
                         .height(DesignToken.sizes.buttonHeight),
-                    shape = DesignToken.shapes.medium,
+                    shape = KptTheme.shapes.medium,
                     onClick = { onAction(OnboardingLanguageAction.SetLanguage(selectedLanguage)) },
                 ) {
                     Text(
@@ -107,7 +107,7 @@ internal fun OnboardingLanguageScreenContent(
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(horizontal = DesignToken.padding.large),
+                    .padding(horizontal = KptTheme.spacing.md),
             ) {
                 Image(
                     modifier = Modifier.height(DesignToken.sizes.avatarMedium).width(165.dp),
@@ -135,7 +135,7 @@ internal fun OnboardingLanguageScreenContent(
                     color = KptTheme.colorScheme.secondary,
                 )
 
-                Spacer(modifier = Modifier.height(DesignToken.spacing.large))
+                Spacer(modifier = Modifier.height(KptTheme.spacing.md))
 
                 LanguageSelectionContent(
                     selectedLanguage = selectedLanguage,

--- a/feature/onboarding-language/src/commonMain/kotlin/org/mifos/mobile/feature/onboarding/language/SetOnboardingLanguageScreen.kt
+++ b/feature/onboarding-language/src/commonMain/kotlin/org/mifos/mobile/feature/onboarding/language/SetOnboardingLanguageScreen.kt
@@ -110,7 +110,7 @@ internal fun OnboardingLanguageScreenContent(
                     .padding(horizontal = DesignToken.padding.large),
             ) {
                 Image(
-                    modifier = Modifier.height(48.dp).width(165.dp),
+                    modifier = Modifier.height(DesignToken.sizes.avatarMedium).width(165.dp),
                     painter = painterResource(
                         mifos_mobile.core.ui.generated.resources.Res.drawable.ic_icon_logo_1,
                     ),

--- a/feature/onboarding-language/src/commonMain/kotlin/org/mifos/mobile/feature/onboarding/language/SetOnboardingLanguageScreen.kt
+++ b/feature/onboarding-language/src/commonMain/kotlin/org/mifos/mobile/feature/onboarding/language/SetOnboardingLanguageScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -51,6 +50,7 @@ import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
 import org.mifos.mobile.core.model.LanguageConfig
 import org.mifos.mobile.core.ui.component.MifosPoweredCard
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 internal fun OnboardingLanguageScreen(
@@ -122,7 +122,7 @@ internal fun OnboardingLanguageScreenContent(
                 Text(
                     text = stringResource(Res.string.feature_onboarding_choose_your_app_language),
                     style = MifosTypography.headlineMedium,
-                    color = MaterialTheme.colorScheme.onSurface,
+                    color = KptTheme.colorScheme.onSurface,
                 )
 
                 Spacer(modifier = Modifier.height(DesignToken.spacing.medium))
@@ -132,7 +132,7 @@ internal fun OnboardingLanguageScreenContent(
                         Res.string.feature_onboarding_chosen_language_can_be_changed_later_in_the_settings,
                     ),
                     style = MifosTypography.bodySmall,
-                    color = MaterialTheme.colorScheme.secondary,
+                    color = KptTheme.colorScheme.secondary,
                 )
 
                 Spacer(modifier = Modifier.height(DesignToken.spacing.large))
@@ -168,7 +168,7 @@ internal fun LanguageSelectionContent(
                     color = AppColors.primaryBlue,
                 ),
                 unselectedTextStyle = MifosTypography.titleSmallEmphasized.copy(
-                    MaterialTheme.colorScheme.onSurface,
+                    KptTheme.colorScheme.onSurface,
                 ),
             )
         }

--- a/feature/onboarding-language/src/commonMain/kotlin/org/mifos/mobile/feature/onboarding/language/SetOnboardingLanguageScreen.kt
+++ b/feature/onboarding-language/src/commonMain/kotlin/org/mifos/mobile/feature/onboarding/language/SetOnboardingLanguageScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import mifos_mobile.core.ui.generated.resources.ic_icon_logo_1
 import mifos_mobile.feature.onboarding_language.generated.resources.Res
@@ -102,7 +101,7 @@ internal fun OnboardingLanguageScreenContent(
         Box(
             modifier = modifier
                 .fillMaxSize()
-                .padding(top = 75.dp),
+                .padding(top = DesignToken.padding.dp75),
         ) {
             Column(
                 modifier = Modifier
@@ -110,7 +109,7 @@ internal fun OnboardingLanguageScreenContent(
                     .padding(horizontal = KptTheme.spacing.md),
             ) {
                 Image(
-                    modifier = Modifier.height(DesignToken.sizes.avatarMedium).width(165.dp),
+                    modifier = Modifier.height(DesignToken.sizes.imageDp48).width(DesignToken.sizes.imageDp165),
                     painter = painterResource(
                         mifos_mobile.core.ui.generated.resources.Res.drawable.ic_icon_logo_1,
                     ),

--- a/feature/passcode/src/commonMain/kotlin/org/mifos/mobile/feature/passcode/PasscodeScreen.kt
+++ b/feature/passcode/src/commonMain/kotlin/org/mifos/mobile/feature/passcode/PasscodeScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -35,7 +34,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import mifos_mobile.feature.passcode.generated.resources.Res
 import mifos_mobile.feature.passcode.generated.resources.feature_passcode_confirm
@@ -117,7 +115,7 @@ private fun PasscodeScreenContent(
                     tint = KptTheme.colorScheme.primary,
                 )
 
-                Spacer(modifier = Modifier.height(24.dp))
+                Spacer(modifier = Modifier.height(DesignToken.spacing.dp24))
 
                 Text(
                     text = when (state.mode) {
@@ -159,7 +157,7 @@ private fun PasscodeScreenContent(
                                 .clip(CircleShape)
                                 .background(color)
                                 .border(
-                                    1.dp,
+                                    DesignToken.strokes.thin,
                                     borderColor,
                                     CircleShape,
                                 ),
@@ -274,9 +272,9 @@ fun KeyButton(
 ) {
     Box(
         modifier = modifier
-            .width(107.33333.dp)
-            .height(41.dp)
-            .clip(RoundedCornerShape(100.dp))
+            .width(DesignToken.sizes.boxDp107)
+            .height(DesignToken.sizes.boxDp41)
+            .clip(DesignToken.shapes.dp100)
             .background(backgroundColor)
             .clickable(onClick = onClick, enabled = enabled),
         contentAlignment = Alignment.Center,
@@ -294,9 +292,9 @@ fun DigitKeyButton(
 ) {
     Box(
         modifier = modifier
-            .width(107.33333.dp)
-            .height(41.dp)
-            .clip(RoundedCornerShape(100.dp))
+            .width(DesignToken.sizes.boxDp107)
+            .height(DesignToken.sizes.boxDp41)
+            .clip(DesignToken.shapes.dp100)
             .background(KptTheme.colorScheme.surfaceContainerLow)
             .clickable(onClick = onClick),
         contentAlignment = Alignment.Center,

--- a/feature/passcode/src/commonMain/kotlin/org/mifos/mobile/feature/passcode/PasscodeScreen.kt
+++ b/feature/passcode/src/commonMain/kotlin/org/mifos/mobile/feature/passcode/PasscodeScreen.kt
@@ -128,7 +128,7 @@ private fun PasscodeScreenContent(
                     color = KptTheme.colorScheme.onBackground,
                 )
 
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(DesignToken.spacing.small))
 
                 Text(
                     text = stringResource(Res.string.feature_passcode_tip),
@@ -137,7 +137,7 @@ private fun PasscodeScreenContent(
                     textAlign = TextAlign.Center,
                 )
 
-                Spacer(modifier = Modifier.height(32.dp))
+                Spacer(modifier = Modifier.height(DesignToken.spacing.extraLargeIncreased))
 
                 Row(horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.large)) {
                     repeat(state.maxDigits) { index ->
@@ -155,7 +155,7 @@ private fun PasscodeScreenContent(
                             }
                         Box(
                             modifier = Modifier
-                                .size(16.dp)
+                                .size(DesignToken.sizes.iconSmall)
                                 .clip(CircleShape)
                                 .background(color)
                                 .border(

--- a/feature/passcode/src/commonMain/kotlin/org/mifos/mobile/feature/passcode/PasscodeScreen.kt
+++ b/feature/passcode/src/commonMain/kotlin/org/mifos/mobile/feature/passcode/PasscodeScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -52,6 +51,7 @@ import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
 import org.mifos.mobile.core.ui.component.MifosPoweredCard
 import org.mifos.mobile.core.ui.utils.EventsEffect
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 internal fun PasscodeScreen(
@@ -110,11 +110,11 @@ private fun PasscodeScreenContent(
                     contentDescription = null,
                     modifier = Modifier
                         .background(
-                            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.2f),
+                            color = KptTheme.colorScheme.primary.copy(alpha = 0.2f),
                             shape = CircleShape,
                         )
                         .padding(DesignToken.padding.small),
-                    tint = MaterialTheme.colorScheme.primary,
+                    tint = KptTheme.colorScheme.primary,
                 )
 
                 Spacer(modifier = Modifier.height(24.dp))
@@ -125,7 +125,7 @@ private fun PasscodeScreenContent(
                         PasscodeMode.Confirm -> stringResource(Res.string.feature_passcode_confirm)
                     },
                     style = MifosTypography.titleMedium,
-                    color = MaterialTheme.colorScheme.onBackground,
+                    color = KptTheme.colorScheme.onBackground,
                 )
 
                 Spacer(modifier = Modifier.height(8.dp))
@@ -133,7 +133,7 @@ private fun PasscodeScreenContent(
                 Text(
                     text = stringResource(Res.string.feature_passcode_tip),
                     style = MifosTypography.bodySmall,
-                    color = MaterialTheme.colorScheme.secondary,
+                    color = KptTheme.colorScheme.secondary,
                     textAlign = TextAlign.Center,
                 )
 
@@ -143,15 +143,15 @@ private fun PasscodeScreenContent(
                     repeat(state.maxDigits) { index ->
                         val filled = index < state.filledDots
                         val color = when {
-                            state.passcodeError -> MaterialTheme.colorScheme.error
-                            filled -> MaterialTheme.colorScheme.primary
+                            state.passcodeError -> KptTheme.colorScheme.error
+                            filled -> KptTheme.colorScheme.primary
                             else -> Color.Transparent
                         }
                         val borderColor =
                             if (state.passcodeError) {
-                                MaterialTheme.colorScheme.error
+                                KptTheme.colorScheme.error
                             } else {
-                                MaterialTheme.colorScheme.primary
+                                KptTheme.colorScheme.primary
                             }
                         Box(
                             modifier = Modifier
@@ -200,7 +200,7 @@ fun NumericKeyboard(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .background(MaterialTheme.colorScheme.surface)
+            .background(KptTheme.colorScheme.surface)
             .padding(DesignToken.padding.large),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.small),
@@ -221,7 +221,7 @@ fun NumericKeyboard(
 
                         PasscodeKey.Backspace -> KeyButton(
                             modifier = Modifier.weight(1f),
-                            backgroundColor = MaterialTheme.colorScheme.tertiaryContainer,
+                            backgroundColor = KptTheme.colorScheme.tertiaryContainer,
                             content = {
                                 Icon(
                                     imageVector = MifosIcons.Backspace,
@@ -233,7 +233,7 @@ fun NumericKeyboard(
 
                         PasscodeKey.Send -> KeyButton(
                             modifier = Modifier.weight(1f),
-                            backgroundColor = MaterialTheme.colorScheme.inversePrimary,
+                            backgroundColor = KptTheme.colorScheme.inversePrimary,
                             content = {
                                 Icon(
                                     imageVector = MifosIcons.Send,
@@ -297,7 +297,7 @@ fun DigitKeyButton(
             .width(107.33333.dp)
             .height(41.dp)
             .clip(RoundedCornerShape(100.dp))
-            .background(MaterialTheme.colorScheme.surfaceContainerLow)
+            .background(KptTheme.colorScheme.surfaceContainerLow)
             .clickable(onClick = onClick),
         contentAlignment = Alignment.Center,
     ) {
@@ -308,13 +308,13 @@ fun DigitKeyButton(
             Text(
                 text = digit,
                 style = MifosTypography.keyBoardNumeric,
-                color = MaterialTheme.colorScheme.onBackground,
+                color = KptTheme.colorScheme.onBackground,
             )
             if (letters.isNotEmpty()) {
                 Text(
                     text = letters,
                     style = MifosTypography.keyBoardAlpha,
-                    color = MaterialTheme.colorScheme.outline,
+                    color = KptTheme.colorScheme.outline,
                 )
             }
         }

--- a/feature/passcode/src/commonMain/kotlin/org/mifos/mobile/feature/passcode/PasscodeScreen.kt
+++ b/feature/passcode/src/commonMain/kotlin/org/mifos/mobile/feature/passcode/PasscodeScreen.kt
@@ -100,7 +100,7 @@ private fun PasscodeScreenContent(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(DesignToken.padding.large)
+                    .padding(KptTheme.spacing.md)
                     .weight(1f),
                 verticalArrangement = Arrangement.Center,
                 horizontalAlignment = Alignment.CenterHorizontally,
@@ -113,7 +113,7 @@ private fun PasscodeScreenContent(
                             color = KptTheme.colorScheme.primary.copy(alpha = 0.2f),
                             shape = CircleShape,
                         )
-                        .padding(DesignToken.padding.small),
+                        .padding(KptTheme.spacing.sm),
                     tint = KptTheme.colorScheme.primary,
                 )
 
@@ -128,7 +128,7 @@ private fun PasscodeScreenContent(
                     color = KptTheme.colorScheme.onBackground,
                 )
 
-                Spacer(modifier = Modifier.height(DesignToken.spacing.small))
+                Spacer(modifier = Modifier.height(KptTheme.spacing.sm))
 
                 Text(
                     text = stringResource(Res.string.feature_passcode_tip),
@@ -137,9 +137,9 @@ private fun PasscodeScreenContent(
                     textAlign = TextAlign.Center,
                 )
 
-                Spacer(modifier = Modifier.height(DesignToken.spacing.extraLargeIncreased))
+                Spacer(modifier = Modifier.height(KptTheme.spacing.xl))
 
-                Row(horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.large)) {
+                Row(horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.md)) {
                     repeat(state.maxDigits) { index ->
                         val filled = index < state.filledDots
                         val color = when {
@@ -201,14 +201,14 @@ fun NumericKeyboard(
         modifier = modifier
             .fillMaxWidth()
             .background(KptTheme.colorScheme.surface)
-            .padding(DesignToken.padding.large),
+            .padding(KptTheme.spacing.md),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.small),
+        verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.sm),
     ) {
         layout.forEach { row ->
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.small),
+                horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.sm),
             ) {
                 row.forEach { key ->
                     when (key) {
@@ -302,7 +302,7 @@ fun DigitKeyButton(
         contentAlignment = Alignment.Center,
     ) {
         Row(
-            horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.small),
+            horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.sm),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(

--- a/feature/passcode/src/commonMain/kotlin/org/mifos/mobile/feature/passcode/verifyPasscode/VerifyPasscodeScreen.kt
+++ b/feature/passcode/src/commonMain/kotlin/org/mifos/mobile/feature/passcode/verifyPasscode/VerifyPasscodeScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -35,7 +34,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import mifos_mobile.feature.passcode.generated.resources.Res
 import mifos_mobile.feature.passcode.generated.resources.feature_passcode_authenticate
@@ -110,7 +108,7 @@ private fun VerifyPasscodeScreenContent(
                     tint = KptTheme.colorScheme.primary,
                 )
 
-                Spacer(modifier = Modifier.height(24.dp))
+                Spacer(modifier = Modifier.height(DesignToken.spacing.dp24))
 
                 Text(
                     text = stringResource(Res.string.feature_passcode_authenticate),
@@ -148,7 +146,7 @@ private fun VerifyPasscodeScreenContent(
                                 .clip(CircleShape)
                                 .background(color)
                                 .border(
-                                    1.dp,
+                                    DesignToken.strokes.thin,
                                     borderColor,
                                     CircleShape,
                                 ),
@@ -263,9 +261,9 @@ fun KeyButton(
 ) {
     Box(
         modifier = modifier
-            .width(107.33333.dp)
-            .height(41.dp)
-            .clip(RoundedCornerShape(100.dp))
+            .width(DesignToken.sizes.boxDp107)
+            .height(DesignToken.sizes.boxDp41)
+            .clip(DesignToken.shapes.dp100)
             .background(backgroundColor)
             .clickable(onClick = onClick, enabled = enabled),
         contentAlignment = Alignment.Center,
@@ -283,9 +281,9 @@ fun DigitKeyButton(
 ) {
     Box(
         modifier = modifier
-            .width(107.33333.dp)
-            .height(41.dp)
-            .clip(RoundedCornerShape(100.dp))
+            .width(DesignToken.sizes.boxDp107)
+            .height(DesignToken.sizes.boxDp41)
+            .clip(DesignToken.shapes.dp100)
             .background(KptTheme.colorScheme.surfaceContainerLow)
             .clickable(onClick = onClick),
         contentAlignment = Alignment.Center,

--- a/feature/passcode/src/commonMain/kotlin/org/mifos/mobile/feature/passcode/verifyPasscode/VerifyPasscodeScreen.kt
+++ b/feature/passcode/src/commonMain/kotlin/org/mifos/mobile/feature/passcode/verifyPasscode/VerifyPasscodeScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -51,6 +50,7 @@ import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
 import org.mifos.mobile.core.ui.component.MifosPoweredCard
 import org.mifos.mobile.core.ui.utils.EventsEffect
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 internal fun VerifyPasscodeScreen(
@@ -103,11 +103,11 @@ private fun VerifyPasscodeScreenContent(
                     contentDescription = null,
                     modifier = Modifier
                         .background(
-                            color = MaterialTheme.colorScheme.primary.copy(alpha = 0.2f),
+                            color = KptTheme.colorScheme.primary.copy(alpha = 0.2f),
                             shape = CircleShape,
                         )
                         .padding(DesignToken.padding.small),
-                    tint = MaterialTheme.colorScheme.primary,
+                    tint = KptTheme.colorScheme.primary,
                 )
 
                 Spacer(modifier = Modifier.height(24.dp))
@@ -115,7 +115,7 @@ private fun VerifyPasscodeScreenContent(
                 Text(
                     text = stringResource(Res.string.feature_passcode_authenticate),
                     style = MifosTypography.titleMedium,
-                    color = MaterialTheme.colorScheme.onBackground,
+                    color = KptTheme.colorScheme.onBackground,
                 )
 
                 Spacer(modifier = Modifier.height(8.dp))
@@ -123,7 +123,7 @@ private fun VerifyPasscodeScreenContent(
                 Text(
                     text = stringResource(Res.string.feature_passcode_authenticate_tip),
                     style = MifosTypography.bodySmall,
-                    color = MaterialTheme.colorScheme.secondary,
+                    color = KptTheme.colorScheme.secondary,
                     textAlign = TextAlign.Center,
                 )
 
@@ -133,14 +133,14 @@ private fun VerifyPasscodeScreenContent(
                     repeat(state.maxDigits) { index ->
                         val filled = index < state.filledDots
                         val color = when {
-                            filled -> MaterialTheme.colorScheme.primary
+                            filled -> KptTheme.colorScheme.primary
                             else -> Color.Transparent
                         }
                         val borderColor =
                             if (state.passcodeError) {
-                                MaterialTheme.colorScheme.error
+                                KptTheme.colorScheme.error
                             } else {
-                                MaterialTheme.colorScheme.primary
+                                KptTheme.colorScheme.primary
                             }
                         Box(
                             modifier = Modifier
@@ -189,7 +189,7 @@ fun NumericKeyboard(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .background(MaterialTheme.colorScheme.surface)
+            .background(KptTheme.colorScheme.surface)
             .padding(DesignToken.padding.large),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.small),
@@ -210,7 +210,7 @@ fun NumericKeyboard(
 
                         PasscodeKey.Backspace -> KeyButton(
                             modifier = Modifier.weight(1f),
-                            backgroundColor = MaterialTheme.colorScheme.tertiaryContainer,
+                            backgroundColor = KptTheme.colorScheme.tertiaryContainer,
                             content = {
                                 Icon(
                                     imageVector = MifosIcons.Backspace,
@@ -222,7 +222,7 @@ fun NumericKeyboard(
 
                         PasscodeKey.Send -> KeyButton(
                             modifier = Modifier.weight(1f),
-                            backgroundColor = MaterialTheme.colorScheme.inversePrimary,
+                            backgroundColor = KptTheme.colorScheme.inversePrimary,
                             content = {
                                 Icon(
                                     imageVector = MifosIcons.Send,
@@ -286,7 +286,7 @@ fun DigitKeyButton(
             .width(107.33333.dp)
             .height(41.dp)
             .clip(RoundedCornerShape(100.dp))
-            .background(MaterialTheme.colorScheme.surfaceContainerLow)
+            .background(KptTheme.colorScheme.surfaceContainerLow)
             .clickable(onClick = onClick),
         contentAlignment = Alignment.Center,
     ) {
@@ -297,13 +297,13 @@ fun DigitKeyButton(
             Text(
                 text = digit,
                 style = MifosTypography.keyBoardNumeric,
-                color = MaterialTheme.colorScheme.onBackground,
+                color = KptTheme.colorScheme.onBackground,
             )
             if (letters.isNotEmpty()) {
                 Text(
                     text = letters,
                     style = MifosTypography.keyBoardAlpha,
-                    color = MaterialTheme.colorScheme.outline,
+                    color = KptTheme.colorScheme.outline,
                 )
             }
         }

--- a/feature/passcode/src/commonMain/kotlin/org/mifos/mobile/feature/passcode/verifyPasscode/VerifyPasscodeScreen.kt
+++ b/feature/passcode/src/commonMain/kotlin/org/mifos/mobile/feature/passcode/verifyPasscode/VerifyPasscodeScreen.kt
@@ -118,7 +118,7 @@ private fun VerifyPasscodeScreenContent(
                     color = KptTheme.colorScheme.onBackground,
                 )
 
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(DesignToken.spacing.small))
 
                 Text(
                     text = stringResource(Res.string.feature_passcode_authenticate_tip),
@@ -127,7 +127,7 @@ private fun VerifyPasscodeScreenContent(
                     textAlign = TextAlign.Center,
                 )
 
-                Spacer(modifier = Modifier.height(32.dp))
+                Spacer(modifier = Modifier.height(DesignToken.spacing.extraLargeIncreased))
 
                 Row(horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.large)) {
                     repeat(state.maxDigits) { index ->
@@ -144,7 +144,7 @@ private fun VerifyPasscodeScreenContent(
                             }
                         Box(
                             modifier = Modifier
-                                .size(16.dp)
+                                .size(DesignToken.sizes.iconSmall)
                                 .clip(CircleShape)
                                 .background(color)
                                 .border(

--- a/feature/passcode/src/commonMain/kotlin/org/mifos/mobile/feature/passcode/verifyPasscode/VerifyPasscodeScreen.kt
+++ b/feature/passcode/src/commonMain/kotlin/org/mifos/mobile/feature/passcode/verifyPasscode/VerifyPasscodeScreen.kt
@@ -93,7 +93,7 @@ private fun VerifyPasscodeScreenContent(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(DesignToken.padding.large)
+                    .padding(KptTheme.spacing.md)
                     .weight(1f),
                 verticalArrangement = Arrangement.Center,
                 horizontalAlignment = Alignment.CenterHorizontally,
@@ -106,7 +106,7 @@ private fun VerifyPasscodeScreenContent(
                             color = KptTheme.colorScheme.primary.copy(alpha = 0.2f),
                             shape = CircleShape,
                         )
-                        .padding(DesignToken.padding.small),
+                        .padding(KptTheme.spacing.sm),
                     tint = KptTheme.colorScheme.primary,
                 )
 
@@ -118,7 +118,7 @@ private fun VerifyPasscodeScreenContent(
                     color = KptTheme.colorScheme.onBackground,
                 )
 
-                Spacer(modifier = Modifier.height(DesignToken.spacing.small))
+                Spacer(modifier = Modifier.height(KptTheme.spacing.sm))
 
                 Text(
                     text = stringResource(Res.string.feature_passcode_authenticate_tip),
@@ -127,9 +127,9 @@ private fun VerifyPasscodeScreenContent(
                     textAlign = TextAlign.Center,
                 )
 
-                Spacer(modifier = Modifier.height(DesignToken.spacing.extraLargeIncreased))
+                Spacer(modifier = Modifier.height(KptTheme.spacing.xl))
 
-                Row(horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.large)) {
+                Row(horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.md)) {
                     repeat(state.maxDigits) { index ->
                         val filled = index < state.filledDots
                         val color = when {
@@ -190,14 +190,14 @@ fun NumericKeyboard(
         modifier = modifier
             .fillMaxWidth()
             .background(KptTheme.colorScheme.surface)
-            .padding(DesignToken.padding.large),
+            .padding(KptTheme.spacing.md),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.small),
+        verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.sm),
     ) {
         layout.forEach { row ->
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.small),
+                horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.sm),
             ) {
                 row.forEach { key ->
                     when (key) {
@@ -291,7 +291,7 @@ fun DigitKeyButton(
         contentAlignment = Alignment.Center,
     ) {
         Row(
-            horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.small),
+            horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.sm),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(

--- a/feature/qr/src/androidMain/kotlin/org/mifos/mobile/feature/qr/CropContent.kt
+++ b/feature/qr/src/androidMain/kotlin/org/mifos/mobile/feature/qr/CropContent.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -35,6 +34,7 @@ import com.attafitamim.krop.core.crop.cropperStyle
 import com.attafitamim.krop.ui.ImageCropperDialog
 import org.mifos.mobile.core.designsystem.component.MifosButton
 import org.mifos.mobile.core.designsystem.theme.DesignToken
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun CropContent(
@@ -87,7 +87,7 @@ fun CropContent(
             ) {
                 Text(
                     text = "Choose Image",
-                    style = MaterialTheme.typography.labelLarge,
+                    style = KptTheme.typography.labelLarge,
                 )
             }
         }

--- a/feature/qr/src/androidMain/kotlin/org/mifos/mobile/feature/qr/CropContent.kt
+++ b/feature/qr/src/androidMain/kotlin/org/mifos/mobile/feature/qr/CropContent.kt
@@ -22,7 +22,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.unit.dp
 import com.attafitamim.krop.core.crop.AspectRatio
 import com.attafitamim.krop.core.crop.CircleCropShape
 import com.attafitamim.krop.core.crop.CropState
@@ -64,7 +63,7 @@ fun CropContent(
         contentAlignment = Alignment.Center,
     ) {
         Column(
-            modifier = modifier.padding(16.dp),
+            modifier = modifier.padding(DesignToken.padding.large),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center,
         ) {

--- a/feature/qr/src/androidMain/kotlin/org/mifos/mobile/feature/qr/CropContent.kt
+++ b/feature/qr/src/androidMain/kotlin/org/mifos/mobile/feature/qr/CropContent.kt
@@ -63,7 +63,7 @@ fun CropContent(
         contentAlignment = Alignment.Center,
     ) {
         Column(
-            modifier = modifier.padding(DesignToken.padding.large),
+            modifier = modifier.padding(KptTheme.spacing.md),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center,
         ) {
@@ -82,7 +82,7 @@ fun CropContent(
             MifosButton(
                 modifier = Modifier.fillMaxWidth().height(DesignToken.sizes.inputHeight),
                 onClick = onPick,
-                shape = DesignToken.shapes.medium,
+                shape = KptTheme.shapes.medium,
             ) {
                 Text(
                     text = "Choose Image",

--- a/feature/qr/src/androidMain/kotlin/org/mifos/mobile/feature/qr/Dialogs.kt
+++ b/feature/qr/src/androidMain/kotlin/org/mifos/mobile/feature/qr/Dialogs.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import com.attafitamim.krop.core.crop.CropError
 import com.attafitamim.krop.core.crop.CropperLoading
+import org.mifos.mobile.core.designsystem.theme.DesignToken
 import template.core.base.designsystem.theme.KptTheme
 
 @Composable
@@ -59,7 +60,7 @@ fun LoadingDialog(
                 Column(
                     verticalArrangement = Arrangement.spacedBy(6.dp, Alignment.CenterVertically),
                     horizontalAlignment = Alignment.CenterHorizontally,
-                    modifier = modifier.padding(16.dp),
+                    modifier = modifier.padding(DesignToken.padding.large),
                 ) {
                     CircularProgressIndicator()
                     Text(text = status.getMessage())

--- a/feature/qr/src/androidMain/kotlin/org/mifos/mobile/feature/qr/Dialogs.kt
+++ b/feature/qr/src/androidMain/kotlin/org/mifos/mobile/feature/qr/Dialogs.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -29,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import com.attafitamim.krop.core.crop.CropError
 import com.attafitamim.krop.core.crop.CropperLoading
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun CropErrorDialog(error: CropError, onDismiss: () -> Unit) {
@@ -55,7 +55,7 @@ fun LoadingDialog(
     var dismissed by remember(status) { mutableStateOf(false) }
     if (!dismissed) {
         Dialog(onDismissRequest = { dismissed = true }) {
-            Surface(shape = MaterialTheme.shapes.small) {
+            Surface(shape = KptTheme.shapes.small) {
                 Column(
                     verticalArrangement = Arrangement.spacedBy(6.dp, Alignment.CenterVertically),
                     horizontalAlignment = Alignment.CenterHorizontally,

--- a/feature/qr/src/androidMain/kotlin/org/mifos/mobile/feature/qr/Dialogs.kt
+++ b/feature/qr/src/androidMain/kotlin/org/mifos/mobile/feature/qr/Dialogs.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import com.attafitamim.krop.core.crop.CropError
 import com.attafitamim.krop.core.crop.CropperLoading
-import org.mifos.mobile.core.designsystem.theme.DesignToken
 import template.core.base.designsystem.theme.KptTheme
 
 @Composable
@@ -60,7 +59,7 @@ fun LoadingDialog(
                 Column(
                     verticalArrangement = Arrangement.spacedBy(6.dp, Alignment.CenterVertically),
                     horizontalAlignment = Alignment.CenterHorizontally,
-                    modifier = modifier.padding(DesignToken.padding.large),
+                    modifier = modifier.padding(KptTheme.spacing.md),
                 ) {
                     CircularProgressIndicator()
                     Text(text = status.getMessage())

--- a/feature/qr/src/androidMain/kotlin/org/mifos/mobile/feature/qr/Dialogs.kt
+++ b/feature/qr/src/androidMain/kotlin/org/mifos/mobile/feature/qr/Dialogs.kt
@@ -24,10 +24,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import com.attafitamim.krop.core.crop.CropError
 import com.attafitamim.krop.core.crop.CropperLoading
+import org.mifos.mobile.core.designsystem.theme.DesignToken
 import template.core.base.designsystem.theme.KptTheme
 
 @Composable
@@ -57,7 +57,7 @@ fun LoadingDialog(
         Dialog(onDismissRequest = { dismissed = true }) {
             Surface(shape = KptTheme.shapes.small) {
                 Column(
-                    verticalArrangement = Arrangement.spacedBy(6.dp, Alignment.CenterVertically),
+                    verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.dp6, Alignment.CenterVertically),
                     horizontalAlignment = Alignment.CenterHorizontally,
                     modifier = modifier.padding(KptTheme.spacing.md),
                 ) {

--- a/feature/qr/src/commonMain/kotlin/org/mifos/mobile/feature/qr/qr/QrCodeReaderScreen.kt
+++ b/feature/qr/src/commonMain/kotlin/org/mifos/mobile/feature/qr/qr/QrCodeReaderScreen.kt
@@ -151,7 +151,7 @@ private fun QrCodeReaderContent(
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(bottom = DesignToken.sizes.buttonHeight + 24.dp),
+                    .padding(bottom = DesignToken.sizes.buttonHeight + DesignToken.spacing.dp24),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 Text(
@@ -169,7 +169,7 @@ private fun QrCodeReaderContent(
                         .fillMaxWidth()
                         .clip(KptTheme.shapes.medium)
                         .drawQrCorners()
-                        .border(1.dp, Color.Transparent, KptTheme.shapes.medium),
+                        .border(DesignToken.strokes.thin, Color.Transparent, KptTheme.shapes.medium),
                     contentAlignment = Alignment.Center,
                 ) {
                     QrScannerWithPermissions(
@@ -199,7 +199,7 @@ private fun QrCodeReaderContent(
                                 horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.sm),
                             ) {
                                 Icon(
-                                    modifier = Modifier.size(20.dp),
+                                    modifier = Modifier.size(DesignToken.sizes.iconDp20),
                                     imageVector = MifosIcons.Warning,
                                     contentDescription = "Warning",
                                     tint = Color.Unspecified,
@@ -241,12 +241,16 @@ private fun QrCodeReaderContent(
 private fun Modifier.drawQrCorners(): Modifier = drawWithContent {
     drawContent()
 
+    // TODO use DesignToken, currently there is some error if replaced directly
     val strokeWidth = 5.dp.toPx()
     val lineLength = 40.dp.toPx()
 
-    val horizontalPadding = 50.dp.toPx() // for left & right
-    val verticalPaddingTop = 50.dp.toPx() // for top corners
-    val verticalPaddingBottom = 200.dp.toPx() // more padding for bottom corners
+    // for left & right
+    val horizontalPadding = 50.dp.toPx()
+    // for top corners
+    val verticalPaddingTop = 50.dp.toPx()
+    // more padding for bottom corners
+    val verticalPaddingBottom = 200.dp.toPx()
 
     val color = AppColors.customWhite
 

--- a/feature/qr/src/commonMain/kotlin/org/mifos/mobile/feature/qr/qr/QrCodeReaderScreen.kt
+++ b/feature/qr/src/commonMain/kotlin/org/mifos/mobile/feature/qr/qr/QrCodeReaderScreen.kt
@@ -63,6 +63,7 @@ import org.mifos.mobile.core.qr.CodeType
 import org.mifos.mobile.core.qr.QrScannerWithPermissions
 import org.mifos.mobile.core.ui.component.MifosPoweredCard
 import org.mifos.mobile.core.ui.utils.EventsEffect
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 internal fun QrCodeReaderScreen(
@@ -144,8 +145,8 @@ private fun QrCodeReaderContent(
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(DesignToken.padding.large)
-                .padding(top = DesignToken.padding.large),
+                .padding(KptTheme.spacing.md)
+                .padding(top = KptTheme.spacing.md),
         ) {
             Column(
                 modifier = Modifier
@@ -166,9 +167,9 @@ private fun QrCodeReaderContent(
                     modifier = Modifier
                         .weight(1f)
                         .fillMaxWidth()
-                        .clip(DesignToken.shapes.medium)
+                        .clip(KptTheme.shapes.medium)
                         .drawQrCorners()
-                        .border(1.dp, Color.Transparent, DesignToken.shapes.medium),
+                        .border(1.dp, Color.Transparent, KptTheme.shapes.medium),
                     contentAlignment = Alignment.Center,
                 ) {
                     QrScannerWithPermissions(
@@ -184,18 +185,18 @@ private fun QrCodeReaderContent(
                         modifier = Modifier
                             .align(Alignment.BottomCenter)
                             .fillMaxWidth()
-                            .padding(DesignToken.padding.small),
-                        shape = DesignToken.shapes.medium,
+                            .padding(KptTheme.spacing.sm),
+                        shape = KptTheme.shapes.medium,
                         variant = CardVariant.OUTLINED,
                     ) {
                         Column(
-                            modifier = Modifier.padding(DesignToken.padding.large),
+                            modifier = Modifier.padding(KptTheme.spacing.md),
                             horizontalAlignment = Alignment.CenterHorizontally,
-                            verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.small),
+                            verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.sm),
                         ) {
                             Row(
                                 verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.small),
+                                horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.sm),
                             ) {
                                 Icon(
                                     modifier = Modifier.size(20.dp),
@@ -226,7 +227,7 @@ private fun QrCodeReaderContent(
                     .align(Alignment.BottomCenter)
                     .fillMaxWidth()
                     .height(DesignToken.sizes.buttonHeight),
-                shape = DesignToken.shapes.medium,
+                shape = KptTheme.shapes.medium,
             ) {
                 Text(
                     text = stringResource(Res.string.feature_qr_upload),

--- a/feature/qr/src/commonMain/kotlin/org/mifos/mobile/feature/qr/qrCodeDisplay/QrCodeDisplayScreen.kt
+++ b/feature/qr/src/commonMain/kotlin/org/mifos/mobile/feature/qr/qrCodeDisplay/QrCodeDisplayScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.github.alexzhirkevich.qrose.rememberQrCodePainter
 import mifos_mobile.feature.qr.generated.resources.Res
@@ -142,7 +141,7 @@ private fun QrCodeDisplayContent(
                 painter = painter,
                 contentDescription = null,
                 modifier = Modifier
-                    .size(212.dp),
+                    .size(DesignToken.sizes.imageDp212),
             )
 
             Spacer(Modifier.height(DesignToken.padding.extraExtraLarge))

--- a/feature/qr/src/commonMain/kotlin/org/mifos/mobile/feature/qr/qrCodeDisplay/QrCodeDisplayScreen.kt
+++ b/feature/qr/src/commonMain/kotlin/org/mifos/mobile/feature/qr/qrCodeDisplay/QrCodeDisplayScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -48,6 +47,7 @@ import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
 import org.mifos.mobile.core.ui.component.MifosPoweredCard
 import org.mifos.mobile.core.ui.utils.EventsEffect
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 internal fun QrCodeDisplayScreen(
@@ -125,7 +125,7 @@ private fun QrCodeDisplayContent(
             Text(
                 text = stringResource(Res.string.scan_your_qr),
                 style = MifosTypography.titleLargeEmphasized,
-                color = MaterialTheme.colorScheme.primary,
+                color = KptTheme.colorScheme.primary,
             )
 
             Spacer(Modifier.height(DesignToken.padding.largeIncreased))
@@ -157,7 +157,7 @@ private fun QrCodeDisplayContent(
         Text(
             text = stringResource(Res.string.generated_on) + date,
             style = MifosTypography.bodySmall,
-            color = MaterialTheme.colorScheme.primary,
+            color = KptTheme.colorScheme.primary,
             modifier = Modifier.align(Alignment.BottomCenter),
         )
     }

--- a/feature/qr/src/commonMain/kotlin/org/mifos/mobile/feature/qr/qrCodeDisplay/QrCodeDisplayScreen.kt
+++ b/feature/qr/src/commonMain/kotlin/org/mifos/mobile/feature/qr/qrCodeDisplay/QrCodeDisplayScreen.kt
@@ -112,8 +112,8 @@ private fun QrCodeDisplayContent(
     Box(
         modifier = modifier
             .padding(
-                horizontal = DesignToken.padding.large,
-                vertical = DesignToken.padding.extraLargeIncreased,
+                horizontal = KptTheme.spacing.md,
+                vertical = KptTheme.spacing.xl,
             )
             .fillMaxSize(),
     ) {

--- a/feature/recent-transaction/src/commonMain/kotlin/org/mifos/mobile/feature/recent/transaction/screen/RecentTransactionScreen.kt
+++ b/feature/recent-transaction/src/commonMain/kotlin/org/mifos/mobile/feature/recent/transaction/screen/RecentTransactionScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -52,7 +51,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.koin.compose.viewmodel.koinViewModel
 import org.mifos.mobile.core.common.CurrencyFormatter
@@ -319,7 +317,7 @@ fun TransactionFilterSheetContent(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 24.dp, vertical = KptTheme.spacing.md),
+            .padding(horizontal = DesignToken.spacing.dp24, vertical = KptTheme.spacing.md),
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -358,9 +356,9 @@ fun TransactionFilterSheetContent(
                     .fillMaxWidth()
                     .clickable { isAccountDropdownExpanded = true },
                 shape = KptTheme.shapes.medium,
-                border = BorderStroke(1.dp, Color.Gray.copy(alpha = 0.5f)),
+                border = BorderStroke(DesignToken.strokes.thin, Color.Gray.copy(alpha = 0.5f)),
                 colors = CardDefaults.cardColors(containerColor = Color.White),
-                elevation = CardDefaults.cardElevation(0.dp),
+                elevation = CardDefaults.cardElevation(KptTheme.elevation.level0),
             ) {
                 Row(
                     modifier = Modifier
@@ -446,7 +444,7 @@ fun TransactionFilterSheetContent(
             )
         }
 
-        Spacer(modifier = Modifier.height(40.dp))
+        Spacer(modifier = Modifier.height(DesignToken.spacing.dp40))
 
         Button(
             onClick = {
@@ -456,8 +454,8 @@ fun TransactionFilterSheetContent(
             },
             modifier = Modifier
                 .fillMaxWidth()
-                .height(50.dp),
-            shape = RoundedCornerShape(25.dp),
+                .height(DesignToken.sizes.buttonDp50),
+            shape = DesignToken.shapes.dp25,
             colors = ButtonDefaults.buttonColors(
                 containerColor = KptTheme.colorScheme.primary,
             ),
@@ -469,7 +467,7 @@ fun TransactionFilterSheetContent(
             )
         }
 
-        Spacer(modifier = Modifier.height(24.dp))
+        Spacer(modifier = Modifier.height(DesignToken.spacing.dp24))
     }
 }
 
@@ -481,10 +479,17 @@ fun FilterOptionChip(
     modifier: Modifier = Modifier,
 ) {
     Surface(
-        modifier = modifier.height(40.dp),
+        modifier = modifier.height(DesignToken.sizes.surfaceDp40),
         shape = DesignToken.shapes.largeIncreased,
         color = if (isSelected) KptTheme.colorScheme.primary else KptTheme.colorScheme.surface,
-        border = if (!isSelected) BorderStroke(1.dp, KptTheme.colorScheme.outline.copy(alpha = 0.5f)) else null,
+        border = if (!isSelected) {
+            BorderStroke(
+                DesignToken.strokes.thin,
+                KptTheme.colorScheme.outline.copy(alpha = 0.5f),
+            )
+        } else {
+            null
+        },
         onClick = onClick,
     ) {
         Box(

--- a/feature/recent-transaction/src/commonMain/kotlin/org/mifos/mobile/feature/recent/transaction/screen/RecentTransactionScreen.kt
+++ b/feature/recent-transaction/src/commonMain/kotlin/org/mifos/mobile/feature/recent/transaction/screen/RecentTransactionScreen.kt
@@ -93,7 +93,7 @@ fun RecentTransactionScreen(
                             Text(
                                 text = "Transaction History",
                                 style = KptTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
-                                modifier = Modifier.padding(end = DesignToken.padding.small),
+                                modifier = Modifier.padding(end = KptTheme.spacing.sm),
                             )
                         }
                         state.selectedAccount?.let { account ->
@@ -195,13 +195,13 @@ fun TransactionItem(
         modifier = modifier
             .fillMaxWidth()
             .clickable { onClick() }
-            .padding(horizontal = DesignToken.padding.large, vertical = DesignToken.padding.medium),
+            .padding(horizontal = KptTheme.spacing.md, vertical = DesignToken.padding.medium),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(
             horizontalAlignment = Alignment.Start,
-            verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.extraSmall),
+            verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.xs),
         ) {
             Text(
                 text = if (isCredit) "CREDIT" else "DEBIT",
@@ -274,7 +274,7 @@ fun TransactionList(
                 HorizontalDivider(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = DesignToken.padding.large),
+                        .padding(horizontal = KptTheme.spacing.md),
                     color = KptTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
                 )
             }
@@ -319,7 +319,7 @@ fun TransactionFilterSheetContent(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 24.dp, vertical = DesignToken.padding.large),
+            .padding(horizontal = 24.dp, vertical = KptTheme.spacing.md),
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -344,7 +344,7 @@ fun TransactionFilterSheetContent(
             }
         }
 
-        HorizontalDivider(modifier = Modifier.padding(vertical = DesignToken.padding.small))
+        HorizontalDivider(modifier = Modifier.padding(vertical = KptTheme.spacing.sm))
 
         Text(
             text = "Filter By Account :",
@@ -357,7 +357,7 @@ fun TransactionFilterSheetContent(
                 modifier = Modifier
                     .fillMaxWidth()
                     .clickable { isAccountDropdownExpanded = true },
-                shape = DesignToken.shapes.medium,
+                shape = KptTheme.shapes.medium,
                 border = BorderStroke(1.dp, Color.Gray.copy(alpha = 0.5f)),
                 colors = CardDefaults.cardColors(containerColor = Color.White),
                 elevation = CardDefaults.cardElevation(0.dp),
@@ -365,7 +365,7 @@ fun TransactionFilterSheetContent(
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(DesignToken.padding.large),
+                        .padding(KptTheme.spacing.md),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
@@ -375,7 +375,7 @@ fun TransactionFilterSheetContent(
                             style = KptTheme.typography.bodyLarge
                                 .copy(fontWeight = FontWeight.Bold),
                         )
-                        Spacer(modifier = Modifier.height(DesignToken.spacing.extraSmall))
+                        Spacer(modifier = Modifier.height(KptTheme.spacing.xs))
                         Text(
                             text = "Balance: ${selectedAccount?.accountBalance ?: "0.0"} " +
                                 (selectedAccount?.currency?.code ?: ""),

--- a/feature/recent-transaction/src/commonMain/kotlin/org/mifos/mobile/feature/recent/transaction/screen/RecentTransactionScreen.kt
+++ b/feature/recent-transaction/src/commonMain/kotlin/org/mifos/mobile/feature/recent/transaction/screen/RecentTransactionScreen.kt
@@ -35,7 +35,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -64,6 +63,7 @@ import org.mifos.mobile.feature.recent.transaction.utils.RecentTransactionAction
 import org.mifos.mobile.feature.recent.transaction.utils.RecentTransactionUiState
 import org.mifos.mobile.feature.recent.transaction.utils.TransactionFilterType
 import org.mifos.mobile.feature.recent.transaction.viewmodel.RecentTransactionViewModel
+import template.core.base.designsystem.theme.KptTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -91,16 +91,16 @@ fun RecentTransactionScreen(
 
                             Text(
                                 text = "Transaction History",
-                                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                                style = KptTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
                                 modifier = Modifier.padding(end = 8.dp),
                             )
                         }
                         state.selectedAccount?.let { account ->
                             Text(
                                 text = account.accountNo ?: "Selected Account",
-                                style = MaterialTheme.typography.bodyMedium,
+                                style = KptTheme.typography.bodyMedium,
                                 fontWeight = FontWeight.Bold,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                color = KptTheme.colorScheme.onSurfaceVariant,
 
                             )
                         }
@@ -118,9 +118,9 @@ fun RecentTransactionScreen(
                             if (
                                 state.filterType != TransactionFilterType.ALL
                             ) {
-                                MaterialTheme.colorScheme.primary
+                                KptTheme.colorScheme.primary
                             } else {
-                                MaterialTheme.colorScheme.onSurface
+                                KptTheme.colorScheme.onSurface
                             },
                         )
                     }
@@ -160,7 +160,7 @@ fun RecentTransactionScreen(
             ModalBottomSheet(
                 onDismissRequest = { viewModel.handleAction(RecentTransactionAction.ToggleFilter) },
                 sheetState = sheetState,
-                containerColor = MaterialTheme.colorScheme.surface,
+                containerColor = KptTheme.colorScheme.surface,
             ) {
                 TransactionFilterSheetContent(
                     accounts = state.accounts,
@@ -204,13 +204,13 @@ fun TransactionItem(
         ) {
             Text(
                 text = if (isCredit) "CREDIT" else "DEBIT",
-                style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold),
-                color = MaterialTheme.colorScheme.onSurface,
+                style = KptTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold),
+                color = KptTheme.colorScheme.onSurface,
             )
             Text(
                 text = formatDate(transaction.date),
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                style = KptTheme.typography.bodyMedium,
+                color = KptTheme.colorScheme.onSurfaceVariant,
             )
         }
 
@@ -220,7 +220,7 @@ fun TransactionItem(
                 transaction.currency?.code ?: "USD",
                 8,
             )}",
-            style = MaterialTheme.typography.bodyLarge.copy(
+            style = KptTheme.typography.bodyLarge.copy(
                 color = amountColor,
                 fontWeight = FontWeight.SemiBold,
             ),
@@ -274,7 +274,7 @@ fun TransactionList(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp),
-                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                    color = KptTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
                 )
             }
         }
@@ -288,7 +288,7 @@ fun ErrorScreen(message: String, onRetry: () -> Unit, modifier: Modifier = Modif
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
-        Text(text = message, color = MaterialTheme.colorScheme.error)
+        Text(text = message, color = KptTheme.colorScheme.error)
         Button(onClick = onRetry) {
             Text("Retry")
         }
@@ -327,7 +327,7 @@ fun TransactionFilterSheetContent(
         ) {
             Text(
                 text = "Filter Transactions",
-                style = MaterialTheme.typography.titleLarge.copy(
+                style = KptTheme.typography.titleLarge.copy(
                     fontWeight = FontWeight.Bold,
                     fontSize = 20.sp,
                 ),
@@ -335,8 +335,8 @@ fun TransactionFilterSheetContent(
             TextButton(onClick = onClear) {
                 Text(
                     text = "Clear All",
-                    style = MaterialTheme.typography.bodyMedium.copy(
-                        color = MaterialTheme.colorScheme.primary,
+                    style = KptTheme.typography.bodyMedium.copy(
+                        color = KptTheme.colorScheme.primary,
                         fontWeight = FontWeight.SemiBold,
                     ),
                 )
@@ -347,7 +347,7 @@ fun TransactionFilterSheetContent(
 
         Text(
             text = "Filter By Account :",
-            style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
+            style = KptTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
             modifier = Modifier.padding(vertical = 12.dp),
         )
 
@@ -371,14 +371,14 @@ fun TransactionFilterSheetContent(
                     Column {
                         Text(
                             text = "A/c No: ${selectedAccount?.accountNo ?: "Select Account"}",
-                            style = MaterialTheme.typography.bodyLarge
+                            style = KptTheme.typography.bodyLarge
                                 .copy(fontWeight = FontWeight.Bold),
                         )
                         Spacer(modifier = Modifier.height(4.dp))
                         Text(
                             text = "Balance: ${selectedAccount?.accountBalance ?: "0.0"} " +
                                 "${selectedAccount?.currency?.code ?: ""}",
-                            style = MaterialTheme.typography.bodySmall.copy(color = Color.Gray),
+                            style = KptTheme.typography.bodySmall.copy(color = Color.Gray),
                         )
                     }
                     Icon(
@@ -401,7 +401,7 @@ fun TransactionFilterSheetContent(
                         text = {
                             Column {
                                 Text(text = account.productName ?: "Account", fontWeight = FontWeight.Bold)
-                                Text(text = account.accountNo ?: "", style = MaterialTheme.typography.bodySmall)
+                                Text(text = account.accountNo ?: "", style = KptTheme.typography.bodySmall)
                             }
                         },
                         onClick = {
@@ -417,7 +417,7 @@ fun TransactionFilterSheetContent(
 
         Text(
             text = "Transaction Type:",
-            style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
+            style = KptTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
             modifier = Modifier.padding(bottom = 12.dp),
         )
 
@@ -458,7 +458,7 @@ fun TransactionFilterSheetContent(
                 .height(50.dp),
             shape = RoundedCornerShape(25.dp),
             colors = ButtonDefaults.buttonColors(
-                containerColor = MaterialTheme.colorScheme.primary,
+                containerColor = KptTheme.colorScheme.primary,
             ),
         ) {
             Text(
@@ -482,8 +482,8 @@ fun FilterOptionChip(
     Surface(
         modifier = modifier.height(40.dp),
         shape = RoundedCornerShape(20.dp),
-        color = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surface,
-        border = if (!isSelected) BorderStroke(1.dp, MaterialTheme.colorScheme.outline.copy(alpha = 0.5f)) else null,
+        color = if (isSelected) KptTheme.colorScheme.primary else KptTheme.colorScheme.surface,
+        border = if (!isSelected) BorderStroke(1.dp, KptTheme.colorScheme.outline.copy(alpha = 0.5f)) else null,
         onClick = onClick,
     ) {
         Box(
@@ -492,7 +492,7 @@ fun FilterOptionChip(
         ) {
             Text(
                 text = label,
-                color = if (isSelected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurface,
+                color = if (isSelected) KptTheme.colorScheme.onPrimary else KptTheme.colorScheme.onSurface,
                 fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
             )
         }

--- a/feature/recent-transaction/src/commonMain/kotlin/org/mifos/mobile/feature/recent/transaction/screen/RecentTransactionScreen.kt
+++ b/feature/recent-transaction/src/commonMain/kotlin/org/mifos/mobile/feature/recent/transaction/screen/RecentTransactionScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.ui.unit.sp
 import org.koin.compose.viewmodel.koinViewModel
 import org.mifos.mobile.core.common.CurrencyFormatter
 import org.mifos.mobile.core.designsystem.icon.MifosIcons
+import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.model.entity.accounts.savings.SavingAccount
 import org.mifos.mobile.core.model.entity.accounts.savings.Transactions
 import org.mifos.mobile.feature.recent.transaction.utils.RecentTransactionAction
@@ -92,7 +93,7 @@ fun RecentTransactionScreen(
                             Text(
                                 text = "Transaction History",
                                 style = KptTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
-                                modifier = Modifier.padding(end = 8.dp),
+                                modifier = Modifier.padding(end = DesignToken.padding.small),
                             )
                         }
                         state.selectedAccount?.let { account ->
@@ -194,13 +195,13 @@ fun TransactionItem(
         modifier = modifier
             .fillMaxWidth()
             .clickable { onClick() }
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+            .padding(horizontal = DesignToken.padding.large, vertical = DesignToken.padding.medium),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(
             horizontalAlignment = Alignment.Start,
-            verticalArrangement = Arrangement.spacedBy(4.dp),
+            verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.extraSmall),
         ) {
             Text(
                 text = if (isCredit) "CREDIT" else "DEBIT",
@@ -273,7 +274,7 @@ fun TransactionList(
                 HorizontalDivider(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = 16.dp),
+                        .padding(horizontal = DesignToken.padding.large),
                     color = KptTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
                 )
             }
@@ -318,7 +319,7 @@ fun TransactionFilterSheetContent(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 24.dp, vertical = 16.dp),
+            .padding(horizontal = 24.dp, vertical = DesignToken.padding.large),
     ) {
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -343,12 +344,12 @@ fun TransactionFilterSheetContent(
             }
         }
 
-        HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+        HorizontalDivider(modifier = Modifier.padding(vertical = DesignToken.padding.small))
 
         Text(
             text = "Filter By Account :",
             style = KptTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
-            modifier = Modifier.padding(vertical = 12.dp),
+            modifier = Modifier.padding(vertical = DesignToken.padding.medium),
         )
 
         Box {
@@ -356,7 +357,7 @@ fun TransactionFilterSheetContent(
                 modifier = Modifier
                     .fillMaxWidth()
                     .clickable { isAccountDropdownExpanded = true },
-                shape = RoundedCornerShape(12.dp),
+                shape = DesignToken.shapes.medium,
                 border = BorderStroke(1.dp, Color.Gray.copy(alpha = 0.5f)),
                 colors = CardDefaults.cardColors(containerColor = Color.White),
                 elevation = CardDefaults.cardElevation(0.dp),
@@ -364,7 +365,7 @@ fun TransactionFilterSheetContent(
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(16.dp),
+                        .padding(DesignToken.padding.large),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
@@ -374,10 +375,10 @@ fun TransactionFilterSheetContent(
                             style = KptTheme.typography.bodyLarge
                                 .copy(fontWeight = FontWeight.Bold),
                         )
-                        Spacer(modifier = Modifier.height(4.dp))
+                        Spacer(modifier = Modifier.height(DesignToken.spacing.extraSmall))
                         Text(
                             text = "Balance: ${selectedAccount?.accountBalance ?: "0.0"} " +
-                                "${selectedAccount?.currency?.code ?: ""}",
+                                (selectedAccount?.currency?.code ?: ""),
                             style = KptTheme.typography.bodySmall.copy(color = Color.Gray),
                         )
                     }
@@ -413,17 +414,17 @@ fun TransactionFilterSheetContent(
             }
         }
 
-        Spacer(modifier = Modifier.height(20.dp))
+        Spacer(modifier = Modifier.height(DesignToken.spacing.largeIncreased))
 
         Text(
             text = "Transaction Type:",
             style = KptTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
-            modifier = Modifier.padding(bottom = 12.dp),
+            modifier = Modifier.padding(bottom = DesignToken.padding.medium),
         )
 
         Row(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.medium),
         ) {
             FilterOptionChip(
                 label = "All",
@@ -481,7 +482,7 @@ fun FilterOptionChip(
 ) {
     Surface(
         modifier = modifier.height(40.dp),
-        shape = RoundedCornerShape(20.dp),
+        shape = DesignToken.shapes.largeIncreased,
         color = if (isSelected) KptTheme.colorScheme.primary else KptTheme.colorScheme.surface,
         border = if (!isSelected) BorderStroke(1.dp, KptTheme.colorScheme.outline.copy(alpha = 0.5f)) else null,
         onClick = onClick,

--- a/feature/savings-account/src/commonMain/kotlin/org/mifos/mobile/feature/savingsaccount/savingsAccount/SavingsAccountScreen.kt
+++ b/feature/savings-account/src/commonMain/kotlin/org/mifos/mobile/feature/savingsaccount/savingsAccount/SavingsAccountScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import mifos_mobile.feature.savings_account.generated.resources.Res
 import mifos_mobile.feature.savings_account.generated.resources.content_description_filter
@@ -238,7 +237,7 @@ internal fun SavingsAccountContent(
                         Icon(
                             modifier = Modifier
                                 .clickable { filtersClicked() }
-                                .size(20.dp),
+                                .size(DesignToken.sizes.iconDp20),
                             imageVector = MifosIcons.Filter,
                             contentDescription = stringResource(Res.string.content_description_filter),
                         )
@@ -250,7 +249,7 @@ internal fun SavingsAccountContent(
                 HorizontalDivider(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(0.99997.dp),
+                        .height(DesignToken.strokes.thin),
                 )
 
                 if (state.isFilteredEmpty) {

--- a/feature/savings-account/src/commonMain/kotlin/org/mifos/mobile/feature/savingsaccount/savingsAccount/SavingsAccountScreen.kt
+++ b/feature/savings-account/src/commonMain/kotlin/org/mifos/mobile/feature/savingsaccount/savingsAccount/SavingsAccountScreen.kt
@@ -169,7 +169,7 @@ internal fun SavingsAccountContent(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(DesignToken.padding.large),
+            .padding(KptTheme.spacing.md),
     ) {
         when (state.uiState) {
             ScreenUiState.Loading -> {
@@ -200,7 +200,7 @@ internal fun SavingsAccountContent(
             }
 
             ScreenUiState.Success -> {
-                Spacer(modifier = Modifier.height(DesignToken.spacing.large))
+                Spacer(modifier = Modifier.height(KptTheme.spacing.md))
 
                 MifosDashboardCard(
                     isSingleLine = true,
@@ -272,7 +272,7 @@ internal fun SavingsAccountContent(
                             .fillMaxSize()
                             .weight(1f),
                     ) {
-                        item { Spacer(modifier = Modifier.height(DesignToken.spacing.small)) }
+                        item { Spacer(modifier = Modifier.height(KptTheme.spacing.sm)) }
 
                         items(accounts) { account ->
                             val color = when (account.status?.value) {

--- a/feature/savings-account/src/commonMain/kotlin/org/mifos/mobile/feature/savingsaccount/savingsAccount/SavingsAccountScreen.kt
+++ b/feature/savings-account/src/commonMain/kotlin/org/mifos/mobile/feature/savingsaccount/savingsAccount/SavingsAccountScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -61,6 +60,7 @@ import org.mifos.mobile.core.ui.component.MifosErrorComponent
 import org.mifos.mobile.core.ui.component.MifosProgressIndicator
 import org.mifos.mobile.core.ui.utils.EventsEffect
 import org.mifos.mobile.core.ui.utils.ScreenUiState
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * A stateful composable that serves as the main entry point for the Savings Account list screen.
@@ -222,7 +222,7 @@ internal fun SavingsAccountContent(
                         Text(
                             text = stringResource(Res.string.feature_savings_account),
                             style = MifosTypography.titleMediumEmphasized,
-                            color = MaterialTheme.colorScheme.onBackground,
+                            color = KptTheme.colorScheme.onBackground,
                         )
                         Text(
                             text = stringResource(
@@ -230,7 +230,7 @@ internal fun SavingsAccountContent(
                                 state.items ?: 0,
                             ),
                             style = MifosTypography.labelMedium,
-                            color = MaterialTheme.colorScheme.secondary,
+                            color = KptTheme.colorScheme.secondary,
                         )
                     }
 
@@ -278,8 +278,8 @@ internal fun SavingsAccountContent(
                             val color = when (account.status?.value) {
                                 SavingStatus.ACTIVE.status -> AppColors.customEnable
                                 SavingStatus.SUBMIT_AND_PENDING_APPROVAL.status -> AppColors.customYellow
-                                SavingStatus.INACTIVE.status -> MaterialTheme.colorScheme.error
-                                else -> MaterialTheme.colorScheme.onSurface
+                                SavingStatus.INACTIVE.status -> KptTheme.colorScheme.error
+                                else -> KptTheme.colorScheme.onSurface
                             }
 
                             val accountStatus = if (account.status?.active == true) {

--- a/feature/savings-account/src/commonMain/kotlin/org/mifos/mobile/feature/savingsaccount/savingsAccountDetails/SavingsAccountDetailsScreen.kt
+++ b/feature/savings-account/src/commonMain/kotlin/org/mifos/mobile/feature/savingsaccount/savingsAccountDetails/SavingsAccountDetailsScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -58,6 +57,7 @@ import org.mifos.mobile.core.ui.utils.EventsEffect
 import org.mifos.mobile.core.ui.utils.ScreenUiState
 import org.mifos.mobile.feature.savingsaccount.components.SavingsActionItems
 import org.mifos.mobile.feature.savingsaccount.components.savingsAccountActions
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * A stateful composable that serves as the entry point for the "Savings Account Details" screen.
@@ -249,9 +249,9 @@ internal fun ActionBar(
             Text(
                 text = stringResource(Res.string.feature_account_action_update),
                 color = if (isUpdatable) {
-                    MaterialTheme.colorScheme.primary
+                    KptTheme.colorScheme.primary
                 } else {
-                    MaterialTheme.colorScheme.inversePrimary
+                    KptTheme.colorScheme.inversePrimary
                 },
                 style = MifosTypography.bodySmallEmphasized,
             )
@@ -261,9 +261,9 @@ internal fun ActionBar(
                 imageVector = MifosIcons.EditRegular,
                 contentDescription = null,
                 tint = if (isUpdatable) {
-                    MaterialTheme.colorScheme.primary
+                    KptTheme.colorScheme.primary
                 } else {
-                    MaterialTheme.colorScheme.inversePrimary
+                    KptTheme.colorScheme.inversePrimary
                 },
 
             )
@@ -296,7 +296,7 @@ internal fun AccountDetailsGrid(
             Text(
                 text = label,
                 style = MifosTypography.labelLargeEmphasized,
-                color = MaterialTheme.colorScheme.onSurface,
+                color = KptTheme.colorScheme.onSurface,
             )
         }
         if (details != null) {
@@ -317,7 +317,7 @@ internal fun AccountDetailsGrid(
                             AppColors
                                 .customEnable
                         } else {
-                            MaterialTheme
+                            KptTheme
                                 .colorScheme.onBackground
                         },
                     )
@@ -347,7 +347,7 @@ internal fun SavingsAccountActions(
         Text(
             text = "Actions",
             style = MifosTypography.labelLargeEmphasized,
-            color = MaterialTheme.colorScheme.onSurface,
+            color = KptTheme.colorScheme.onSurface,
         )
         FlowRow(
             modifier = Modifier.fillMaxWidth(),

--- a/feature/savings-account/src/commonMain/kotlin/org/mifos/mobile/feature/savingsaccount/savingsAccountDetails/SavingsAccountDetailsScreen.kt
+++ b/feature/savings-account/src/commonMain/kotlin/org/mifos/mobile/feature/savingsaccount/savingsAccountDetails/SavingsAccountDetailsScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import mifos_mobile.feature.savings_account.generated.resources.Res
 import mifos_mobile.feature.savings_account.generated.resources.feature_account_action_update
@@ -309,7 +308,7 @@ internal fun AccountDetailsGrid(
                 details.forEach { item ->
                     MifosLabelValueCard(
                         modifier = Modifier
-                            .height(64.dp)
+                            .height(DesignToken.sizes.cardDp64)
                             .weight(1f),
                         label = stringResource(item.label),
                         value = item.value,

--- a/feature/savings-account/src/commonMain/kotlin/org/mifos/mobile/feature/savingsaccount/savingsAccountDetails/SavingsAccountDetailsScreen.kt
+++ b/feature/savings-account/src/commonMain/kotlin/org/mifos/mobile/feature/savingsaccount/savingsAccountDetails/SavingsAccountDetailsScreen.kt
@@ -182,8 +182,8 @@ internal fun SavingsAccountDetailsContent(
                     modifier = Modifier
                         .fillMaxSize()
                         .verticalScroll(rememberScrollState())
-                        .padding(DesignToken.padding.large),
-                    verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.large),
+                        .padding(KptTheme.spacing.md),
+                    verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.md),
                 ) {
                     ActionBar(
                         isUpdatable = state.isUpdatable,
@@ -244,7 +244,7 @@ internal fun ActionBar(
                 onAction(SavingsAccountDetailsAction.OnUpdateAccount)
             },
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.extraSmall),
+            horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.xs),
         ) {
             Text(
                 text = stringResource(Res.string.feature_account_action_update),
@@ -342,7 +342,7 @@ internal fun SavingsAccountActions(
     onActionClick: (String) -> Unit,
 ) {
     Column(
-        verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.large),
+        verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.md),
     ) {
         Text(
             text = "Actions",

--- a/feature/savings-account/src/commonMain/kotlin/org/mifos/mobile/feature/savingsaccount/savingsAccountUpdate/AccountUpdateScreen.kt
+++ b/feature/savings-account/src/commonMain/kotlin/org/mifos/mobile/feature/savingsaccount/savingsAccountUpdate/AccountUpdateScreen.kt
@@ -189,9 +189,9 @@ internal fun AccountUpdateScreenContent(
                 Column(
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(DesignToken.padding.large)
+                        .padding(KptTheme.spacing.md)
                         .padding(top = DesignToken.padding.medium),
-                    verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.large),
+                    verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.md),
                 ) {
                     MifosDetailsCard(
                         keyValuePairs = state.details,
@@ -222,7 +222,7 @@ internal fun AccountUpdateScreenContent(
                             },
 
                             enabled = state.selectedProductId != null,
-                            shape = DesignToken.shapes.medium,
+                            shape = KptTheme.shapes.medium,
                             colors = ButtonDefaults.buttonColors(
                                 containerColor = KptTheme.colorScheme.primary,
                             ),
@@ -251,7 +251,7 @@ internal fun AccountUpdateScreenContent(
 private fun Account_Update_Preview() {
     MifosMobileTheme {
         Column(
-            modifier = Modifier.fillMaxSize().padding(DesignToken.padding.large),
+            modifier = Modifier.fillMaxSize().padding(KptTheme.spacing.md),
         ) {
             AccountUpdateScreenContent(
                 state = AccountUpdateState(clientId = 1, accountId = -1L, dialogState = null),

--- a/feature/savings-account/src/commonMain/kotlin/org/mifos/mobile/feature/savingsaccount/savingsAccountUpdate/AccountUpdateScreen.kt
+++ b/feature/savings-account/src/commonMain/kotlin/org/mifos/mobile/feature/savingsaccount/savingsAccountUpdate/AccountUpdateScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -48,6 +47,7 @@ import org.mifos.mobile.core.ui.component.MifosProgressIndicator
 import org.mifos.mobile.core.ui.component.MifosProgressIndicatorOverlay
 import org.mifos.mobile.core.ui.utils.EventsEffect
 import org.mifos.mobile.core.ui.utils.ScreenUiState
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * A stateful composable that serves as the entry point for the "Account Update" screen.
@@ -224,7 +224,7 @@ internal fun AccountUpdateScreenContent(
                             enabled = state.selectedProductId != null,
                             shape = DesignToken.shapes.medium,
                             colors = ButtonDefaults.buttonColors(
-                                containerColor = MaterialTheme.colorScheme.primary,
+                                containerColor = KptTheme.colorScheme.primary,
                             ),
                         )
                     }

--- a/feature/savings-account/src/commonMain/kotlin/org/mifos/mobile/feature/savingsaccount/savingsAccountWithdraw/AccountWithdrawScreen.kt
+++ b/feature/savings-account/src/commonMain/kotlin/org/mifos/mobile/feature/savingsaccount/savingsAccountWithdraw/AccountWithdrawScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -46,6 +45,7 @@ import org.mifos.mobile.core.designsystem.theme.MifosTypography
 import org.mifos.mobile.core.ui.component.MifosDetailsCard
 import org.mifos.mobile.core.ui.component.MifosPoweredCard
 import org.mifos.mobile.core.ui.utils.EventsEffect
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * A stateful composable that serves as the entry point for the "Account Withdraw" screen.
@@ -184,9 +184,9 @@ internal fun AccountWithdrawScreenContent(
                     shape = DesignToken.shapes.medium,
                     textStyle = MifosTypography.bodyLarge,
                     colors = OutlinedTextFieldDefaults.colors(
-                        focusedBorderColor = MaterialTheme.colorScheme.secondaryContainer,
-                        unfocusedBorderColor = MaterialTheme.colorScheme.secondaryContainer,
-                        errorBorderColor = MaterialTheme.colorScheme.error,
+                        focusedBorderColor = KptTheme.colorScheme.secondaryContainer,
+                        unfocusedBorderColor = KptTheme.colorScheme.secondaryContainer,
+                        errorBorderColor = KptTheme.colorScheme.error,
                     ),
                 )
                 MifosButton(
@@ -204,7 +204,7 @@ internal fun AccountWithdrawScreenContent(
                     enabled = state.remark.isNotBlank(),
                     shape = DesignToken.shapes.medium,
                     colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.primary,
+                        containerColor = KptTheme.colorScheme.primary,
                     ),
                 )
             }

--- a/feature/savings-account/src/commonMain/kotlin/org/mifos/mobile/feature/savingsaccount/savingsAccountWithdraw/AccountWithdrawScreen.kt
+++ b/feature/savings-account/src/commonMain/kotlin/org/mifos/mobile/feature/savingsaccount/savingsAccountWithdraw/AccountWithdrawScreen.kt
@@ -164,9 +164,9 @@ internal fun AccountWithdrawScreenContent(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(DesignToken.padding.large)
+                .padding(KptTheme.spacing.md)
                 .padding(top = DesignToken.padding.medium),
-            verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.large),
+            verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.md),
         ) {
             MifosDetailsCard(
                 keyValuePairs = state.details,
@@ -181,7 +181,7 @@ internal fun AccountWithdrawScreenContent(
                         onAction(AccountWithdrawAction.RemarkChange(it))
                     },
                     label = stringResource(Res.string.feature_savings_withdraw_remarks_label),
-                    shape = DesignToken.shapes.medium,
+                    shape = KptTheme.shapes.medium,
                     textStyle = MifosTypography.bodyLarge,
                     colors = OutlinedTextFieldDefaults.colors(
                         focusedBorderColor = KptTheme.colorScheme.secondaryContainer,
@@ -202,7 +202,7 @@ internal fun AccountWithdrawScreenContent(
                     },
 
                     enabled = state.remark.isNotBlank(),
-                    shape = DesignToken.shapes.medium,
+                    shape = KptTheme.shapes.medium,
                     colors = ButtonDefaults.buttonColors(
                         containerColor = KptTheme.colorScheme.primary,
                     ),
@@ -223,7 +223,7 @@ internal fun AccountWithdrawScreenContent(
 private fun Account_Update_Preview() {
     MifosMobileTheme {
         Column(
-            modifier = Modifier.fillMaxSize().padding(DesignToken.padding.large),
+            modifier = Modifier.fillMaxSize().padding(KptTheme.spacing.md),
         ) {
             AccountWithdrawScreenContent(
                 state = AccountWithdrawState(accountId = -1L, dialogState = null),

--- a/feature/savings-application/src/commonMain/kotlin/org/mifos/mobile/feature/savings/application/fillApplication/FillApplicationScreen.kt
+++ b/feature/savings-application/src/commonMain/kotlin/org/mifos/mobile/feature/savings/application/fillApplication/FillApplicationScreen.kt
@@ -207,9 +207,9 @@ internal fun SavingsFillApplicationContent(
             ScreenUiState.Success -> {
                 Column(
                     modifier = Modifier
-                        .padding(DesignToken.padding.large)
+                        .padding(KptTheme.spacing.md)
                         .verticalScroll(rememberScrollState()),
-                    verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.large),
+                    verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.md),
                 ) {
                     Text(
                         text = stringResource(Res.string.feature_apply_savings_label_details),
@@ -229,7 +229,7 @@ internal fun SavingsFillApplicationContent(
                         value = state.minOpeningBalance,
                         onValueChange = { onAction(SavingsApplicationAction.MinimumOpeningBalanceChange(it)) },
                         label = stringResource(Res.string.feature_apply_savings_label_minimum_opening_balance),
-                        shape = DesignToken.shapes.medium,
+                        shape = KptTheme.shapes.medium,
                         textStyle = MifosTypography.bodyLarge,
                         config = MifosTextFieldConfig(
                             isError = state.minOpeningBalanceError != null,
@@ -251,7 +251,7 @@ internal fun SavingsFillApplicationContent(
                         value = state.frequency,
                         onValueChange = { onAction(SavingsApplicationAction.FrequencyChange(it)) },
                         label = stringResource(Res.string.feature_apply_savings_label_frequency),
-                        shape = DesignToken.shapes.medium,
+                        shape = KptTheme.shapes.medium,
                         textStyle = MifosTypography.bodyLarge,
                         config = MifosTextFieldConfig(
                             isError = state.frequencyError != null,
@@ -308,7 +308,7 @@ internal fun SavingsFillApplicationContent(
                         onClick = {
                             onAction(SavingsApplicationAction.NavigateToAuthentication)
                         },
-                        shape = DesignToken.shapes.medium,
+                        shape = KptTheme.shapes.medium,
                     ) {
                         Text(
                             text = stringResource(Res.string.feature_button_next),

--- a/feature/savings-application/src/commonMain/kotlin/org/mifos/mobile/feature/savings/application/fillApplication/FillApplicationScreen.kt
+++ b/feature/savings-application/src/commonMain/kotlin/org/mifos/mobile/feature/savings/application/fillApplication/FillApplicationScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CheckboxDefaults
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -62,6 +61,7 @@ import org.mifos.mobile.core.ui.component.MifosProgressIndicator
 import org.mifos.mobile.core.ui.component.MifosProgressIndicatorOverlay
 import org.mifos.mobile.core.ui.utils.EventsEffect
 import org.mifos.mobile.core.ui.utils.ScreenUiState
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * A stateful composable serving as the entry point for the "Fill Savings Application" screen.
@@ -214,7 +214,7 @@ internal fun SavingsFillApplicationContent(
                     Text(
                         text = stringResource(Res.string.feature_apply_savings_label_details),
                         style = MifosTypography.labelLargeEmphasized,
-                        color = MaterialTheme.colorScheme.onSurface,
+                        color = KptTheme.colorScheme.onSurface,
                     )
 
                     MifosOutlineDropdown(
@@ -244,7 +244,7 @@ internal fun SavingsFillApplicationContent(
                     Text(
                         text = stringResource(Res.string.feature_apply_savings_label_lock_in_period),
                         style = MifosTypography.labelLargeEmphasized,
-                        color = MaterialTheme.colorScheme.onSurface,
+                        color = KptTheme.colorScheme.onSurface,
                     )
 
                     MifosOutlinedTextField(
@@ -276,7 +276,7 @@ internal fun SavingsFillApplicationContent(
                         Text(
                             text = stringResource(Res.string.feature_apply_savings_label_overdraft),
                             style = MifosTypography.labelLargeEmphasized,
-                            color = MaterialTheme.colorScheme.onSurface,
+                            color = KptTheme.colorScheme.onSurface,
                         )
 
                         Row(

--- a/feature/savings-application/src/commonMain/kotlin/org/mifos/mobile/feature/savings/application/savingsApplication/SavingsApplyScreen.kt
+++ b/feature/savings-application/src/commonMain/kotlin/org/mifos/mobile/feature/savings/application/savingsApplication/SavingsApplyScreen.kt
@@ -50,6 +50,7 @@ import org.mifos.mobile.core.ui.component.MifosProgressIndicator
 import org.mifos.mobile.core.ui.component.MifosProgressIndicatorOverlay
 import org.mifos.mobile.core.ui.utils.EventsEffect
 import org.mifos.mobile.core.ui.utils.ScreenUiState
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * A stateful composable that serves as the entry point for the "Apply for Savings" screen.
@@ -186,15 +187,15 @@ internal fun SavingsAccountContent(
             ScreenUiState.Success -> {
                 Column(
                     modifier = Modifier
-                        .padding(DesignToken.padding.large)
+                        .padding(KptTheme.spacing.md)
                         .verticalScroll(rememberScrollState()),
-                    verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.large),
+                    verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.md),
                 ) {
                     MifosOutlinedTextField(
                         value = state.applicantName,
                         onValueChange = { },
                         label = stringResource(Res.string.feature_apply_savings_label_applicant_name),
-                        shape = DesignToken.shapes.medium,
+                        shape = KptTheme.shapes.medium,
                         textStyle = MifosTypography.bodyLarge,
                         config = MifosTextFieldConfig(
                             enabled = false,
@@ -216,7 +217,7 @@ internal fun SavingsAccountContent(
                                 )
                             },
                         ),
-                        shape = DesignToken.shapes.medium,
+                        shape = KptTheme.shapes.medium,
                     )
 
                     MifosOutlineDropdown(
@@ -245,7 +246,7 @@ internal fun SavingsAccountContent(
                         onClick = {
                             onAction(SavingsApplicationAction.NavigateToConfirmDetails)
                         },
-                        shape = DesignToken.shapes.medium,
+                        shape = KptTheme.shapes.medium,
                     ) {
                         Text(
                             text = stringResource(Res.string.feature_apply_savings_button_continue),

--- a/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/about/AboutScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/about/AboutScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import mifos_mobile.feature.settings.generated.resources.Res
 import mifos_mobile.feature.settings.generated.resources.feature_settings_about_logo_content_description
 import mifos_mobile.feature.settings.generated.resources.feature_settings_about_mifos
@@ -153,7 +152,7 @@ internal fun AboutScreenContent(
                                 text = "• $point",
                                 style = MifosTypography.bodySmall,
                                 color = AppColors.customBlack,
-                                modifier = Modifier.padding(vertical = 2.dp),
+                                modifier = Modifier.padding(vertical = DesignToken.padding.dp2),
                             )
                         }
                     }

--- a/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/about/AboutScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/about/AboutScreen.kt
@@ -104,12 +104,12 @@ internal fun AboutScreenContent(
                 Column(
                     Modifier
                         .fillMaxWidth()
-                        .padding(DesignToken.padding.extraLargeIncreased),
+                        .padding(KptTheme.spacing.xl),
                     verticalArrangement = Arrangement.spacedBy(DesignToken.padding.largeIncreased),
                 ) {
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(DesignToken.padding.small),
+                        horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.sm),
                     ) {
                         Image(
                             painter = painterResource(Res.drawable.mifos_icon),
@@ -140,7 +140,7 @@ internal fun AboutScreenContent(
                         text = stringResource(Res.string.feature_settings_about_what_does_mifos_do),
                         style = MifosTypography.titleSmallEmphasized,
                         color = AppColors.customBlack,
-                        modifier = Modifier.padding(top = DesignToken.padding.small),
+                        modifier = Modifier.padding(top = KptTheme.spacing.sm),
                     )
 
                     Column {

--- a/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/about/AboutScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/about/AboutScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -48,6 +47,7 @@ import org.mifos.mobile.core.designsystem.theme.AppColors
 import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * The main entry point for the "About Us" screen. This composable function serves as a wrapper
@@ -120,7 +120,7 @@ internal fun AboutScreenContent(
                         )
                         Text(
                             text = stringResource(Res.string.feature_settings_about_mifos),
-                            color = MaterialTheme.colorScheme.primary,
+                            color = KptTheme.colorScheme.primary,
                             style = MifosTypography.titleLarge,
                         )
                     }

--- a/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/appInfo/AppInfoScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/appInfo/AppInfoScreen.kt
@@ -125,7 +125,7 @@ internal fun AppInfoContent(
                     ) {
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(DesignToken.padding.small),
+                            horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.sm),
                         ) {
                             Image(
                                 painter = painterResource(Res.drawable.mifos_icon),
@@ -155,7 +155,7 @@ internal fun AppInfoContent(
                         Text(
                             text = stringResource(Res.string.feature_settings_appinfo_app_name),
                             style = MifosTypography.titleMediumEmphasized,
-                            modifier = Modifier.padding(top = DesignToken.padding.small),
+                            modifier = Modifier.padding(top = KptTheme.spacing.sm),
                             color = AppColors.customBlack,
                         )
 
@@ -168,7 +168,7 @@ internal fun AppInfoContent(
                                     text = point,
                                     style = MifosTypography.bodySmall,
                                     modifier = Modifier.padding(
-                                        vertical = DesignToken.padding.small,
+                                        vertical = KptTheme.spacing.sm,
                                     ),
                                     color = AppColors.customBlack,
                                 )

--- a/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/appInfo/AppInfoScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/appInfo/AppInfoScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -47,6 +46,7 @@ import org.mifos.mobile.core.designsystem.theme.AppColors
 import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
 import org.mifos.mobile.feature.settings.util.appVersion
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * The main composable for the App Info screen, which acts as a stateful wrapper
@@ -136,7 +136,7 @@ internal fun AppInfoContent(
                             )
                             Text(
                                 text = stringResource(Res.string.feature_settings_about_mifos),
-                                color = MaterialTheme.colorScheme.primary,
+                                color = KptTheme.colorScheme.primary,
                                 style = MifosTypography.titleLarge,
                             )
                         }

--- a/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/appInfo/AppInfoScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/appInfo/AppInfoScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import mifos_mobile.feature.settings.generated.resources.Res
 import mifos_mobile.feature.settings.generated.resources.feature_settings_about_logo_content_description
@@ -184,7 +183,7 @@ internal fun AppInfoContent(
                             contentDescription =
                             stringResource(Res.string.feature_settings_appinfo_logo_content_description),
                             modifier = Modifier
-                                .size(150.dp)
+                                .size(DesignToken.sizes.imageDp150)
                                 .align(Alignment.BottomEnd).zIndex(0f),
                         )
                     }

--- a/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/componenets/MifosLogoutDilaog.kt
+++ b/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/componenets/MifosLogoutDilaog.kt
@@ -64,7 +64,7 @@ fun MifosLogoutDialog(
                         modifier = Modifier
                             .fillMaxWidth()
                             .height(DesignToken.sizes.buttonHeight),
-                        shape = DesignToken.shapes.medium,
+                        shape = KptTheme.shapes.medium,
                         onClick = visibilityState.onLogout,
                     ) {
                         Text(
@@ -77,7 +77,7 @@ fun MifosLogoutDialog(
                         modifier = Modifier.fillMaxWidth(),
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(
-                            space = DesignToken.spacing.extraSmall,
+                            space = KptTheme.spacing.xs,
                             alignment = Alignment.CenterHorizontally,
                         ),
                     ) {
@@ -119,7 +119,7 @@ fun MifosLogoutDialog(
                 )
             },
             containerColor = Color.White,
-            shape = DesignToken.shapes.medium,
+            shape = KptTheme.shapes.medium,
         )
     }
 }

--- a/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/componenets/MifosLogoutDilaog.kt
+++ b/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/componenets/MifosLogoutDilaog.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -36,6 +35,7 @@ import org.mifos.mobile.core.designsystem.component.MifosButton
 import org.mifos.mobile.core.designsystem.theme.AppColors
 import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * A composable function that displays a confirmation dialog for logging out.
@@ -84,13 +84,13 @@ fun MifosLogoutDialog(
                         Text(
                             text = stringResource(visibilityState.message),
                             style = MifosTypography.bodySmallEmphasized,
-                            color = MaterialTheme.colorScheme.secondary,
+                            color = KptTheme.colorScheme.secondary,
                         )
 
                         Text(
                             text = stringResource(visibilityState.messageActionText),
                             style = MifosTypography.bodySmallEmphasized,
-                            color = MaterialTheme.colorScheme.primary,
+                            color = KptTheme.colorScheme.primary,
                             modifier = Modifier.clickable {
                                 visibilityState.onNavigateToHome.invoke()
                             },
@@ -112,7 +112,7 @@ fun MifosLogoutDialog(
                 Text(
                     text = stringResource(visibilityState.description),
                     style = MifosTypography.labelMediumEmphasized,
-                    color = MaterialTheme.colorScheme.secondary,
+                    color = KptTheme.colorScheme.secondary,
                     modifier = Modifier
                         .fillMaxWidth()
                         .testTag("AlertContentText"),

--- a/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/faq/FaqScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/faq/FaqScreen.kt
@@ -130,9 +130,9 @@ private fun FaqContent(
         if (faqArrayList.isNotEmpty()) {
             LazyColumn(
                 modifier = Modifier.weight(1f).fillMaxWidth()
-                    .padding(horizontal = DesignToken.padding.large)
+                    .padding(horizontal = KptTheme.spacing.md)
                     .padding(top = DesignToken.padding.extraLarge),
-                verticalArrangement = Arrangement.spacedBy(DesignToken.padding.small),
+                verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.sm),
             ) {
                 itemsIndexed(items = faqArrayList) { index, faqItem ->
                     FaqItemHolder(
@@ -153,7 +153,7 @@ private fun FaqContent(
                     text = stringResource(Res.string.feature_settings_faq_doubt),
                     style = MifosTypography.bodySmall,
                 )
-                Spacer(modifier = Modifier.height(DesignToken.spacing.small))
+                Spacer(modifier = Modifier.height(KptTheme.spacing.sm))
                 Text(
                     text = stringResource(Res.string.feature_settings_faq_contact_us),
                     style = MifosTypography.bodySmall,

--- a/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/faq/FaqScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/faq/FaqScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -47,6 +46,7 @@ import org.mifos.mobile.core.ui.component.EmptyDataView
 import org.mifos.mobile.core.ui.component.FaqItemHolder
 import org.mifos.mobile.core.ui.utils.DevicePreview
 import org.mifos.mobile.core.ui.utils.EventsEffect
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * A stateful composable that displays the FAQ screen. It collects state and events from
@@ -158,7 +158,7 @@ private fun FaqContent(
                 Text(
                     text = stringResource(Res.string.feature_settings_faq_contact_us),
                     style = MifosTypography.bodySmall,
-                    color = MaterialTheme.colorScheme.primary,
+                    color = KptTheme.colorScheme.primary,
                     modifier = Modifier.clickable {
                         onAction(FaqAction.NavigateToHelp)
                     },

--- a/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/faq/FaqScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/faq/FaqScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import mifos_mobile.feature.settings.generated.resources.Res
 import mifos_mobile.feature.settings.generated.resources.feature_settings_action_faq
@@ -154,7 +153,7 @@ private fun FaqContent(
                     text = stringResource(Res.string.feature_settings_faq_doubt),
                     style = MifosTypography.bodySmall,
                 )
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(DesignToken.spacing.small))
                 Text(
                     text = stringResource(Res.string.feature_settings_faq_contact_us),
                     style = MifosTypography.bodySmall,

--- a/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/help/HelpScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/help/HelpScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CardDefaults
@@ -349,7 +348,7 @@ private fun HelpActionButton(
         colors = ButtonDefaults.buttonColors(
             containerColor = Color.White.copy(alpha = 0.3f),
         ),
-        shape = RoundedCornerShape(DesignToken.padding.small),
+        shape = DesignToken.shapes.small,
         contentPadding = PaddingValues(
             horizontal = DesignToken.padding.extraLarge,
             vertical = DesignToken.padding.medium,

--- a/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/help/HelpScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/help/HelpScreen.kt
@@ -55,6 +55,7 @@ import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
 import org.mifos.mobile.core.ui.utils.ShareUtils
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * A stateful composable that constructs the "Help" screen, including its scaffold and top bar.
@@ -108,7 +109,7 @@ internal fun HelpScreenContent(
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
             .padding(
-                horizontal = DesignToken.padding.large,
+                horizontal = KptTheme.spacing.md,
                 vertical = DesignToken.padding.medium,
             )
             .statusBarsPadding(),
@@ -144,7 +145,7 @@ private fun FAQCard(
                 style = MifosTypography.titleSmallEmphasized,
                 color = Color.White,
             )
-            Spacer(modifier = Modifier.height(DesignToken.padding.small))
+            Spacer(modifier = Modifier.height(KptTheme.spacing.sm))
             Text(
                 text = stringResource(Res.string.feature_settings_doubt_message),
                 style = MifosTypography.labelMedium,
@@ -254,7 +255,7 @@ private fun SupportCard(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(top = DesignToken.padding.small),
+                .padding(top = KptTheme.spacing.sm),
         ) {
             SupportCardContent(
                 titleRes = titleRes,
@@ -291,7 +292,7 @@ private fun SupportCardContent(
 ) {
     Column(
         modifier = modifier.padding(DesignToken.padding.extraLarge),
-        verticalArrangement = Arrangement.spacedBy(DesignToken.padding.large),
+        verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.md),
     ) {
         Text(
             text = stringResource(titleRes),
@@ -348,7 +349,7 @@ private fun HelpActionButton(
         colors = ButtonDefaults.buttonColors(
             containerColor = Color.White.copy(alpha = 0.3f),
         ),
-        shape = DesignToken.shapes.small,
+        shape = KptTheme.shapes.small,
         contentPadding = PaddingValues(
             horizontal = DesignToken.padding.extraLarge,
             vertical = DesignToken.padding.medium,

--- a/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/language/LanguageScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/language/LanguageScreen.kt
@@ -93,8 +93,8 @@ internal fun LanguageScreenContent(
                 modifier = modifier
                     .fillMaxWidth()
                     .height(DesignToken.sizes.buttonHeight)
-                    .padding(horizontal = DesignToken.padding.large),
-                shape = DesignToken.shapes.medium,
+                    .padding(horizontal = KptTheme.spacing.md),
+                shape = KptTheme.shapes.medium,
                 onClick = { onAction(LanguageAction.SetLanguage(uiState.selectedLanguage)) },
             ) {
                 Text(
@@ -125,7 +125,7 @@ internal fun LanguageSelectionContent(
     onSetLanguage: (LanguageConfig) -> Unit,
 ) {
     LazyColumn(
-        modifier = modifier.padding(DesignToken.padding.large),
+        modifier = modifier.padding(KptTheme.spacing.md),
         verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.medium),
     ) {
         items(LanguageConfig.entries) {

--- a/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/language/LanguageScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/language/LanguageScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -39,6 +38,7 @@ import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
 import org.mifos.mobile.core.model.LanguageConfig
 import org.mifos.mobile.core.ui.utils.EventsEffect
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * A stateful composable that constructs the "Language" screen. It observes state from the
@@ -140,7 +140,7 @@ internal fun LanguageSelectionContent(
                     color = AppColors.primaryBlue,
                 ),
                 unselectedTextStyle = MifosTypography.titleSmallEmphasized.copy(
-                    MaterialTheme.colorScheme.onSurface,
+                    KptTheme.colorScheme.onSurface,
                 ),
             )
         }

--- a/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/passcode/UpdatePasscodeScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/passcode/UpdatePasscodeScreen.kt
@@ -149,7 +149,7 @@ internal fun PasscodeScreenContent(
             showPasswordChange = { onAction(PasscodeAction.OldPasscodeVisibleClick) },
         )
 
-        Spacer(modifier = Modifier.height(12.dp))
+        Spacer(modifier = Modifier.height(DesignToken.spacing.medium))
 
         MifosPasswordField(
             value = passcodeData.newPasscode,
@@ -165,7 +165,7 @@ internal fun PasscodeScreenContent(
             showPasswordChange = { onAction(PasscodeAction.NewPasscodeVisibleClick) },
         )
 
-        Spacer(modifier = Modifier.height(12.dp))
+        Spacer(modifier = Modifier.height(DesignToken.spacing.medium))
 
         MifosPasswordField(
             value = passcodeData.confirmPasscode,

--- a/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/passcode/UpdatePasscodeScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/passcode/UpdatePasscodeScreen.kt
@@ -42,6 +42,7 @@ import org.mifos.mobile.core.ui.component.MifosProgressIndicator
 import org.mifos.mobile.core.ui.component.MifosSuccessDialog
 import org.mifos.mobile.core.ui.component.SuccessDialogState
 import org.mifos.mobile.core.ui.utils.EventsEffect
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * A stateful composable that manages the "Update Passcode" screen.
@@ -106,7 +107,7 @@ internal fun UpdatePasscodeScreen(
         PasscodeScreenContent(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(horizontal = DesignToken.padding.large)
+                .padding(horizontal = KptTheme.spacing.md)
                 .statusBarsPadding(),
             passcodeData = state,
             onAction = onAction,

--- a/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/passcode/UpdatePasscodeScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/passcode/UpdatePasscodeScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import mifos_mobile.feature.settings.generated.resources.Res
 import mifos_mobile.feature.settings.generated.resources.feature_settings_authorization_passcode
@@ -131,7 +130,7 @@ internal fun PasscodeScreenContent(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(top = 24.dp)
+            .padding(top = DesignToken.spacing.dp24)
             .verticalScroll(
                 rememberScrollState(),
             ),
@@ -184,7 +183,7 @@ internal fun PasscodeScreenContent(
             showPasswordChange = { onAction(PasscodeAction.ConfirmPasscodeVisibleClick) },
         )
 
-        Spacer(modifier = Modifier.height(24.dp))
+        Spacer(modifier = Modifier.height(DesignToken.spacing.dp24))
 
         MifosButton(
             text = {

--- a/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/password/ChangePasswordScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/password/ChangePasswordScreen.kt
@@ -42,6 +42,7 @@ import org.mifos.mobile.core.ui.component.MifosProgressIndicator
 import org.mifos.mobile.core.ui.component.MifosSuccessDialog
 import org.mifos.mobile.core.ui.component.SuccessDialogState
 import org.mifos.mobile.core.ui.utils.EventsEffect
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * A stateful composable that serves as the entry point for the "Change Password" screen.
@@ -107,7 +108,7 @@ internal fun ChangePasswordScreen(
             PasswordScreenContent(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(horizontal = DesignToken.padding.large),
+                    .padding(horizontal = KptTheme.spacing.md),
                 state = state,
                 onAction = onAction,
             )

--- a/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/settings/SettingsScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.collections.immutable.ImmutableList
 import mifos_mobile.feature.settings.generated.resources.Res
@@ -182,7 +181,7 @@ internal fun SettingsScreenContent(
                         HorizontalDivider(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .height(0.99997.dp),
+                                .height(DesignToken.strokes.thin),
                         )
                         SettingsActions(state.settingsItems) {
                             if (it.route == Constants.LOGOUT) {
@@ -220,11 +219,11 @@ internal fun SettingsProfileCard(
             modifier = Modifier
                 .size(DesignToken.sizes.profile)
                 .clip(CircleShape)
-                .border(1.dp, KptTheme.colorScheme.primary, CircleShape),
+                .border(DesignToken.strokes.thin, KptTheme.colorScheme.primary, CircleShape),
         ) {
             MifosUserImage(
                 bitmap = state.profileImage,
-                modifier = Modifier.size(100.dp),
+                modifier = Modifier.size(DesignToken.sizes.imageDp100),
                 username = state.client?.displayName,
             )
         }
@@ -281,7 +280,7 @@ internal fun SettingsActions(
                 HorizontalDivider(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(0.99997.dp),
+                        .height(DesignToken.strokes.thin),
                 )
             }
         }

--- a/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/settings/SettingsScreen.kt
@@ -156,7 +156,7 @@ internal fun SettingsScreenContent(
             ScreenUiState.Success -> {
                 Column(
                     modifier = Modifier
-                        .padding(vertical = DesignToken.padding.large)
+                        .padding(vertical = KptTheme.spacing.md)
                         .verticalScroll(rememberScrollState()),
 
                 ) {
@@ -229,10 +229,10 @@ internal fun SettingsProfileCard(
             )
         }
 
-        Spacer(modifier = Modifier.width(DesignToken.spacing.large))
+        Spacer(modifier = Modifier.width(KptTheme.spacing.md))
 
         Column(
-            verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.extraSmall),
+            verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.xs),
         ) {
             Text(
                 text = state.client?.displayName ?: "",
@@ -270,7 +270,7 @@ internal fun SettingsActions(
         ) {
             items.forEach { item ->
                 MifosActionCard(
-                    modifier = Modifier.padding(horizontal = DesignToken.padding.large),
+                    modifier = Modifier.padding(horizontal = KptTheme.spacing.md),
                     title = item.title,
                     subTitle = item.subTitle,
                     icon = item.icon,

--- a/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/settings/SettingsScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -56,6 +55,7 @@ import org.mifos.mobile.core.ui.utils.ScreenUiState
 import org.mifos.mobile.feature.settings.componenets.LogoutDialogState
 import org.mifos.mobile.feature.settings.componenets.MifosLogoutDialog
 import org.mifos.mobile.feature.settings.componenets.SettingsItems
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * A stateful composable that serves as the entry point for the main "Settings" screen.
@@ -220,7 +220,7 @@ internal fun SettingsProfileCard(
             modifier = Modifier
                 .size(DesignToken.sizes.profile)
                 .clip(CircleShape)
-                .border(1.dp, MaterialTheme.colorScheme.primary, CircleShape),
+                .border(1.dp, KptTheme.colorScheme.primary, CircleShape),
         ) {
             MifosUserImage(
                 bitmap = state.profileImage,
@@ -237,7 +237,7 @@ internal fun SettingsProfileCard(
             Text(
                 text = state.client?.displayName ?: "",
                 style = MifosTypography.labelMediumEmphasized,
-                color = MaterialTheme.colorScheme.primary,
+                color = KptTheme.colorScheme.primary,
             )
 
 //            TODO email is not receiving from api response
@@ -246,7 +246,7 @@ internal fun SettingsProfileCard(
             Text(
                 text = stringResource(Res.string.feature_settings_customer_account_no, state.client?.accountNo ?: ""),
                 style = MifosTypography.labelMediumEmphasized,
-                color = MaterialTheme.colorScheme.secondary,
+                color = KptTheme.colorScheme.secondary,
             )
         }
     }

--- a/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/theme/ChangeThemeScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/theme/ChangeThemeScreen.kt
@@ -95,7 +95,7 @@ internal fun ThemeScreenContent(
         },
     ) {
         Column(
-            modifier = Modifier.padding(DesignToken.padding.large),
+            modifier = Modifier.padding(KptTheme.spacing.md),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(DesignToken.padding.largeIncreased),
         ) {
@@ -118,7 +118,7 @@ internal fun ThemeScreenContent(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(DesignToken.sizes.buttonHeight),
-                shape = DesignToken.shapes.medium,
+                shape = KptTheme.shapes.medium,
                 onClick = {
                     onAction(ThemeAction.SetTheme)
                 },

--- a/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/theme/ChangeThemeScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/theme/ChangeThemeScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -38,6 +37,7 @@ import org.mifos.mobile.core.designsystem.theme.MifosTypography
 import org.mifos.mobile.core.model.MifosThemeConfig
 import org.mifos.mobile.core.ui.utils.DevicePreview
 import org.mifos.mobile.core.ui.utils.EventsEffect
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * A stateful composable that constructs the "Change Theme" screen.
@@ -109,7 +109,7 @@ internal fun ThemeScreenContent(
                         color = AppColors.primaryBlue,
                     ),
                     unselectedTextStyle = MifosTypography.titleSmallEmphasized.copy(
-                        MaterialTheme.colorScheme.onSurface,
+                        KptTheme.colorScheme.onSurface,
                     ),
                 )
             }

--- a/feature/share-account/src/commonMain/kotlin/org/mifos/mobile/feature/shareaccount/shareAccount/ShareAccountScreen.kt
+++ b/feature/share-account/src/commonMain/kotlin/org/mifos/mobile/feature/shareaccount/shareAccount/ShareAccountScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import mifos_mobile.feature.share_account.generated.resources.Res
 import mifos_mobile.feature.share_account.generated.resources.feature_account_empty_share_accounts
@@ -238,14 +237,14 @@ internal fun ShareAccountContent(
                         Icon(
                             modifier = Modifier
                                 .clickable {}
-                                .size(20.dp),
+                                .size(DesignToken.sizes.iconDp20),
                             imageVector = MifosIcons.SearchNew,
                             contentDescription = null,
                         )
                         Icon(
                             modifier = Modifier
                                 .clickable { filtersClicked() }
-                                .size(20.dp),
+                                .size(DesignToken.sizes.iconDp20),
                             imageVector = MifosIcons.Filter,
                             contentDescription = null,
                         )
@@ -257,7 +256,7 @@ internal fun ShareAccountContent(
                 HorizontalDivider(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(0.99997.dp),
+                        .height(DesignToken.strokes.thin),
                 )
 
                 if (state.isFilteredEmpty) {

--- a/feature/share-account/src/commonMain/kotlin/org/mifos/mobile/feature/shareaccount/shareAccount/ShareAccountScreen.kt
+++ b/feature/share-account/src/commonMain/kotlin/org/mifos/mobile/feature/shareaccount/shareAccount/ShareAccountScreen.kt
@@ -167,7 +167,7 @@ internal fun ShareAccountContent(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(DesignToken.padding.large),
+            .padding(KptTheme.spacing.md),
     ) {
         when (state.uiState) {
             ScreenUiState.Loading -> {
@@ -198,7 +198,7 @@ internal fun ShareAccountContent(
             }
 
             ScreenUiState.Success -> {
-                Spacer(modifier = Modifier.height(DesignToken.spacing.large))
+                Spacer(modifier = Modifier.height(KptTheme.spacing.md))
 
                 MifosDashboardCard(
                     isSingleLine = true,
@@ -279,7 +279,7 @@ internal fun ShareAccountContent(
                             .weight(1f),
                     ) {
                         item {
-                            Spacer(modifier = Modifier.height(DesignToken.spacing.small))
+                            Spacer(modifier = Modifier.height(KptTheme.spacing.sm))
                         }
                         items(state.shareAccounts.orEmpty()) { account ->
                             val color = when (account.status?.value) {

--- a/feature/share-account/src/commonMain/kotlin/org/mifos/mobile/feature/shareaccount/shareAccount/ShareAccountScreen.kt
+++ b/feature/share-account/src/commonMain/kotlin/org/mifos/mobile/feature/shareaccount/shareAccount/ShareAccountScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -57,6 +56,7 @@ import org.mifos.mobile.core.ui.component.MifosErrorComponent
 import org.mifos.mobile.core.ui.component.MifosProgressIndicator
 import org.mifos.mobile.core.ui.utils.EventsEffect
 import org.mifos.mobile.core.ui.utils.ScreenUiState
+import template.core.base.designsystem.theme.KptTheme
 import kotlin.collections.orEmpty
 
 /**
@@ -220,7 +220,7 @@ internal fun ShareAccountContent(
                         Text(
                             text = stringResource(Res.string.feature_share_account),
                             style = MifosTypography.titleMediumEmphasized,
-                            color = MaterialTheme.colorScheme.onBackground,
+                            color = KptTheme.colorScheme.onBackground,
                         )
                         Text(
                             text = stringResource(
@@ -228,7 +228,7 @@ internal fun ShareAccountContent(
                                 state.items ?: 0,
                             ),
                             style = MifosTypography.labelMedium,
-                            color = MaterialTheme.colorScheme.secondary,
+                            color = KptTheme.colorScheme.secondary,
                         )
                     }
 
@@ -286,8 +286,8 @@ internal fun ShareAccountContent(
                                 LoanStatus.ACTIVE.status -> AppColors.customEnable
                                 LoanStatus.SUBMIT_AND_PENDING_APPROVAL.status -> AppColors.customYellow
                                 LoanStatus.WITHDRAWN.status, LoanStatus.MATURED.status ->
-                                    MaterialTheme.colorScheme.error
-                                else -> MaterialTheme.colorScheme.onSurface
+                                    KptTheme.colorScheme.error
+                                else -> KptTheme.colorScheme.onSurface
                             }
 
                             MifosAccountCard(

--- a/feature/share-application/src/commonMain/kotlin/org/mifos/mobile/feature/share/application/fillApplication/FillApplicationScreen.kt
+++ b/feature/share-application/src/commonMain/kotlin/org/mifos/mobile/feature/share/application/fillApplication/FillApplicationScreen.kt
@@ -218,9 +218,9 @@ internal fun ShareFillApplicationForm(
 ) {
     Column(
         modifier = modifier
-            .padding(DesignToken.padding.large)
+            .padding(KptTheme.spacing.md)
             .verticalScroll(rememberScrollState()),
-        verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.large),
+        verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.md),
     ) {
         Text(
             text = stringResource(Res.string.feature_apply_share_label_terms),
@@ -240,7 +240,7 @@ internal fun ShareFillApplicationForm(
             value = state.currentPrice,
             onValueChange = { onAction(ShareApplicationAction.CurrentPriceChange(it)) },
             label = stringResource(Res.string.feature_apply_share_label_current_price),
-            shape = DesignToken.shapes.medium,
+            shape = KptTheme.shapes.medium,
             textStyle = MifosTypography.bodyLarge,
             config = MifosTextFieldConfig(
                 isError = state.currentPriceError != null,
@@ -256,7 +256,7 @@ internal fun ShareFillApplicationForm(
             value = state.totalNumberOfShares,
             onValueChange = { onAction(ShareApplicationAction.TotalNumberOfSharesChange(it)) },
             label = stringResource(Res.string.feature_apply_share_label_total_number_of_shares),
-            shape = DesignToken.shapes.medium,
+            shape = KptTheme.shapes.medium,
             textStyle = MifosTypography.bodyLarge,
             config = MifosTextFieldConfig(
                 isError = state.sharesError != null,
@@ -291,7 +291,7 @@ internal fun ShareFillApplicationForm(
             value = state.mapFrequency,
             onValueChange = { onAction(ShareApplicationAction.MapFrequencyChange(it)) },
             label = stringResource(Res.string.feature_apply_share_label_minimum_frequency),
-            shape = DesignToken.shapes.medium,
+            shape = KptTheme.shapes.medium,
             textStyle = MifosTypography.bodyLarge,
             config = MifosTextFieldConfig(
                 isError = state.mapFrequencyError != null,
@@ -322,7 +322,7 @@ internal fun ShareFillApplicationForm(
             value = state.lipFrequency,
             onValueChange = { onAction(ShareApplicationAction.LipFrequencyChange(it)) },
             label = stringResource(Res.string.feature_apply_share_label_lockin_frequency),
-            shape = DesignToken.shapes.medium,
+            shape = KptTheme.shapes.medium,
             textStyle = MifosTypography.bodyLarge,
             config = MifosTextFieldConfig(
                 isError = state.lipFrequencyError != null,
@@ -349,7 +349,7 @@ internal fun ShareFillApplicationForm(
             onClick = {
                 onAction(ShareApplicationAction.NavigateToAuthentication)
             },
-            shape = DesignToken.shapes.medium,
+            shape = KptTheme.shapes.medium,
         ) {
             Text(
                 text = stringResource(Res.string.feature_share_button_next),

--- a/feature/share-application/src/commonMain/kotlin/org/mifos/mobile/feature/share/application/fillApplication/FillApplicationScreen.kt
+++ b/feature/share-application/src/commonMain/kotlin/org/mifos/mobile/feature/share/application/fillApplication/FillApplicationScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -61,6 +60,7 @@ import org.mifos.mobile.core.ui.component.MifosPoweredCard
 import org.mifos.mobile.core.ui.component.MifosProgressIndicator
 import org.mifos.mobile.core.ui.component.MifosProgressIndicatorOverlay
 import org.mifos.mobile.core.ui.utils.EventsEffect
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * A Composable function that represents the Share Fill Application screen.
@@ -225,7 +225,7 @@ internal fun ShareFillApplicationForm(
         Text(
             text = stringResource(Res.string.feature_apply_share_label_terms),
             style = MifosTypography.labelLargeEmphasized,
-            color = MaterialTheme.colorScheme.onSurface,
+            color = KptTheme.colorScheme.onSurface,
         )
 
         MifosOutlineDropdown(
@@ -284,7 +284,7 @@ internal fun ShareFillApplicationForm(
         Text(
             text = stringResource(Res.string.feature_apply_share_section_minimum_active_period),
             style = MifosTypography.labelLargeEmphasized,
-            color = MaterialTheme.colorScheme.onSurface,
+            color = KptTheme.colorScheme.onSurface,
         )
 
         MifosOutlinedTextField(
@@ -315,7 +315,7 @@ internal fun ShareFillApplicationForm(
         Text(
             text = stringResource(Res.string.feature_apply_share_section_lockin_period),
             style = MifosTypography.labelLargeEmphasized,
-            color = MaterialTheme.colorScheme.onSurface,
+            color = KptTheme.colorScheme.onSurface,
         )
 
         MifosOutlinedTextField(

--- a/feature/share-application/src/commonMain/kotlin/org/mifos/mobile/feature/share/application/shareApplication/ShareApplyScreen.kt
+++ b/feature/share-application/src/commonMain/kotlin/org/mifos/mobile/feature/share/application/shareApplication/ShareApplyScreen.kt
@@ -49,6 +49,7 @@ import org.mifos.mobile.core.ui.component.MifosOutlineDropdown
 import org.mifos.mobile.core.ui.component.MifosPoweredCard
 import org.mifos.mobile.core.ui.component.MifosProgressIndicator
 import org.mifos.mobile.core.ui.utils.EventsEffect
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * A Composable function that represents the Share Apply screen.
@@ -198,15 +199,15 @@ internal fun ShareApplicationForm(
 ) {
     Column(
         modifier = modifier
-            .padding(DesignToken.padding.large)
+            .padding(KptTheme.spacing.md)
             .verticalScroll(rememberScrollState()),
-        verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.large),
+        verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.md),
     ) {
         MifosOutlinedTextField(
             value = state.applicantName,
             onValueChange = { },
             label = stringResource(Res.string.feature_share_label_applicant_name),
-            shape = DesignToken.shapes.medium,
+            shape = KptTheme.shapes.medium,
             textStyle = MifosTypography.bodyLarge,
             config = MifosTextFieldConfig(
                 enabled = false,
@@ -228,7 +229,7 @@ internal fun ShareApplicationForm(
                     )
                 },
             ),
-            shape = DesignToken.shapes.medium,
+            shape = KptTheme.shapes.medium,
         )
 
         MifosOutlineDropdown(
@@ -247,7 +248,7 @@ internal fun ShareApplicationForm(
             onClick = {
                 onAction(ShareApplicationAction.NavigateToConfirmDetails)
             },
-            shape = DesignToken.shapes.medium,
+            shape = KptTheme.shapes.medium,
         ) {
             Text(
                 text = stringResource(Res.string.feature_share_button_next),

--- a/feature/status/src/commonMain/kotlin/org/mifos/mobile/feature/status/Components.kt
+++ b/feature/status/src/commonMain/kotlin/org/mifos/mobile/feature/status/Components.kt
@@ -29,11 +29,11 @@ import mifos_mobile.core.ui.generated.resources.ic_icon_success
 import org.koin.compose.viewmodel.koinViewModel
 import org.mifos.mobile.core.common.Constants
 import org.mifos.mobile.core.designsystem.component.MifosScaffold
-import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.model.EventType
 import org.mifos.mobile.core.ui.component.MifosPoweredCard
 import org.mifos.mobile.core.ui.component.MifosStatusComponent
 import org.mifos.mobile.core.ui.utils.EventsEffect
+import template.core.base.designsystem.theme.KptTheme
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
@@ -76,7 +76,7 @@ internal fun StatusScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(DesignToken.padding.large),
+                .padding(KptTheme.spacing.md),
             verticalArrangement = Arrangement.Center,
         ) {
             MifosStatusComponent(

--- a/feature/third-party-transfer/src/commonMain/kotlin/org/mifos/mobile/feature/third/party/transfer/thirdPartyTransfer/TptScreen.kt
+++ b/feature/third-party-transfer/src/commonMain/kotlin/org/mifos/mobile/feature/third/party/transfer/thirdPartyTransfer/TptScreen.kt
@@ -151,7 +151,7 @@ internal fun TprContent(
         onNavigateBack = { },
         actions = {
             Row(
-                horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.large),
+                horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.md),
             ) {
                 // TODO : once ui/ux team gives this flow uncomment and implement
 //                Image(
@@ -212,7 +212,7 @@ internal fun TptForm(
 ) {
     Column(
         modifier = modifier
-            .padding(DesignToken.padding.large)
+            .padding(KptTheme.spacing.md)
             .verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.spacedBy(DesignToken.padding.largeIncreased),
     ) {
@@ -243,7 +243,7 @@ internal fun TptForm(
         )
 
         Row(
-            horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.small),
+            horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.sm),
             modifier = Modifier
                 .align(Alignment.CenterHorizontally),
         ) {
@@ -268,7 +268,7 @@ internal fun TptForm(
             value = state.amount,
             onValueChange = { onAction(TptAction.OnAmountChanged(it)) },
             label = stringResource(Res.string.feature_tpt_label_amount),
-            shape = DesignToken.shapes.medium,
+            shape = KptTheme.shapes.medium,
             textStyle = MifosTypography.bodyLarge,
             config = MifosTextFieldConfig(
                 isError = state.amountError != null,
@@ -296,7 +296,7 @@ internal fun TptForm(
             value = state.remark,
             onValueChange = { onAction(TptAction.OnRemarksChanged(it)) },
             label = stringResource(Res.string.feature_tpt_label_remarks),
-            shape = DesignToken.shapes.medium,
+            shape = KptTheme.shapes.medium,
             textStyle = MifosTypography.bodyLarge,
             config = MifosTextFieldConfig(
                 isError = state.remarkError != null,
@@ -325,7 +325,7 @@ internal fun TptForm(
                 onAction(TptAction.OnMakeTransferClicked)
             },
             enabled = state.isEnabled,
-            shape = DesignToken.shapes.medium,
+            shape = KptTheme.shapes.medium,
         ) {
             Text(
                 text = stringResource(Res.string.feature_tpt_transfer_button),

--- a/feature/third-party-transfer/src/commonMain/kotlin/org/mifos/mobile/feature/third/party/transfer/thirdPartyTransfer/TptScreen.kt
+++ b/feature/third-party-transfer/src/commonMain/kotlin/org/mifos/mobile/feature/third/party/transfer/thirdPartyTransfer/TptScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -60,6 +59,7 @@ import org.mifos.mobile.core.ui.utils.EventsEffect
 import org.mifos.mobile.core.ui.utils.ScreenUiState
 import org.mifos.mobile.feature.third.party.transfer.navigation.TptNavigationDestination
 import org.mifos.mobile.feature.third.party.transfer.navigation.TptNavigator
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * Composable function for the Third Party Transfer screen.
@@ -164,7 +164,7 @@ internal fun TprContent(
                     modifier = Modifier.clickable {
                         onAction(TptAction.OnNotificationClicked)
                     },
-                    colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onSurface),
+                    colorFilter = ColorFilter.tint(KptTheme.colorScheme.onSurface),
                 )
             }
         },
@@ -250,7 +250,7 @@ internal fun TptForm(
             Text(
                 text = stringResource(Res.string.feature_tpt_tip),
                 style = MifosTypography.labelMedium,
-                color = MaterialTheme.colorScheme.secondary,
+                color = KptTheme.colorScheme.secondary,
             )
 
             Text(
@@ -260,7 +260,7 @@ internal fun TptForm(
                     },
                 text = stringResource(Res.string.feature_tpt_tip_action),
                 style = MifosTypography.labelMedium,
-                color = MaterialTheme.colorScheme.primary,
+                color = KptTheme.colorScheme.primary,
             )
         }
 
@@ -280,7 +280,7 @@ internal fun TptForm(
                         Icon(
                             imageVector = MifosIcons.ErrorCircle,
                             contentDescription = null,
-                            tint = MaterialTheme.colorScheme.error,
+                            tint = KptTheme.colorScheme.error,
                         )
                     }
                 } else {
@@ -308,7 +308,7 @@ internal fun TptForm(
                         Icon(
                             imageVector = MifosIcons.ErrorCircle,
                             contentDescription = null,
-                            tint = MaterialTheme.colorScheme.error,
+                            tint = KptTheme.colorScheme.error,
                         )
                     }
                 } else {

--- a/feature/transfer-process/src/commonMain/kotlin/org/mifos/mobile/feature/transfer/process/makeTransfer/MakeTransferScreen.kt
+++ b/feature/transfer-process/src/commonMain/kotlin/org/mifos/mobile/feature/transfer/process/makeTransfer/MakeTransferScreen.kt
@@ -146,8 +146,8 @@ internal fun MakeTransferScreenContent(
                         .fillMaxSize()
                         .verticalScroll(rememberScrollState())
                         .padding(
-                            horizontal = DesignToken.padding.large,
-                            vertical = DesignToken.padding.extraLargeIncreased,
+                            horizontal = KptTheme.spacing.md,
+                            vertical = KptTheme.spacing.xl,
                         ),
                     verticalArrangement = Arrangement.spacedBy(DesignToken.padding.largeIncreased),
                 ) {
@@ -180,7 +180,7 @@ internal fun MakeTransferScreenContent(
                         value = state.amount,
                         onValueChange = { onAction(MakeTransferAction.OnAmountChanged(it)) },
                         label = stringResource(Res.string.amount),
-                        shape = DesignToken.shapes.medium,
+                        shape = KptTheme.shapes.medium,
                         textStyle = MifosTypography.bodyLarge,
                         config = MifosTextFieldConfig(
                             enabled = state.outstandingBalance == null,
@@ -207,7 +207,7 @@ internal fun MakeTransferScreenContent(
                         value = state.remark,
                         onValueChange = { onAction(MakeTransferAction.OnRemarksChanged(it)) },
                         label = stringResource(Res.string.remarks),
-                        shape = DesignToken.shapes.medium,
+                        shape = KptTheme.shapes.medium,
                         textStyle = MifosTypography.bodyLarge,
                         config = MifosTextFieldConfig(
                             isError = state.remarkError != null,

--- a/feature/transfer-process/src/commonMain/kotlin/org/mifos/mobile/feature/transfer/process/makeTransfer/MakeTransferScreen.kt
+++ b/feature/transfer-process/src/commonMain/kotlin/org/mifos/mobile/feature/transfer/process/makeTransfer/MakeTransferScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -56,6 +55,7 @@ import org.mifos.mobile.core.ui.component.MifosPoweredCard
 import org.mifos.mobile.core.ui.component.MifosProgressIndicator
 import org.mifos.mobile.core.ui.component.MifosProgressIndicatorOverlay
 import org.mifos.mobile.core.ui.utils.EventsEffect
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 internal fun MakeTransferScreen(
@@ -191,7 +191,7 @@ internal fun MakeTransferScreenContent(
                                     Icon(
                                         imageVector = MifosIcons.ErrorCircle,
                                         contentDescription = stringResource(Res.string.error_description),
-                                        tint = MaterialTheme.colorScheme.error,
+                                        tint = KptTheme.colorScheme.error,
                                     )
                                 }
                             } else {
@@ -219,7 +219,7 @@ internal fun MakeTransferScreenContent(
                                     Icon(
                                         imageVector = MifosIcons.ErrorCircle,
                                         contentDescription = null,
-                                        tint = MaterialTheme.colorScheme.error,
+                                        tint = KptTheme.colorScheme.error,
                                     )
                                 }
                             } else {

--- a/feature/transfer-process/src/commonMain/kotlin/org/mifos/mobile/feature/transfer/process/transferProcess/TransferProcessScreen.kt
+++ b/feature/transfer-process/src/commonMain/kotlin/org/mifos/mobile/feature/transfer/process/transferProcess/TransferProcessScreen.kt
@@ -142,9 +142,9 @@ private fun TransferProcessContent(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(DesignToken.padding.large)
+            .padding(KptTheme.spacing.md)
             .verticalScroll(rememberScrollState()),
-        verticalArrangement = Arrangement.spacedBy(DesignToken.padding.large),
+        verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.md),
     ) {
         MifosDetailsCard(
             keyValuePairs = mapOf(
@@ -163,7 +163,7 @@ private fun TransferProcessContent(
             onClick = {
                 onAction(TransferProcessAction.OnNavigate)
             },
-            shape = DesignToken.shapes.medium,
+            shape = KptTheme.shapes.medium,
         ) {
             Text(
                 text = stringResource(Res.string.cancel),

--- a/feature/transfer-process/src/commonMain/kotlin/org/mifos/mobile/feature/transfer/process/transferProcess/TransferProcessScreen.kt
+++ b/feature/transfer-process/src/commonMain/kotlin/org/mifos/mobile/feature/transfer/process/transferProcess/TransferProcessScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -50,6 +49,7 @@ import org.mifos.mobile.core.ui.component.MifosProgressIndicator
 import org.mifos.mobile.core.ui.component.MifosProgressIndicatorOverlay
 import org.mifos.mobile.core.ui.utils.EventsEffect
 import org.mifos.mobile.core.ui.utils.ScreenUiState
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 internal fun TransferProcessScreen(
@@ -167,7 +167,7 @@ private fun TransferProcessContent(
         ) {
             Text(
                 text = stringResource(Res.string.cancel),
-                style = MaterialTheme.typography.labelLarge,
+                style = KptTheme.typography.labelLarge,
             )
         }
 


### PR DESCRIPTION
Fixes - [Jira-#MM-389](https://mifosforge.jira.com/browse/MM-389)

Didn't create a Jira ticket, click [here](https://mifosforge.jira.com/jira/software/c/projects/MM/issues/) to create new.

Summary of changes:
- Replaced MaterialTheme with KptTheme for Typography and Color Scheme
- Used KptTheme for shapes, spacing, padding which matched with DesignToken, remaining uses DesignToken
- Non-standard values have been replaced with DesignToken's custom values
- New type introduced for strokes in DesignToken.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the static analysis check `./gradlew check` or `ci-prepush.sh` to make sure you didn't break anything

- [ ] If you have multiple commits please combine them into one commit by squashing them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Style
* Unified theming across the app: migrated components to a single design system for consistent colors, typography, shapes, and spacing.
* Refined spacing, paddings, dividers and icon/image sizes for improved visual alignment and layout consistency.
* Introduced additional design tokens (sizes, strokes, shapes, spacings) to enable more consistent UI elements and thinner dividers across screens.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->