### PR TITLE
Introduce AuthEventBus and centralized unauthorized handling on 401 responses

### DIFF
--- a/cmp-navigation/src/commonMain/kotlin/cmp/navigation/di/KoinModules.kt
+++ b/cmp-navigation/src/commonMain/kotlin/cmp/navigation/di/KoinModules.kt
@@ -14,6 +14,7 @@ import cmp.navigation.authenticatednavbar.AuthenticatedNavbarNavigationViewModel
 import cmp.navigation.rootnav.RootNavViewModel
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
+import org.mifos.mobile.core.common.di.AuthEventModule
 import org.mifos.mobile.core.common.di.DispatchersModule
 import org.mifos.mobile.core.data.di.RepositoryModule
 import org.mifos.mobile.core.datastore.di.PreferencesModule
@@ -44,6 +45,7 @@ import org.mifos.mobile.feature.transfer.process.di.TransferProcessModule
 object KoinModules {
     private val commonModules = module {
         includes(DispatchersModule)
+        includes(AuthEventModule)
     }
     private val dataModules = module {
         includes(RepositoryModule)

--- a/cmp-navigation/src/commonMain/kotlin/cmp/navigation/rootnav/RootNavViewModel.kt
+++ b/cmp-navigation/src/commonMain/kotlin/cmp/navigation/rootnav/RootNavViewModel.kt
@@ -15,6 +15,8 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
+import org.mifos.mobile.core.common.authEvent.AuthEvent
+import org.mifos.mobile.core.common.authEvent.AuthEventBus
 import org.mifos.mobile.core.data.repository.UserDataRepository
 import org.mifos.mobile.core.datastore.model.AppSettings
 import org.mifos.mobile.core.model.AuthState
@@ -22,6 +24,7 @@ import org.mifos.mobile.core.ui.utils.BaseViewModel
 
 class RootNavViewModel(
     userDataRepository: UserDataRepository,
+    authEventBus: AuthEventBus,
 ) : BaseViewModel<RootNavState, Unit, RootNavAction>(
     initialState = RootNavState.Splash,
 ) {
@@ -36,6 +39,14 @@ class RootNavViewModel(
                 settingsData = settingsData,
             )
         }.onEach(::handleAction)
+            .launchIn(viewModelScope)
+
+        authEventBus.events
+            .onEach { event ->
+                when (event) {
+                    AuthEvent.LoggedOut -> mutableStateFlow.update { RootNavState.Auth }
+                }
+            }
             .launchIn(viewModelScope)
     }
 

--- a/core/common/src/commonMain/kotlin/org/mifos/mobile/core/common/authEvent/AuthEvent.kt
+++ b/core/common/src/commonMain/kotlin/org/mifos/mobile/core/common/authEvent/AuthEvent.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+ */
+package org.mifos.mobile.core.common.authEvent
+
+sealed interface AuthEvent {
+    data object LoggedOut : AuthEvent
+}

--- a/core/common/src/commonMain/kotlin/org/mifos/mobile/core/common/authEvent/AuthEventBus.kt
+++ b/core/common/src/commonMain/kotlin/org/mifos/mobile/core/common/authEvent/AuthEventBus.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+ */
+package org.mifos.mobile.core.common.authEvent
+
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+// EventBus to force the user back to login screen
+class AuthEventBus {
+    private val _events = MutableSharedFlow<AuthEvent>(
+        replay = 0,
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    val events: SharedFlow<AuthEvent> = _events.asSharedFlow()
+
+    suspend fun emit(event: AuthEvent) {
+        _events.emit(event)
+    }
+}

--- a/core/common/src/commonMain/kotlin/org/mifos/mobile/core/common/di/AuthEventModule.kt
+++ b/core/common/src/commonMain/kotlin/org/mifos/mobile/core/common/di/AuthEventModule.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2025 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+ */
+package org.mifos.mobile.core.common.di
+
+import org.koin.dsl.module
+import org.mifos.mobile.core.common.authEvent.AuthEventBus
+
+val AuthEventModule = module {
+    single { AuthEventBus() }
+}

--- a/core/network/src/commonMain/kotlin/org/mifos/mobile/core/network/di/NetworkModule.kt
+++ b/core/network/src/commonMain/kotlin/org/mifos/mobile/core/network/di/NetworkModule.kt
@@ -12,6 +12,8 @@ package org.mifos.mobile.core.network.di
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.auth.Auth
 import org.koin.dsl.module
+import org.mifos.mobile.core.common.authEvent.AuthEvent
+import org.mifos.mobile.core.common.authEvent.AuthEventBus
 import org.mifos.mobile.core.datastore.UserPreferencesRepository
 import org.mifos.mobile.core.network.DataManager
 import org.mifos.mobile.core.network.KtorfitClient
@@ -23,11 +25,17 @@ val NetworkModule = module {
 
     single<HttpClient>(KtorClient) {
         val preferencesRepository = get<UserPreferencesRepository>()
+        val authEventBus: AuthEventBus = get()
 
         ktorHttpClient.config {
             install(Auth)
             install(KtorInterceptor) {
                 getToken = { preferencesRepository.token.value }
+
+                onUnauthorized = suspend {
+                    preferencesRepository.logOut()
+                    authEventBus.emit(AuthEvent.LoggedOut)
+                }
             }
         }
     }

--- a/core/network/src/commonMain/kotlin/org/mifos/mobile/core/network/utils/KtorInterceptor.kt
+++ b/core/network/src/commonMain/kotlin/org/mifos/mobile/core/network/utils/KtorInterceptor.kt
@@ -48,7 +48,8 @@ class KtorInterceptor(
                     runCatching {
                         plugin.onUnauthorized?.invoke()
                     }.onFailure { throwable ->
-                        null
+                        // Handle the exception if needed
+                        throwable.printStackTrace()
                     }
                 }
                 proceed()

--- a/core/network/src/commonMain/kotlin/org/mifos/mobile/core/network/utils/KtorInterceptor.kt
+++ b/core/network/src/commonMain/kotlin/org/mifos/mobile/core/network/utils/KtorInterceptor.kt
@@ -46,10 +46,10 @@ class KtorInterceptor(
                 // Trigger onUnauthorized handler when response code is 401
                 if (context.response.status == HttpStatusCode.Unauthorized) {
                     runCatching {
-                                   plugin.onUnauthorized?.invoke()
-                               }.onFailure { throwable ->
-                                    null
-                               }
+                        plugin.onUnauthorized?.invoke()
+                    }.onFailure { throwable ->
+                        null
+                    }
                 }
                 proceed()
             }

--- a/core/network/src/commonMain/kotlin/org/mifos/mobile/core/network/utils/KtorInterceptor.kt
+++ b/core/network/src/commonMain/kotlin/org/mifos/mobile/core/network/utils/KtorInterceptor.kt
@@ -13,11 +13,14 @@ import io.ktor.client.HttpClient
 import io.ktor.client.plugins.HttpClientPlugin
 import io.ktor.client.request.HttpRequestPipeline
 import io.ktor.client.request.header
+import io.ktor.client.statement.HttpResponsePipeline
+import io.ktor.http.HttpStatusCode
 import io.ktor.util.AttributeKey
 import org.mifos.mobile.core.datastore.UserPreferencesRepository
 
 class KtorInterceptor(
     private val getToken: () -> String?,
+    private val onUnauthorized: (suspend () -> Unit)?,
 ) {
     companion object Plugin : HttpClientPlugin<Config, KtorInterceptor> {
         private const val HEADER_TENANT = "Fineract-Platform-TenantId"
@@ -39,17 +42,28 @@ class KtorInterceptor(
                     }
                 }
             }
+            scope.responsePipeline.intercept(HttpResponsePipeline.After) {
+                // Trigger onUnauthorized handler when response code is 401
+                if (context.response.status == HttpStatusCode.Unauthorized) {
+                    plugin.onUnauthorized?.invoke()
+                }
+                proceed()
+            }
         }
 
         override fun prepare(block: Config.() -> Unit): KtorInterceptor {
             val config = Config().apply(block)
-            return KtorInterceptor(config.getToken)
+            return KtorInterceptor(
+                getToken = config.getToken,
+                onUnauthorized = config.onUnauthorized,
+            )
         }
     }
 }
 
 class Config {
     lateinit var getToken: () -> String?
+    var onUnauthorized: (suspend () -> Unit)? = null
 }
 
 class KtorInterceptorRe(

--- a/core/network/src/commonMain/kotlin/org/mifos/mobile/core/network/utils/KtorInterceptor.kt
+++ b/core/network/src/commonMain/kotlin/org/mifos/mobile/core/network/utils/KtorInterceptor.kt
@@ -45,7 +45,11 @@ class KtorInterceptor(
             scope.responsePipeline.intercept(HttpResponsePipeline.After) {
                 // Trigger onUnauthorized handler when response code is 401
                 if (context.response.status == HttpStatusCode.Unauthorized) {
-                    plugin.onUnauthorized?.invoke()
+                    runCatching {
+                                   plugin.onUnauthorized?.invoke()
+                               }.onFailure { throwable ->
+                                    null
+                               }
                 }
                 proceed()
             }


### PR DESCRIPTION
##Force user to logout and navigate to login screen when server throws 401 response

##Fixes - [Jira-#MM-466](https://mifosforge.jira.com/jira/software/c/projects/MM/issues?filter=allissues&jql=project%20%3D%20%22MM%22%20ORDER%20BY%20created%20DESC&groupBy=assignee&selectedIssue=MM-466)

##Overview
This PR introduces a reusable authentication event architecture that centralizes unauthorized response handling across the application modules. The change ensures that when the backend returns HTTP 401, the app cleanly triggers a logout event via a shared event bus

##Key Changes
Added AuthEventBus interface + implementation in core-common module to avoid any circular dependency keeping the multi module architecture intact.

Added a new AuthEvent DI module exposing AuthEventBus as a shared singleton.

Introduced a UserPreferenceRepository-backed unauthorized lambda responsible for logout cleanup and state reset.

Integrated AuthEventBus and unauthorized lambda into network module DI.

Updated Ktor response interceptor to detect 401 Unauthorized and trigger the unauthorized lambda → dispatching the logout event.

Ensured entire logout execution path remains module-independent and testable.

##Technical Flow
401 Response → Interceptor triggers lambda → EventBus dispatches Unauthorized event → Logout + preference clearing executed → UI layer can react via subscription.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App now listens for global authentication events and immediately returns users to the login flow on logout.
  * Added a lightweight authentication event bus for background components to broadcast logout events.

* **Bug Fixes**
  * Improved handling of 401 Unauthorized responses so sessions expire and users are signed out reliably.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->