### PR TITLE
fix : Logout dialog colour in settings

### DIFF
--- a/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/componenets/MifosLogoutDilaog.kt
+++ b/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/componenets/MifosLogoutDilaog.kt
@@ -21,7 +21,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import mifos_mobile.feature.settings.generated.resources.Res
 import mifos_mobile.feature.settings.generated.resources.feature_settings_logout_action
@@ -33,7 +32,6 @@ import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.mifos.mobile.core.designsystem.component.MifosButton
-import org.mifos.mobile.core.designsystem.theme.AppColors
 import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
 
@@ -102,7 +100,6 @@ fun MifosLogoutDialog(
                 Text(
                     text = stringResource(visibilityState.title),
                     style = MifosTypography.headlineSmallEmphasized,
-                    color = AppColors.customBlack,
                     modifier = Modifier
                         .fillMaxWidth()
                         .testTag("AlertTitleText"),
@@ -118,7 +115,6 @@ fun MifosLogoutDialog(
                         .testTag("AlertContentText"),
                 )
             },
-            containerColor = Color.White,
             shape = DesignToken.shapes.medium,
         )
     }


### PR DESCRIPTION
Fixes - [Jira-#Issue_Number](https://mifosforge.jira.com/browse/MM-475)

| Before | Now |
|--------|-----|
| <img src="https://github.com/user-attachments/assets/bfd841cc-d352-4b70-920e-7b10b1a9d18b" width="300"/> | <img src="https://github.com/user-attachments/assets/1ae8e630-f2b0-4ba2-b271-7408268e8dde" width="300"/> |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated logout dialog styling to use Material Design default theme colors instead of explicit color overrides.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->