### PR TITLE
refactor(core): replace MaterialTheme with KptMaterialTheme

### DIFF
--- a/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/MifosBasicDialog.kt
+++ b/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/MifosBasicDialog.kt
@@ -10,7 +10,6 @@
 package org.mifos.mobile.core.designsystem.component
 
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -19,6 +18,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun MifosBasicDialog(
@@ -42,7 +42,7 @@ fun MifosBasicDialog(
                 {
                     Text(
                         text = it,
-                        style = MaterialTheme.typography.headlineSmall,
+                        style = KptTheme.typography.headlineSmall,
                         modifier = Modifier.testTag("AlertTitleText"),
                     )
                 }
@@ -50,11 +50,11 @@ fun MifosBasicDialog(
             text = {
                 Text(
                     text = visibilityState.message,
-                    style = MaterialTheme.typography.bodyMedium,
+                    style = KptTheme.typography.bodyMedium,
                     modifier = Modifier.testTag("AlertContentText"),
                 )
             },
-            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+            containerColor = KptTheme.colorScheme.surfaceContainerHigh,
             modifier = Modifier.semantics {
                 testTag = "AlertPopup"
             },
@@ -96,7 +96,7 @@ fun MifosBasicDialog(
                 {
                     Text(
                         text = it,
-                        style = MaterialTheme.typography.headlineSmall,
+                        style = KptTheme.typography.headlineSmall,
                         modifier = Modifier.testTag("AlertTitleText"),
                     )
                 }
@@ -104,11 +104,11 @@ fun MifosBasicDialog(
             text = {
                 Text(
                     text = visibilityState.message,
-                    style = MaterialTheme.typography.bodyMedium,
+                    style = KptTheme.typography.bodyMedium,
                     modifier = Modifier.testTag("AlertContentText"),
                 )
             },
-            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+            containerColor = KptTheme.colorScheme.surfaceContainerHigh,
             modifier = Modifier.semantics {
                 testTag = "AlertPopup"
             },

--- a/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/MifosBottomSheet.kt
+++ b/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/MifosBottomSheet.kt
@@ -13,7 +13,6 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -23,10 +22,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import com.arkivanov.essenty.backhandler.BackCallback
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import org.mifos.mobile.core.designsystem.theme.DesignToken
+import template.core.base.designsystem.theme.KptTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -54,7 +54,7 @@ fun MifosBottomSheet(
 
     AnimatedVisibility(visible = showBottomSheet) {
         ModalBottomSheet(
-            containerColor = MaterialTheme.colorScheme.surface,
+            containerColor = KptTheme.colorScheme.surface,
             onDismissRequest = {
                 showBottomSheet = false
                 dismissSheet()
@@ -73,7 +73,7 @@ fun MifosBottomSheetPreview() {
     MifosBottomSheet(
         content = {
             Box {
-                Modifier.height(100.dp)
+                Modifier.height(DesignToken.sizes.boxDp100)
             }
         },
         onDismiss = {},

--- a/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/MifosButton.kt
+++ b/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/MifosButton.kt
@@ -21,7 +21,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ButtonElevation
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -29,6 +28,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.dp
 import org.mifos.mobile.core.designsystem.theme.DesignToken
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * Mifos button with generic content slot. Wraps Material 3 [Button].
@@ -54,7 +54,7 @@ fun MifosButton(
 ) {
     Button(
         onClick = onClick,
-        modifier = modifier.height(48.dp),
+        modifier = modifier.height(DesignToken.sizes.buttonHeightDp48),
         enabled = enabled,
         colors = colors,
         shape = shape,
@@ -81,16 +81,16 @@ fun MifosButton(
     text: @Composable () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
-    shape: Shape = DesignToken.shapes.medium,
+    shape: Shape = KptTheme.shapes.medium,
     contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
     elevation: ButtonElevation? = ButtonDefaults.buttonElevation(),
     colors: ButtonColors = ButtonDefaults.buttonColors(
-        containerColor = MaterialTheme.colorScheme.primary,
+        containerColor = KptTheme.colorScheme.primary,
     ),
 ) {
     Button(
         onClick = onClick,
-        modifier = modifier.height(48.dp),
+        modifier = modifier.height(DesignToken.sizes.buttonHeightDp48),
         enabled = enabled,
         colors = colors,
         shape = shape,
@@ -118,7 +118,7 @@ fun MifosOutlinedButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
-    shape: Shape = DesignToken.shapes.medium,
+    shape: Shape = KptTheme.shapes.medium,
     border: BorderStroke? = ButtonDefaults.outlinedButtonBorder(enabled),
     colors: ButtonColors = ButtonDefaults.outlinedButtonColors(),
     contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
@@ -127,7 +127,7 @@ fun MifosOutlinedButton(
     OutlinedButton(
         onClick = onClick,
         modifier = modifier
-            .height(48.dp),
+            .height(DesignToken.sizes.buttonHeightDp48),
         enabled = enabled,
         shape = shape,
         colors = colors,
@@ -158,7 +158,7 @@ fun MifosTextButton(
         modifier = modifier,
         enabled = enabled,
         colors = ButtonDefaults.textButtonColors(
-            contentColor = MaterialTheme.colorScheme.onBackground,
+            contentColor = KptTheme.colorScheme.onBackground,
         ),
         content = content,
     )
@@ -218,7 +218,7 @@ private fun MifosButtonContent(
                     start = if (leadingIcon != null) {
                         ButtonDefaults.IconSpacing
                     } else {
-                        0.dp
+                        DesignToken.padding.none
                     },
                 ),
         ) {
@@ -238,5 +238,6 @@ object MifosButtonDefaults {
 
     // TODO: File bug
     // OutlinedButton default border width isn't exposed via ButtonDefaults
+    // TODO use DesignToken, currently it throws error
     val OutlinedButtonBorderWidth = 1.dp
 }

--- a/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/MifosCard.kt
+++ b/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/MifosCard.kt
@@ -31,14 +31,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardColors
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CardElevation
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -51,7 +49,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import fluent.ui.system.icons.FluentIcons
 import fluent.ui.system.icons.filled.Document
 import mifos_mobile.core.designsystem.generated.resources.Res
@@ -64,12 +61,13 @@ import org.mifos.mobile.core.designsystem.icon.MifosIcons
 import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun MifosCard(
     modifier: Modifier = Modifier,
-    shape: Shape = RoundedCornerShape(8.dp),
-    elevation: Dp = 1.dp,
+    shape: Shape = KptTheme.shapes.small,
+    elevation: Dp = KptTheme.elevation.level1,
     onClick: (() -> Unit)? = null,
     colors: CardColors = CardDefaults.cardColors(),
     content: @Composable ColumnScope.() -> Unit,
@@ -166,7 +164,7 @@ fun MifosUploadStateCard(
     icon: ImageVector,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    height: Dp = 112.dp,
+    height: Dp = DesignToken.sizes.cardDp112,
 ) {
     MifosCustomCard(
         modifier = Modifier
@@ -175,17 +173,17 @@ fun MifosUploadStateCard(
         onClick = onClick,
         enabled = true,
         variant = CardVariant.FILLED,
-        shape = DesignToken.shapes.medium,
+        shape = KptTheme.shapes.medium,
         elevation = CardDefaults.cardElevation(
-            defaultElevation = DesignToken.elevation.none,
+            defaultElevation = KptTheme.elevation.level0,
         ),
         colors = CardDefaults.cardColors(
             containerColor = Color.Transparent,
-            contentColor = MaterialTheme.colorScheme.onSurface,
+            contentColor = KptTheme.colorScheme.onSurface,
         ),
         borderStroke = BorderStroke(
-            1.dp,
-            MaterialTheme.colorScheme.secondaryContainer,
+            DesignToken.strokes.thin,
+            KptTheme.colorScheme.secondaryContainer,
         ),
     ) {
         MifosUploadStateCardContent(
@@ -214,11 +212,11 @@ fun MifosUploadStateCardContent(
             contentDescription = null,
             modifier = Modifier.size(DesignToken.sizes.iconMedium),
         )
-        Spacer(modifier = Modifier.height(DesignToken.spacing.extraSmall))
+        Spacer(modifier = Modifier.height(KptTheme.spacing.xs))
         Text(
             text = text,
             style = MifosTypography.bodySmall,
-            color = MaterialTheme.colorScheme.secondary,
+            color = KptTheme.colorScheme.secondary,
         )
     }
 }
@@ -236,7 +234,7 @@ fun MifosUploadedStateCard(
     removeText: String = stringResource(Res.string.feature_upload_id_remove_file),
     selectText: String = stringResource(Res.string.feature_upload_id_select_new_file),
     viewText: String = stringResource(Res.string.feature_upload_id_view_file),
-    height: Dp = 112.dp,
+    height: Dp = DesignToken.sizes.cardDp112,
 ) {
     Box(modifier = modifier.fillMaxWidth()) {
         MifosCustomCard(
@@ -245,10 +243,10 @@ fun MifosUploadedStateCard(
                 .height(height),
             enabled = false,
             variant = CardVariant.OUTLINED,
-            shape = DesignToken.shapes.medium,
-            elevation = CardDefaults.cardElevation(defaultElevation = DesignToken.elevation.none),
-            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.onPrimary),
-            borderStroke = BorderStroke(1.dp, MaterialTheme.colorScheme.secondaryContainer),
+            shape = KptTheme.shapes.medium,
+            elevation = CardDefaults.cardElevation(defaultElevation = KptTheme.elevation.level0),
+            colors = CardDefaults.cardColors(containerColor = KptTheme.colorScheme.onPrimary),
+            borderStroke = BorderStroke(DesignToken.strokes.thin, KptTheme.colorScheme.secondaryContainer),
         ) {
             MifosUploadedCardContent(
                 icon = icon,
@@ -265,14 +263,14 @@ fun MifosUploadedStateCard(
 
         Box(
             modifier = Modifier
-                .padding(start = DesignToken.padding.large)
-                .offset(y = (-7).dp),
+                .padding(start = KptTheme.spacing.md)
+                .offset(y = DesignToken.spacing.negativeDp7),
         ) {
             Text(
                 text = label,
                 style = MifosTypography.bodySmall,
                 modifier = Modifier
-                    .padding(horizontal = DesignToken.padding.extraSmall),
+                    .padding(horizontal = KptTheme.spacing.xs),
             )
         }
     }
@@ -299,50 +297,50 @@ fun MifosUploadedCardContent(
     ) {
         Box(
             modifier = Modifier
-                .size(DesignToken.sizes.avatarSmall + 4.dp)
+                .size(DesignToken.sizes.boxDp36)
                 .background(
-                    color = MaterialTheme.colorScheme.primary,
-                    shape = DesignToken.shapes.small,
+                    color = KptTheme.colorScheme.primary,
+                    shape = KptTheme.shapes.small,
                 ),
             contentAlignment = Alignment.Center,
         ) {
             Image(
                 imageVector = icon,
                 contentDescription = "file icon",
-                colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onSurface),
+                colorFilter = ColorFilter.tint(KptTheme.colorScheme.onSurface),
                 modifier = Modifier
                     .size(DesignToken.sizes.iconMedium)
                     .align(Alignment.Center),
             )
         }
 
-        Spacer(modifier = Modifier.width(DesignToken.spacing.large))
+        Spacer(modifier = Modifier.width(KptTheme.spacing.md))
 
         Column {
             Text(
                 text = fileName,
                 style = MifosTypography.titleSmallEmphasized,
-                color = MaterialTheme.colorScheme.onSurface,
+                color = KptTheme.colorScheme.onSurface,
             )
 
             Text(
                 text = fileSize,
                 style = MifosTypography.bodySmall,
-                color = MaterialTheme.colorScheme.secondary,
+                color = KptTheme.colorScheme.secondary,
             )
 
             Spacer(modifier = Modifier.height(DesignToken.spacing.largeIncreased))
 
             FlowRow(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.large),
+                horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.md),
             ) {
                 Text(
                     modifier = Modifier.clickable {
                         onRemoveClick()
                     },
                     text = removeText,
-                    color = MaterialTheme.colorScheme.primary,
+                    color = KptTheme.colorScheme.primary,
                     style = MifosTypography.labelMedium,
                 )
 
@@ -351,7 +349,7 @@ fun MifosUploadedCardContent(
                         onViewClick()
                     },
                     text = viewText,
-                    color = MaterialTheme.colorScheme.primary,
+                    color = KptTheme.colorScheme.primary,
                     style = MifosTypography.labelMedium,
                 )
 
@@ -360,7 +358,7 @@ fun MifosUploadedCardContent(
                         onSelectNewClick()
                     },
                     text = selectText,
-                    color = MaterialTheme.colorScheme.primary,
+                    color = KptTheme.colorScheme.primary,
                     style = MifosTypography.labelMedium,
                 )
             }
@@ -381,27 +379,27 @@ fun MifosExploreCard(
         modifier = modifier
             .height(DesignToken.sizes.inputHeight)
             .border(
-                1.dp,
-                MaterialTheme.colorScheme.secondaryContainer,
-                DesignToken.shapes.medium,
+                DesignToken.strokes.thin,
+                KptTheme.colorScheme.secondaryContainer,
+                KptTheme.shapes.medium,
             ),
         variant = CardVariant.OUTLINED,
         onClick = onClick,
         colors = CardDefaults.cardColors(
             containerColor = Color.Transparent,
-            contentColor = MaterialTheme.colorScheme.onSurface,
+            contentColor = KptTheme.colorScheme.onSurface,
         ),
     ) {
         Row(
-            modifier = Modifier.padding(DesignToken.padding.large),
+            modifier = Modifier.padding(KptTheme.spacing.md),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.small),
+            horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.sm),
         ) {
             Image(
                 imageVector = icon,
                 contentDescription = text,
                 modifier = Modifier.size(DesignToken.sizes.iconMedium),
-                colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onSurface),
+                colorFilter = ColorFilter.tint(KptTheme.colorScheme.onSurface),
             )
 
             Text(
@@ -426,8 +424,8 @@ fun MifosExploreCard(
 @Composable
 private fun Mifos_Explore_Card_Preview() {
     Column(
-        modifier = Modifier.padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier.padding(KptTheme.spacing.md),
+        verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.sm),
     ) {
         Row {
             // Method 1: Automatic multiline (spaces become line breaks)
@@ -469,7 +467,7 @@ private fun Mifos_Explore_Card_Preview() {
 private fun Upload_Card_Preview() {
     MifosMobileTheme {
         Column(
-            modifier = Modifier.fillMaxSize().padding(DesignToken.padding.large),
+            modifier = Modifier.fillMaxSize().padding(KptTheme.spacing.md),
             verticalArrangement = Arrangement.spacedBy(DesignToken.padding.largeIncreased),
         ) {
             Text(
@@ -480,25 +478,25 @@ private fun Upload_Card_Preview() {
                 MifosCustomCard(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(112.dp),
+                        .height(DesignToken.sizes.cardDp112),
                     onClick = {},
                     enabled = true,
                     variant = it,
-                    shape = DesignToken.shapes.medium,
+                    shape = KptTheme.shapes.medium,
                     elevation = CardDefaults.cardElevation(
                         defaultElevation = if (it == CardVariant.ELEVATED) {
                             DesignToken.elevation.elevation
                         } else {
-                            DesignToken.elevation.none
+                            KptTheme.elevation.level0
                         },
                     ),
                     colors = CardDefaults.cardColors(
                         containerColor = Color.Transparent,
-                        contentColor = MaterialTheme.colorScheme.onSurface,
+                        contentColor = KptTheme.colorScheme.onSurface,
                     ),
                     borderStroke = BorderStroke(
-                        1.dp,
-                        MaterialTheme.colorScheme.secondaryContainer,
+                        DesignToken.strokes.thin,
+                        KptTheme.colorScheme.secondaryContainer,
                     ),
                 ) {
                     Column(
@@ -513,11 +511,11 @@ private fun Upload_Card_Preview() {
                             contentDescription = null,
                             modifier = Modifier.size(DesignToken.sizes.iconMedium),
                         )
-                        Spacer(modifier = Modifier.height(DesignToken.spacing.extraSmall))
+                        Spacer(modifier = Modifier.height(KptTheme.spacing.xs))
                         Text(
                             text = "Upload Documents",
                             style = MifosTypography.bodySmall,
-                            color = MaterialTheme.colorScheme.secondary,
+                            color = KptTheme.colorScheme.secondary,
                         )
                     }
                 }
@@ -542,7 +540,7 @@ private fun Upload_Card_Preview() {
 fun FloatingTitleCardPreview() {
     MifosMobileTheme {
         Column(
-            modifier = Modifier.fillMaxSize().padding(DesignToken.padding.large),
+            modifier = Modifier.fillMaxSize().padding(KptTheme.spacing.md),
             verticalArrangement = Arrangement.spacedBy(DesignToken.padding.largeIncreased),
         ) {
             MifosUploadedStateCard(

--- a/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/MifosLoadingDialog.kt
+++ b/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/MifosLoadingDialog.kt
@@ -14,11 +14,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -26,11 +24,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun MifosLoadingDialog(
@@ -48,9 +46,9 @@ fun MifosLoadingDialog(
                 ),
             ) {
                 Card(
-                    shape = RoundedCornerShape(28.dp),
+                    shape = KptTheme.shapes.extraLarge,
                     colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                        containerColor = KptTheme.colorScheme.surfaceContainerHigh,
                     ),
                     modifier = modifier
                         .semantics {
@@ -69,16 +67,16 @@ fun MifosLoadingDialog(
                             modifier = Modifier
                                 .testTag("AlertTitleText")
                                 .padding(
-                                    top = 24.dp,
-                                    bottom = 8.dp,
+                                    top = KptTheme.spacing.lg,
+                                    bottom = KptTheme.spacing.sm,
                                 ),
                         )
                         CircularProgressIndicator(
                             modifier = Modifier
                                 .testTag("AlertProgressIndicator")
                                 .padding(
-                                    top = 8.dp,
-                                    bottom = 24.dp,
+                                    top = KptTheme.spacing.sm,
+                                    bottom = KptTheme.spacing.lg,
                                 ),
                         )
                     }

--- a/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/MifosNavigation.kt
+++ b/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/MifosNavigation.kt
@@ -12,7 +12,6 @@ package org.mifos.mobile.core.designsystem.component
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.NavigationRail
@@ -21,10 +20,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.mifos.mobile.core.designsystem.icon.MifosIcons
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * Now in Android navigation bar item with icon and label content slots. Wraps Material 3
@@ -77,8 +76,8 @@ fun MifosNavigationBar(
 ) {
     NavigationBar(
         modifier = modifier,
-        containerColor = MaterialTheme.colorScheme.background,
-        tonalElevation = 0.dp,
+        containerColor = KptTheme.colorScheme.background,
+        tonalElevation = KptTheme.elevation.level0,
         content = content,
     )
 }
@@ -236,11 +235,11 @@ fun MifosNavigationRailPreview() {
  */
 object MifosNavigationDefaults {
     @Composable
-    fun navigationContentColor() = MaterialTheme.colorScheme.onSurfaceVariant
+    fun navigationContentColor() = KptTheme.colorScheme.onSurfaceVariant
 
     @Composable
-    fun navigationSelectedItemColor() = MaterialTheme.colorScheme.onPrimaryContainer
+    fun navigationSelectedItemColor() = KptTheme.colorScheme.onPrimaryContainer
 
     @Composable
-    fun navigationIndicatorColor() = MaterialTheme.colorScheme.primaryContainer
+    fun navigationIndicatorColor() = KptTheme.colorScheme.primaryContainer
 }

--- a/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/MifosOtpTextField.kt
+++ b/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/MifosOtpTextField.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -35,8 +34,9 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import org.mifos.mobile.core.designsystem.theme.DesignToken
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun MifosOtpTextField(
@@ -50,7 +50,7 @@ fun MifosOtpTextField(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .padding(16.dp),
+            .padding(KptTheme.spacing.md),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         BasicTextField(
@@ -88,7 +88,7 @@ fun MifosOtpTextField(
                             index = index,
                             text = otpText,
                         )
-                        Spacer(modifier = Modifier.width(8.dp))
+                        Spacer(modifier = Modifier.width(KptTheme.spacing.sm))
                     }
                 }
             },
@@ -97,10 +97,10 @@ fun MifosOtpTextField(
             // display erro message in text
             Text(
                 text = "Invalid OTP",
-                style = MaterialTheme.typography.bodyMedium,
+                style = KptTheme.typography.bodyMedium,
                 color = Color.Red,
                 textAlign = TextAlign.Center,
-                modifier = Modifier.padding(top = 8.dp),
+                modifier = Modifier.padding(top = KptTheme.spacing.sm),
             )
         }
     }
@@ -120,10 +120,10 @@ private fun CharView(
     }
     Text(
         modifier = modifier
-            .width(40.dp)
+            .width(DesignToken.sizes.textDp40)
             .wrapContentHeight(align = Alignment.CenterVertically),
         text = char,
-        style = MaterialTheme.typography.headlineSmall,
+        style = KptTheme.typography.headlineSmall,
         color = if (isFocused) {
             Color.DarkGray
         } else {

--- a/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/MifosPasswordField.kt
+++ b/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/MifosPasswordField.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.TextFieldColors
 import androidx.compose.runtime.Composable
@@ -35,9 +34,9 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.mifos.mobile.core.designsystem.icon.MifosIcons
-import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.utils.nonLetterColorVisualTransformation
 import org.mifos.mobile.core.designsystem.utils.tabNavigation
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun MifosPasswordField(
@@ -47,11 +46,11 @@ fun MifosPasswordField(
     showPasswordChange: (Boolean) -> Unit,
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
-    shape: Shape = DesignToken.shapes.medium,
+    shape: Shape = KptTheme.shapes.medium,
     colors: TextFieldColors = OutlinedTextFieldDefaults.colors(
-        focusedBorderColor = MaterialTheme.colorScheme.secondaryContainer,
-        unfocusedBorderColor = MaterialTheme.colorScheme.secondaryContainer,
-        errorBorderColor = MaterialTheme.colorScheme.error,
+        focusedBorderColor = KptTheme.colorScheme.secondaryContainer,
+        unfocusedBorderColor = KptTheme.colorScheme.secondaryContainer,
+        errorBorderColor = KptTheme.colorScheme.error,
     ),
     isError: Boolean = false,
     readOnly: Boolean = false,
@@ -91,9 +90,9 @@ fun MifosPasswordField(
             errorText = hint,
             trailingIcon = {
                 val color = if (isError) {
-                    MaterialTheme.colorScheme.error
+                    KptTheme.colorScheme.error
                 } else {
-                    MaterialTheme
+                    KptTheme
                         .colorScheme.onSurface
                 }
                 IconButton(

--- a/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/MifosRadioButton.kt
+++ b/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/MifosRadioButton.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.selection.selectableGroup
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.RadioButtonColors
 import androidx.compose.material3.Text
@@ -46,12 +45,12 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.mifos.mobile.core.designsystem.theme.AppColors
 import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * Enhanced radio button component for Mifos Mobile with improved accessibility,
@@ -83,10 +82,10 @@ fun MifosRadioButton(
     contentDescription: String? = null,
     selectedColor: Color = AppColors.primaryBlue,
     unselectedColor: Color = AppColors.borderColor,
-    errorColor: Color = MaterialTheme.colorScheme.error,
+    errorColor: Color = KptTheme.colorScheme.error,
     selectedTextStyle: TextStyle = MifosTypography.titleSmallEmphasized,
     unselectedTextStyle: TextStyle = MifosTypography.titleSmall,
-    borderWidth: Dp = 1.dp,
+    borderWidth: Dp = DesignToken.strokes.thin,
     animationDurationMs: Int = 200,
 ) {
     // Animated colors for smooth transitions
@@ -137,13 +136,13 @@ fun MifosRadioButton(
     ) {
         Row(
             modifier = modifier
-                .padding(vertical = DesignToken.padding.extraSmall)
+                .padding(vertical = KptTheme.spacing.xs)
                 .border(
                     width = borderWidth,
                     color = animatedBorderColor.copy(
                         alpha = if (enabled) 1.0f else 0.6f,
                     ),
-                    shape = DesignToken.shapes.medium,
+                    shape = KptTheme.shapes.medium,
                 )
                 .clickable(
                     enabled = enabled,
@@ -152,11 +151,11 @@ fun MifosRadioButton(
                     interactionSource = interactionSource,
                     indication = ripple(
                         bounded = true,
-                        radius = 24.dp,
+                        radius = DesignToken.sizes.rippleRadiusDp24,
                     ),
                 )
-                .padding(DesignToken.padding.large),
-            horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.small),
+                .padding(KptTheme.spacing.md),
+            horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.sm),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             RadioButton(
@@ -237,13 +236,13 @@ private fun Enhanced_Radio_Button_Preview() {
             modifier = Modifier
                 .fillMaxSize()
                 .padding(DesignToken.padding.medium),
-            verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.large),
+            verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.md),
         ) {
             // Individual radio buttons
             Text(
                 text = "Individual Radio Buttons",
                 style = MifosTypography.headlineMedium,
-                modifier = Modifier.padding(bottom = DesignToken.spacing.small),
+                modifier = Modifier.padding(bottom = KptTheme.spacing.sm),
             )
 
             MifosRadioButton(
@@ -282,7 +281,7 @@ private fun Enhanced_Radio_Button_Preview() {
             Text(
                 text = "Radio Button Group",
                 style = MifosTypography.headlineMedium,
-                modifier = Modifier.padding(bottom = DesignToken.spacing.small),
+                modifier = Modifier.padding(bottom = KptTheme.spacing.sm),
             )
 
             MifosRadioButtonGroup(
@@ -298,7 +297,7 @@ private fun Enhanced_Radio_Button_Preview() {
             Text(
                 text = "Payment Methods (with Error)",
                 style = MifosTypography.headlineMedium,
-                modifier = Modifier.padding(bottom = DesignToken.spacing.small),
+                modifier = Modifier.padding(bottom = KptTheme.spacing.sm),
             )
 
             MifosRadioButtonGroup(

--- a/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/MifosScaffold.kt
+++ b/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/MifosScaffold.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FabPosition
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.SnackbarHost
@@ -38,11 +37,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.mifos.mobile.core.designsystem.theme.AppColors
+import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
+import template.core.base.designsystem.theme.KptTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -50,8 +50,8 @@ fun MifosScaffold(
     onNavigationIconClick: () -> Unit,
     modifier: Modifier = Modifier,
     topBarTitle: String? = null,
-    containerColor: Color = MaterialTheme.colorScheme.surface,
-    contentColor: Color = MaterialTheme.colorScheme.onSurface,
+    containerColor: Color = KptTheme.colorScheme.surface,
+    contentColor: Color = KptTheme.colorScheme.onSurface,
     floatingActionButtonContent: FloatingActionButtonContent? = null,
     pullToRefreshState: MifosPullToRefreshState = rememberMifosPullToRefreshState(),
     contentWindowInsets: WindowInsets = ScaffoldDefaults
@@ -83,7 +83,7 @@ fun MifosScaffold(
         snackbarHost = snackbarHost,
         containerColor = containerColor,
         contentColor = contentColor,
-        contentWindowInsets = WindowInsets(0.dp),
+        contentWindowInsets = WindowInsets(DesignToken.padding.none),
         content = { paddingValues ->
             val internalPullToRefreshState = rememberPullToRefreshState()
             Box(
@@ -131,8 +131,8 @@ fun MifosScaffold(
     modifier: Modifier = Modifier,
     onNavigationIconClick: () -> Unit = {},
     topBarTitle: String? = null,
-    containerColor: Color = MaterialTheme.colorScheme.surface,
-    contentColor: Color = MaterialTheme.colorScheme.onSurface,
+    containerColor: Color = KptTheme.colorScheme.surface,
+    contentColor: Color = KptTheme.colorScheme.onSurface,
     floatingActionButtonContent: FloatingActionButtonContent? = null,
     pullToRefreshState: MifosPullToRefreshState = rememberMifosPullToRefreshState(),
     contentWindowInsets: WindowInsets = ScaffoldDefaults
@@ -165,7 +165,7 @@ fun MifosScaffold(
         snackbarHost = snackbarHost,
         containerColor = containerColor,
         contentColor = contentColor,
-        contentWindowInsets = WindowInsets(0.dp),
+        contentWindowInsets = WindowInsets(DesignToken.padding.none),
         content = { paddingValues ->
             val internalPullToRefreshState = rememberPullToRefreshState()
             Box(
@@ -214,8 +214,8 @@ fun MifosElevatedScaffold(
     modifier: Modifier = Modifier,
     brandIcon: DrawableResource? = null,
     bottomBar: @Composable () -> Unit = {},
-    containerColor: Color = MaterialTheme.colorScheme.surface,
-    contentColor: Color = MaterialTheme.colorScheme.onSurface,
+    containerColor: Color = KptTheme.colorScheme.surface,
+    contentColor: Color = KptTheme.colorScheme.onSurface,
     floatingActionButtonContent: FloatingActionButtonContent? = null,
     pullToRefreshState: MifosPullToRefreshState = rememberMifosPullToRefreshState(),
     contentWindowInsets: WindowInsets = ScaffoldDefaults
@@ -245,7 +245,7 @@ fun MifosElevatedScaffold(
         },
         bottomBar = bottomBar,
         snackbarHost = snackbarHost,
-        contentWindowInsets = WindowInsets(0.dp),
+        contentWindowInsets = WindowInsets(DesignToken.padding.none),
         containerColor = containerColor,
         contentColor = contentColor,
         content = { paddingValues ->
@@ -273,8 +273,8 @@ fun MifosElevatedScaffold(
                         modifier = Modifier.align(Alignment.TopCenter),
                         isRefreshing = pullToRefreshState.isRefreshing,
                         state = internalPullToRefreshState,
-                        containerColor = MaterialTheme.colorScheme.tertiary,
-                        color = MaterialTheme.colorScheme.primary,
+                        containerColor = KptTheme.colorScheme.tertiary,
+                        color = KptTheme.colorScheme.primary,
                     )
                 }
             }
@@ -293,8 +293,8 @@ fun MifosScaffold(
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     pullToRefreshState: MifosPullToRefreshState = rememberMifosPullToRefreshState(),
     floatingActionButtonPosition: FabPosition = FabPosition.End,
-    containerColor: Color = MaterialTheme.colorScheme.surface,
-    contentColor: Color = MaterialTheme.colorScheme.onSurface,
+    containerColor: Color = KptTheme.colorScheme.surface,
+    contentColor: Color = KptTheme.colorScheme.onSurface,
     contentWindowInsets: WindowInsets = ScaffoldDefaults
         .contentWindowInsets
         .only(WindowInsetsSides.Horizontal),
@@ -339,8 +339,8 @@ fun MifosScaffold(
                         modifier = Modifier.align(Alignment.TopCenter),
                         isRefreshing = pullToRefreshState.isRefreshing,
                         state = internalPullToRefreshState,
-                        containerColor = MaterialTheme.colorScheme.tertiary,
-                        color = MaterialTheme.colorScheme.primary,
+                        containerColor = KptTheme.colorScheme.tertiary,
+                        color = KptTheme.colorScheme.primary,
                     )
                 }
             }

--- a/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/MifosSearchTextField.kt
+++ b/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/MifosSearchTextField.kt
@@ -18,7 +18,6 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
@@ -27,6 +26,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun MifosSearchTextField(
@@ -47,7 +47,7 @@ fun MifosSearchTextField(
             )
         },
         onValueChange = onValueChange,
-        textStyle = MaterialTheme.typography.bodyLarge,
+        textStyle = KptTheme.typography.bodyLarge,
         trailingIcon = {
             AnimatedVisibility(visible = value.text.isNotEmpty()) {
                 IconButton(onClick = onSearchDismiss) {

--- a/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/MifosTab.kt
+++ b/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/MifosTab.kt
@@ -12,7 +12,6 @@ package org.mifos.mobile.core.designsystem.component
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.contentColorFor
@@ -21,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun MifosTab(
@@ -28,8 +28,8 @@ fun MifosTab(
     selected: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    selectedColor: Color = MaterialTheme.colorScheme.primary,
-    unselectedColor: Color = MaterialTheme.colorScheme.primaryContainer,
+    selectedColor: Color = KptTheme.colorScheme.primary,
+    unselectedColor: Color = KptTheme.colorScheme.primaryContainer,
 ) {
     Tab(
         text = {

--- a/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/MifosTextField.kt
+++ b/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/MifosTextField.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalTextStyle
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.OutlinedTextFieldDefaults.colors
@@ -40,6 +39,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.VisualTransformation
 import org.mifos.mobile.core.designsystem.icon.MifosIcons
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun MifosOutlinedTextField(
@@ -49,9 +49,9 @@ fun MifosOutlinedTextField(
     modifier: Modifier = Modifier,
     shape: Shape = OutlinedTextFieldDefaults.shape,
     colors: TextFieldColors = colors(
-        focusedBorderColor = MaterialTheme.colorScheme.secondaryContainer,
-        unfocusedBorderColor = MaterialTheme.colorScheme.secondaryContainer,
-        errorBorderColor = MaterialTheme.colorScheme.error,
+        focusedBorderColor = KptTheme.colorScheme.secondaryContainer,
+        unfocusedBorderColor = KptTheme.colorScheme.secondaryContainer,
+        errorBorderColor = KptTheme.colorScheme.error,
     ),
     textStyle: TextStyle = LocalTextStyle.current,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
@@ -101,7 +101,7 @@ fun MifosOutlinedTextField(
                     modifier = Modifier.testTag("errorTag"),
                     text = it,
                     style = MifosTypography.bodySmall,
-                    color = MaterialTheme.colorScheme.error,
+                    color = KptTheme.colorScheme.error,
                 )
             }
         },
@@ -160,7 +160,7 @@ fun MifosTextField(
                     modifier = Modifier.testTag("errorTag"),
                     text = it ?: "",
                     style = MifosTypography.bodySmall,
-                    color = MaterialTheme.colorScheme.error,
+                    color = KptTheme.colorScheme.error,
                 )
             }
         },
@@ -187,7 +187,7 @@ private fun ClearIconButton(
             Icon(
                 imageVector = clearIcon,
                 contentDescription = "trailingIcon",
-                tint = MaterialTheme.colorScheme.onSurface,
+                tint = KptTheme.colorScheme.onSurface,
             )
         }
     }

--- a/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/MifosTopAppBar.kt
+++ b/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/MifosTopAppBar.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeTopAppBar
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MediumTopAppBar
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -32,11 +31,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.mifos.mobile.core.designsystem.icon.MifosIcons
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.designsystem.utils.mirrorIfRtl
+import template.core.base.designsystem.theme.KptTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -94,11 +93,11 @@ fun MifosTopAppBar(
     }
 
     val topAppBarColors = TopAppBarDefaults.largeTopAppBarColors(
-        containerColor = MaterialTheme.colorScheme.surface,
-        scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainer,
-        navigationIconContentColor = MaterialTheme.colorScheme.onSurface,
-        titleContentColor = MaterialTheme.colorScheme.onSurface,
-        actionIconContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        containerColor = KptTheme.colorScheme.surface,
+        scrolledContainerColor = KptTheme.colorScheme.surfaceContainer,
+        navigationIconContentColor = KptTheme.colorScheme.onSurface,
+        titleContentColor = KptTheme.colorScheme.onSurface,
+        actionIconContentColor = KptTheme.colorScheme.onSurfaceVariant,
     )
 
     if (titleTextHasOverflow) {
@@ -111,7 +110,7 @@ fun MifosTopAppBar(
                 // making adding any arguments for softWrap and minLines superfluous.
                 Text(
                     text = title,
-                    style = MaterialTheme.typography.titleLarge,
+                    style = KptTheme.typography.titleLarge,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.testTag("PageTitleLabel"),
                 )
@@ -127,7 +126,7 @@ fun MifosTopAppBar(
             title = {
                 Text(
                     text = title,
-                    style = MaterialTheme.typography.titleLarge,
+                    style = KptTheme.typography.titleLarge,
                     maxLines = 1,
                     softWrap = false,
                     overflow = TextOverflow.Ellipsis,
@@ -172,11 +171,11 @@ fun MifosTopAppBar(
     }
 
     val topAppBarColors = TopAppBarDefaults.largeTopAppBarColors(
-        containerColor = MaterialTheme.colorScheme.surface,
-        scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainer,
-        navigationIconContentColor = MaterialTheme.colorScheme.onSurface,
-        titleContentColor = MaterialTheme.colorScheme.onSurface,
-        actionIconContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        containerColor = KptTheme.colorScheme.surface,
+        scrolledContainerColor = KptTheme.colorScheme.surfaceContainer,
+        navigationIconContentColor = KptTheme.colorScheme.onSurface,
+        titleContentColor = KptTheme.colorScheme.onSurface,
+        actionIconContentColor = KptTheme.colorScheme.onSurfaceVariant,
     )
 
     LargeTopAppBar(
@@ -185,20 +184,20 @@ fun MifosTopAppBar(
         navigationIcon = navigationIconContent,
         title = {
             Column(
-                verticalArrangement = Arrangement.spacedBy(4.dp),
+                verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.xs),
             ) {
                 // The height of the component is controlled and will only allow for 1 extra row,
                 // making adding any arguments for softWrap and minLines superfluous.
                 Text(
                     text = title,
-                    style = MaterialTheme.typography.titleLarge,
+                    style = KptTheme.typography.titleLarge,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.testTag("PageTitleLabel"),
                 )
 
                 Text(
                     text = subtitle,
-                    style = MaterialTheme.typography.bodyMedium,
+                    style = KptTheme.typography.bodyMedium,
                     modifier = Modifier.testTag("PageTitleSubTitle"),
                 )
             }

--- a/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/MifosTopBar.kt
+++ b/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/MifosTopBar.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -28,13 +27,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.mifos.mobile.core.designsystem.icon.MifosIcons
 import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
+import template.core.base.designsystem.theme.KptTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -48,7 +47,7 @@ fun MifosTopBar(
         title = {
             Text(
                 text = topBarTitle,
-                style = MaterialTheme.typography.titleMedium,
+                style = KptTheme.typography.titleMedium,
             )
         },
         navigationIcon = {
@@ -62,7 +61,7 @@ fun MifosTopBar(
             }
         },
         colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-            containerColor = MaterialTheme.colorScheme.surface,
+            containerColor = KptTheme.colorScheme.surface,
         ),
         actions = actions,
         modifier = modifier,
@@ -82,7 +81,7 @@ fun MifosTopBar(
         title = {
             Text(
                 text = topBarTitle,
-                style = MaterialTheme.typography.titleMedium,
+                style = KptTheme.typography.titleMedium,
             )
         },
         navigationIcon = {
@@ -98,7 +97,7 @@ fun MifosTopBar(
             }
         },
         colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-            containerColor = MaterialTheme.colorScheme.surface,
+            containerColor = KptTheme.colorScheme.surface,
         ),
         actions = actions,
         modifier = modifier,
@@ -120,7 +119,7 @@ fun MifosRoundedTopAppBar(
                 Text(
                     text = title,
                     style = MifosTypography.titleMedium,
-                    color = MaterialTheme.colorScheme.onBackground,
+                    color = KptTheme.colorScheme.onBackground,
                 )
             }
         },
@@ -134,7 +133,7 @@ fun MifosRoundedTopAppBar(
                         painter = painterResource(brandIcon),
                         contentDescription = "Brand Icon",
                         modifier = Modifier
-                            .size(96.dp, 28.dp)
+                            .size(DesignToken.sizes.imageDp96, DesignToken.sizes.imageDp28)
                             .align(Alignment.TopStart),
                     )
                 }
@@ -150,18 +149,18 @@ fun MifosRoundedTopAppBar(
             }
         },
         colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-            containerColor = MaterialTheme.colorScheme.surface,
+            containerColor = KptTheme.colorScheme.surface,
         ),
         modifier = modifier
             .fillMaxWidth()
             .shadow(
                 elevation = DesignToken.elevation.elevation,
                 shape = DesignToken.shapes.topBar,
-                spotColor = MaterialTheme.colorScheme.onSurface,
-                ambientColor = MaterialTheme.colorScheme.onSurface,
+                spotColor = KptTheme.colorScheme.onSurface,
+                ambientColor = KptTheme.colorScheme.onSurface,
             )
             .clip(DesignToken.shapes.topBar)
-            .background(MaterialTheme.colorScheme.surface),
+            .background(KptTheme.colorScheme.surface),
     )
 }
 

--- a/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/scrollbar/AppScrollbars.kt
+++ b/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/scrollbar/AppScrollbars.kt
@@ -27,7 +27,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
@@ -53,6 +52,8 @@ import kotlinx.coroutines.delay
 import org.mifos.mobile.core.designsystem.component.scrollbar.ThumbState.Active
 import org.mifos.mobile.core.designsystem.component.scrollbar.ThumbState.Dormant
 import org.mifos.mobile.core.designsystem.component.scrollbar.ThumbState.Inactive
+import org.mifos.mobile.core.designsystem.theme.DesignToken
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * The time period for showing the scrollbar thumb after interacting with it, before it fades away
@@ -130,8 +131,8 @@ private fun ScrollableState.DraggableScrollbarThumb(
         modifier = Modifier
             .run {
                 when (orientation) {
-                    Vertical -> width(12.dp).fillMaxHeight()
-                    Horizontal -> height(12.dp).fillMaxWidth()
+                    Vertical -> width(DesignToken.sizes.boxDp12).fillMaxHeight()
+                    Horizontal -> height(DesignToken.sizes.boxDp12).fillMaxWidth()
                 }
             }
             .scrollThumb(this, interactionSource),
@@ -150,8 +151,8 @@ private fun ScrollableState.DecorativeScrollbarThumb(
         modifier = Modifier
             .run {
                 when (orientation) {
-                    Vertical -> width(2.dp).fillMaxHeight()
-                    Horizontal -> height(2.dp).fillMaxWidth()
+                    Vertical -> width(DesignToken.strokes.dp2).fillMaxHeight()
+                    Horizontal -> height(DesignToken.strokes.dp2).fillMaxWidth()
                 }
             }
             .scrollThumb(this, interactionSource),
@@ -181,6 +182,7 @@ private data class ScrollThumbElement(val colorProducer: ColorProducer) :
     }
 }
 
+// TODO use KptTheme for shapes, using it directly throws error
 private class ScrollThumbNode(var colorProducer: ColorProducer) : DrawModifierNode,
     Modifier.Node() {
     private val shape = RoundedCornerShape(16.dp)
@@ -224,8 +226,8 @@ private fun scrollbarThumbColor(
 
     val color = animateColorAsState(
         targetValue = when (state) {
-            Active -> MaterialTheme.colorScheme.onSurface.copy(0.5f)
-            Inactive -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f)
+            Active -> KptTheme.colorScheme.onSurface.copy(0.5f)
+            Inactive -> KptTheme.colorScheme.onSurface.copy(alpha = 0.2f)
             Dormant -> Color.Transparent
         },
         animationSpec = SpringSpec(

--- a/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/scrollbar/Scrollbar.kt
+++ b/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/component/scrollbar/Scrollbar.kt
@@ -42,13 +42,13 @@ import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.packFloats
 import androidx.compose.ui.util.unpackFloat1
 import androidx.compose.ui.util.unpackFloat2
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeout
+import org.mifos.mobile.core.designsystem.theme.DesignToken
 import kotlin.jvm.JvmInline
 import kotlin.math.max
 import kotlin.math.min
@@ -192,7 +192,7 @@ fun Scrollbar(
     state: ScrollbarState,
     modifier: Modifier = Modifier,
     interactionSource: MutableInteractionSource? = null,
-    minThumbSize: Dp = 40.dp,
+    minThumbSize: Dp = DesignToken.sizes.minThumbSizeDp40,
     onThumbMoved: ((Float) -> Unit)? = null,
     thumb: @Composable () -> Unit,
 ) {

--- a/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/theme/DesignToken.kt
+++ b/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/theme/DesignToken.kt
@@ -97,6 +97,9 @@ data class AppSpacing(
     val extraExtraLarge: Dp = 48.dp,
     val full: Dp = 1000.dp,
     // custom spacings
+    val negativeDp7: Dp = (-7).dp,
+    val dp2: Dp = 2.dp,
+    val dp5: Dp = 5.dp,
     val dp6: Dp = 6.dp,
     val dp10: Dp = 10.dp,
     val dp24: Dp = 24.dp,
@@ -151,7 +154,10 @@ data class AppPadding(
     val full: Dp = 1000.dp,
     // custom paddings
     val dp2: Dp = 2.dp,
+    val dp6: Dp = 6.dp,
+    val dp10: Dp = 10.dp,
     val dp14: Dp = 14.dp,
+    val dp56: Dp = 56.dp,
     val dp75: Dp = 75.dp,
     val dp100: Dp = 100.dp,
 )
@@ -210,7 +216,10 @@ data class AppShapes(
     val bottomSheet: Shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp),
     val topBar: Shape = RoundedCornerShape(bottomStart = 16.dp, bottomEnd = 16.dp),
     // custom shapes
+    val topCornerDp8: Shape = RoundedCornerShape(topStart = 8.dp, topEnd = 8.dp),
     val topCornerDp16: Shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
+    val bottomCornerDp12: Shape = RoundedCornerShape(bottomStart = 12.dp, bottomEnd = 12.dp),
+    val dp2: Shape = RoundedCornerShape(2.dp),
     val dp25: Shape = RoundedCornerShape(25.dp),
     val dp100: Shape = RoundedCornerShape(100.dp),
 )
@@ -253,6 +262,7 @@ data class AppElevation(
     val elevation: Dp = 25.dp,
     // custom elevation
     val dp6: Dp = 6.dp,
+    val dp2: Dp = 2.dp,
 )
 
 /**
@@ -300,7 +310,7 @@ data class AppElevation(
  */
 @Immutable
 data class AppSizes(
-    val iconMiny: Dp = 12.dp,
+    val iconTiny: Dp = 12.dp,
     val iconSmall: Dp = 16.dp,
     val iconMedium: Dp = 24.dp,
     val iconLarge: Dp = 32.dp,
@@ -314,9 +324,15 @@ data class AppSizes(
     val profile: Dp = 72.dp,
     val headerToContentHeight: Dp = 28.dp,
     // custom sizes
+    val iconDp39: Dp = 39.dp,
+    val iconDp100: Dp = 100.dp,
     val checkboxDp18: Dp = 18.dp,
+    val imageDp14: Dp = 14.dp,
+    val imageDp28: Dp = 28.dp,
     val imageDp48: Dp = 48.dp,
+    val imageDp50: Dp = 50.dp,
     val imageDp60: Dp = 60.dp,
+    val imageDp96: Dp = 96.dp,
     val imageDp100: Dp = 100.dp,
     val imageDp128: Dp = 128.dp,
     val imageDp140: Dp = 140.dp,
@@ -325,16 +341,34 @@ data class AppSizes(
     val imageDp212: Dp = 212.dp,
     val iconDp20: Dp = 20.dp,
     val cardDp64: Dp = 64.dp,
+    val cardDp112: Dp = 112.dp,
     val cardDp128: Dp = 128.dp,
+    val boxDp4: Dp = 4.dp,
+    val boxDp12: Dp = 12.dp,
+    val boxDp36: Dp = 36.dp,
     val boxDp41: Dp = 41.dp,
+    val boxDp76: Dp = 76.dp,
+    val boxDp128: Dp = 128.dp,
+    val boxDp100: Dp = 100.dp,
     val boxDp107: Dp = 107.33333.dp,
     val buttonDp50: Dp = 50.dp,
     val surfaceDp40: Dp = 40.dp,
+    val minThumbSizeDp40: Dp = 40.dp,
+    val lazyColHeightInDp500: Dp = 500.dp,
+    val rippleRadiusDp24: Dp = 24.dp,
+    val textDp40: Dp = 40.dp,
+    val surfaceColWidthInDp80: Dp = 80.dp,
+    val dropDownMenuHeightInDp200: Dp = 200.dp,
+    val backgroundDp100: Dp = 100.dp,
+    val buttonHeightDp48: Dp = 48.dp,
+    val stepIndicatorDp40: Dp = 40.dp,
 )
 
 @Immutable
 data class AppStrokes(
+    val dpPoint5: Dp = 0.5.dp,
     val thin: Dp = 1.dp,
+    val dp2: Dp = 2.dp,
     val dp5: Dp = 5.dp,
 )
 

--- a/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/theme/MifosBackground.kt
+++ b/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/theme/MifosBackground.kt
@@ -18,8 +18,8 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import template.core.base.designsystem.theme.KptTheme
 
 /**
  * The main background for the app.
@@ -37,10 +37,10 @@ fun MifosBackground(
     val tonalElevation = LocalBackgroundTheme.current.tonalElevation
     Surface(
         color = if (color == Color.Unspecified) Color.Transparent else color,
-        tonalElevation = if (tonalElevation == Dp.Unspecified) 0.dp else tonalElevation,
+        tonalElevation = if (tonalElevation == Dp.Unspecified) KptTheme.elevation.level0 else tonalElevation,
         modifier = modifier.fillMaxSize(),
     ) {
-        CompositionLocalProvider(LocalAbsoluteTonalElevation provides 0.dp) {
+        CompositionLocalProvider(LocalAbsoluteTonalElevation provides KptTheme.elevation.level0) {
             content()
         }
     }
@@ -57,7 +57,7 @@ annotation class ThemePreview
 @Composable
 fun BackgroundDefault() {
     MifosMobileTheme {
-        MifosBackground(Modifier.size(100.dp), content = {})
+        MifosBackground(Modifier.size(DesignToken.sizes.backgroundDp100), content = {})
     }
 }
 
@@ -65,7 +65,7 @@ fun BackgroundDefault() {
 @Composable
 fun BackgroundDynamic() {
     MifosMobileTheme {
-        MifosBackground(Modifier.size(100.dp), content = {})
+        MifosBackground(Modifier.size(DesignToken.sizes.backgroundDp100), content = {})
     }
 }
 
@@ -73,6 +73,6 @@ fun BackgroundDynamic() {
 @Composable
 fun BackgroundAndroid() {
     MifosMobileTheme {
-        MifosBackground(Modifier.size(100.dp), content = {})
+        MifosBackground(Modifier.size(DesignToken.sizes.backgroundDp100), content = {})
     }
 }

--- a/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/theme/Theme.kt
@@ -11,13 +11,15 @@ package org.mifos.mobile.core.designsystem.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.ColorScheme
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
-import org.mifos.mobile.core.designsystem.theme.DesignToken.spacing
+import template.core.base.designsystem.KptMaterialTheme
+import template.core.base.designsystem.theme.KptThemeProviderImpl
+import template.core.base.designsystem.toKptColorScheme
+import template.core.base.designsystem.toKptTypography
 
 val lightScheme = lightColorScheme(
     primary = primaryLight,
@@ -270,21 +272,22 @@ fun MifosMobileTheme(
     content: @Composable () -> Unit,
 ) {
     val colorScheme = when {
-        androidTheme -> if (darkTheme) darkScheme else lightScheme
-        else -> colorScheme(darkTheme, shouldDisplayDynamicTheming)
-    }
+        shouldDisplayDynamicTheming -> colorScheme(darkTheme, true)
+        androidTheme -> if (darkTheme) darkColorScheme() else lightColorScheme()
+        else -> if (darkTheme) darkScheme else lightScheme
+    }.toKptColorScheme()
 
-    MaterialTheme(
-        colorScheme = colorScheme,
-        typography = appTypography(),
-    ) {
-        DesignTokenTheme(
-            spacing = spacing,
-            shapes = AppShapes(),
-            elevation = AppElevation(),
-            content = content,
-        )
-    }
+    val typography = appTypography().toKptTypography()
+
+    val theme = KptThemeProviderImpl(
+        colors = colorScheme,
+        typography = typography,
+    )
+
+    KptMaterialTheme(
+        theme = theme,
+        content = content,
+    )
 }
 
 @Composable

--- a/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/utils/NonLetterColorVisualTransformation.kt
+++ b/core/designsystem/src/commonMain/kotlin/org/mifos/mobile/core/designsystem/utils/NonLetterColorVisualTransformation.kt
@@ -9,7 +9,6 @@
  */
 package org.mifos.mobile.core.designsystem.utils
 
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
@@ -19,11 +18,12 @@ import androidx.compose.ui.text.input.OffsetMapping
 import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.withStyle
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun nonLetterColorVisualTransformation(): VisualTransformation {
-    val digitColor = MaterialTheme.colorScheme.primary
-    val specialCharacterColor = MaterialTheme.colorScheme.error
+    val digitColor = KptTheme.colorScheme.primary
+    val specialCharacterColor = KptTheme.colorScheme.error
     return remember(digitColor, specialCharacterColor) {
         NonLetterColorVisualTransformation(
             digitColor = digitColor,

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/PasswordStrengthIndicator.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/PasswordStrengthIndicator.kt
@@ -27,11 +27,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -44,7 +42,6 @@ import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -52,6 +49,7 @@ import org.mifos.mobile.core.designsystem.icon.MifosIcons
 import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
+import template.core.base.designsystem.theme.KptTheme
 
 @Suppress("LongMethod", "CyclomaticComplexMethod", "MagicNumber")
 @Composable
@@ -74,11 +72,11 @@ fun PasswordStrengthIndicator(
         label = "Width Percent State",
     )
     val indicatorColor = when (state) {
-        PasswordStrengthState.NONE -> MaterialTheme.colorScheme.error
-        PasswordStrengthState.WEAK_1 -> MaterialTheme.colorScheme.error
-        PasswordStrengthState.WEAK_2 -> MaterialTheme.colorScheme.error
+        PasswordStrengthState.NONE -> KptTheme.colorScheme.error
+        PasswordStrengthState.WEAK_1 -> KptTheme.colorScheme.error
+        PasswordStrengthState.WEAK_2 -> KptTheme.colorScheme.error
         PasswordStrengthState.WEAK_3 -> weakColor
-        PasswordStrengthState.GOOD -> MaterialTheme.colorScheme.primary
+        PasswordStrengthState.GOOD -> KptTheme.colorScheme.primary
         PasswordStrengthState.STRONG -> strongColor
         PasswordStrengthState.VERY_STRONG -> Color.Magenta
     }
@@ -101,14 +99,14 @@ fun PasswordStrengthIndicator(
         Box(
             Modifier
                 .fillMaxWidth()
-                .height(4.dp)
-                .background(MaterialTheme.colorScheme.surfaceContainerHigh),
+                .height(DesignToken.sizes.boxDp4)
+                .background(KptTheme.colorScheme.surfaceContainerHigh),
         ) {
             Box(
                 modifier = Modifier
                     .fillMaxHeight()
                     .fillMaxWidth()
-                    .clip(RoundedCornerShape(2.dp))
+                    .clip(DesignToken.shapes.dp2)
                     .graphicsLayer {
                         transformOrigin = TransformOrigin(pivotFractionX = 0f, pivotFractionY = 0f)
                         scaleX = widthPercent
@@ -118,7 +116,7 @@ fun PasswordStrengthIndicator(
                     },
             )
         }
-        Spacer(Modifier.height(4.dp))
+        Spacer(Modifier.height(KptTheme.spacing.xs))
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,
@@ -132,7 +130,7 @@ fun PasswordStrengthIndicator(
             }
             Text(
                 text = label,
-                style = MaterialTheme.typography.labelSmall,
+                style = KptTheme.typography.labelSmall,
                 color = indicatorColor,
             )
         }
@@ -149,7 +147,7 @@ private fun MinimumCharacterCount(
         targetValue = if (minimumRequirementMet) {
             strongColor
         } else {
-            MaterialTheme.colorScheme.surfaceDim
+            KptTheme.colorScheme.surfaceDim
         },
         label = "minimumCharacterCountColor",
     )
@@ -169,14 +167,14 @@ private fun MinimumCharacterCount(
                 imageVector = it,
                 contentDescription = null,
                 tint = characterCountColor,
-                modifier = Modifier.size(12.dp),
+                modifier = Modifier.size(DesignToken.sizes.iconTiny),
             )
         }
-        Spacer(modifier = Modifier.width(2.dp))
+        Spacer(modifier = Modifier.width(DesignToken.spacing.dp2))
         Text(
             text = "$minimumCharacterCount characters",
             color = characterCountColor,
-            style = MaterialTheme.typography.labelSmall,
+            style = KptTheme.typography.labelSmall,
         )
     }
 }
@@ -207,13 +205,13 @@ fun CombinedPasswordErrorCard(
     )
 
     val indicatorColor = when (passwordStrengthState) {
-        PasswordStrengthState.NONE -> MaterialTheme.colorScheme.error
-        PasswordStrengthState.WEAK_1 -> MaterialTheme.colorScheme.error
-        PasswordStrengthState.WEAK_2 -> MaterialTheme.colorScheme.error
+        PasswordStrengthState.NONE -> KptTheme.colorScheme.error
+        PasswordStrengthState.WEAK_1 -> KptTheme.colorScheme.error
+        PasswordStrengthState.WEAK_2 -> KptTheme.colorScheme.error
         PasswordStrengthState.WEAK_3 -> weakColor
         PasswordStrengthState.GOOD -> Color.Magenta
         PasswordStrengthState.STRONG -> strongColor
-        PasswordStrengthState.VERY_STRONG -> MaterialTheme.colorScheme.primary
+        PasswordStrengthState.VERY_STRONG -> KptTheme.colorScheme.primary
     }
 
     val animatedIndicatorColor by animateColorAsState(
@@ -236,13 +234,13 @@ fun CombinedPasswordErrorCard(
             modifier = modifier
                 .fillMaxWidth()
                 .testTag("passwordErrorCard"),
-            shape = DesignToken.shapes.medium,
+            shape = KptTheme.shapes.medium,
             colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.error.copy(alpha = 0.05f),
+                containerColor = KptTheme.colorScheme.error.copy(alpha = 0.05f),
             ),
             border = BorderStroke(
-                width = 1.dp,
-                color = MaterialTheme.colorScheme.error.copy(alpha = 0.2f),
+                width = DesignToken.strokes.thin,
+                color = KptTheme.colorScheme.error.copy(alpha = 0.2f),
             ),
         ) {
             Column {
@@ -250,14 +248,14 @@ fun CombinedPasswordErrorCard(
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(4.dp)
-                        .background(MaterialTheme.colorScheme.surfaceContainerHigh),
+                        .height(DesignToken.sizes.boxDp4)
+                        .background(KptTheme.colorScheme.surfaceContainerHigh),
                 ) {
                     Box(
                         modifier = Modifier
                             .fillMaxHeight()
                             .fillMaxWidth()
-                            .clip(RoundedCornerShape(topStart = 8.dp, topEnd = 8.dp))
+                            .clip(DesignToken.shapes.topCornerDp8)
                             .graphicsLayer {
                                 transformOrigin = TransformOrigin(pivotFractionX = 0f, pivotFractionY = 0f)
                                 scaleX = widthPercent
@@ -269,8 +267,8 @@ fun CombinedPasswordErrorCard(
                 }
 
                 Column(
-                    modifier = Modifier.padding(12.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.padding(DesignToken.padding.medium),
+                    verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.xs),
                 ) {
                     // Header row with "Password Requirements" and strength label
                     Row(
@@ -280,18 +278,18 @@ fun CombinedPasswordErrorCard(
                     ) {
                         Row(
                             verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(6.dp),
+                            horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.dp6),
                         ) {
                             Icon(
                                 imageVector = MifosIcons.OutlinedInfo,
                                 contentDescription = "Error",
-                                tint = MaterialTheme.colorScheme.error,
-                                modifier = Modifier.size(16.dp),
+                                tint = KptTheme.colorScheme.error,
+                                modifier = Modifier.size(DesignToken.sizes.iconSmall),
                             )
                             Text(
                                 text = "Password Requirements",
                                 style = MifosTypography.labelMedium,
-                                color = MaterialTheme.colorScheme.error,
+                                color = KptTheme.colorScheme.error,
                                 fontWeight = FontWeight.Medium,
                             )
                         }
@@ -301,9 +299,9 @@ fun CombinedPasswordErrorCard(
                                 modifier = Modifier
                                     .background(
                                         color = animatedIndicatorColor,
-                                        shape = RoundedCornerShape(4.dp),
+                                        shape = KptTheme.shapes.extraSmall,
                                     )
-                                    .padding(horizontal = 8.dp, vertical = 4.dp),
+                                    .padding(horizontal = KptTheme.spacing.sm, vertical = KptTheme.spacing.xs),
                             ) {
                                 Text(
                                     text = strengthLabel,
@@ -330,21 +328,21 @@ fun CombinedPasswordErrorCard(
                                 .fillMaxWidth()
                                 .testTag("passwordError"),
                             verticalAlignment = Alignment.Top,
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.sm),
                         ) {
                             Box(
                                 modifier = Modifier
-                                    .size(4.dp)
+                                    .size(DesignToken.sizes.boxDp4)
                                     .background(
-                                        color = MaterialTheme.colorScheme.error,
+                                        color = KptTheme.colorScheme.error,
                                         shape = CircleShape,
                                     )
-                                    .padding(top = 6.dp),
+                                    .padding(top = DesignToken.padding.dp6),
                             )
                             Text(
                                 text = stringResource(it),
                                 style = MifosTypography.tag,
-                                color = MaterialTheme.colorScheme.error,
+                                color = KptTheme.colorScheme.error,
                                 modifier = Modifier.weight(1f),
                             )
                         }
@@ -358,23 +356,23 @@ fun CombinedPasswordErrorCard(
                                 .testTag("passwordError_$index"),
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.spacedBy(
-                                space = 8.dp,
+                                space = KptTheme.spacing.xs,
                                 alignment = Alignment.CenterHorizontally,
                             ),
                         ) {
                             Box(
                                 modifier = Modifier
-                                    .size(4.dp)
+                                    .size(DesignToken.sizes.boxDp4)
                                     .background(
-                                        color = MaterialTheme.colorScheme.error,
+                                        color = KptTheme.colorScheme.error,
                                         shape = CircleShape,
                                     )
-                                    .padding(top = 6.dp),
+                                    .padding(top = DesignToken.padding.dp6),
                             )
                             Text(
                                 text = stringResource(error),
                                 style = MifosTypography.tag,
-                                color = MaterialTheme.colorScheme.error,
+                                color = KptTheme.colorScheme.error,
                                 modifier = Modifier.weight(1f),
                             )
                         }

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/AboutUsItemCard.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/AboutUsItemCard.kt
@@ -13,17 +13,16 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.ui.utils.DevicePreview
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun AboutUsItemCard(
@@ -33,26 +32,26 @@ fun AboutUsItemCard(
     modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = modifier.padding(16.dp),
+        modifier = modifier.padding(KptTheme.spacing.md),
     ) {
         iconUrl?.let { painterResource(it) }?.let {
             Icon(
                 painter = it,
                 contentDescription = "About Us Icon URL",
-                modifier = Modifier.padding(end = 8.dp),
+                modifier = Modifier.padding(end = KptTheme.spacing.sm),
             )
         }
         Column {
             Text(
                 text = title,
-                style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier.padding(end = 8.dp),
+                style = KptTheme.typography.bodyLarge,
+                modifier = Modifier.padding(end = KptTheme.spacing.sm),
             )
             if (subtitle != null) {
                 Text(
                     text = stringResource(subtitle),
-                    style = MaterialTheme.typography.bodyLarge,
-                    modifier = Modifier.padding(end = 8.dp),
+                    style = KptTheme.typography.bodyLarge,
+                    modifier = Modifier.padding(end = KptTheme.spacing.sm),
                 )
             }
         }

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/BeneficiariesListing.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/BeneficiariesListing.kt
@@ -35,6 +35,7 @@ import org.mifos.mobile.core.designsystem.theme.MifosTypography
 import org.mifos.mobile.core.model.entity.beneficiary.Beneficiary
 import org.mifos.mobile.core.model.entity.templates.account.AccountType
 import org.mifos.mobile.core.ui.utils.DevicePreview
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun MifosBeneficiariesCard(
@@ -47,7 +48,7 @@ fun MifosBeneficiariesCard(
             .fillMaxWidth()
             .clickable { onBeneficiaryClick() }
             .padding(
-                DesignToken.padding.large,
+                KptTheme.spacing.md,
             ),
     ) {
         Row(
@@ -68,7 +69,7 @@ fun MifosBeneficiariesCard(
 
             Column(
                 modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(DesignToken.padding.extraSmall),
+                verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.xs),
             ) {
                 Text(
                     text = beneficiary.name ?: "",

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/BeneficiaryCard.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/BeneficiaryCard.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -39,6 +38,7 @@ import org.mifos.mobile.core.designsystem.theme.MifosTypography
 import org.mifos.mobile.core.model.entity.beneficiary.Beneficiary
 import org.mifos.mobile.core.model.entity.templates.account.AccountType
 import org.mifos.mobile.core.ui.utils.DevicePreview
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun MifosBeneficiaryTopCard(
@@ -47,7 +47,7 @@ fun MifosBeneficiaryTopCard(
 ) {
     MifosCustomCard(
         modifier = modifier,
-        shape = MaterialTheme.shapes.medium,
+        shape = KptTheme.shapes.medium,
     ) {
         Box(
             modifier = Modifier.fillMaxWidth(),
@@ -60,7 +60,7 @@ fun MifosBeneficiaryTopCard(
                 contentScale = ContentScale.Crop,
             )
             Row(
-                Modifier.padding(DesignToken.padding.large),
+                Modifier.padding(KptTheme.spacing.md),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 // pass BitMap also once fetching client Image

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/EmptyDataView.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/EmptyDataView.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -25,7 +24,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import mifos_mobile.core.ui.generated.resources.Res
 import mifos_mobile.core.ui.generated.resources.no_internet
 import org.jetbrains.compose.resources.DrawableResource
@@ -37,6 +35,7 @@ import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
 import org.mifos.mobile.core.ui.utils.DevicePreview
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun EmptyDataView(
@@ -52,12 +51,12 @@ fun EmptyDataView(
     ) {
         Icon(
             modifier = Modifier
-                .size(50.dp),
+                .size(DesignToken.sizes.imageDp50),
             imageVector = icon,
             contentDescription = null,
             tint = Color.Unspecified,
         )
-        Spacer(modifier = Modifier.height(DesignToken.spacing.small))
+        Spacer(modifier = Modifier.height(KptTheme.spacing.sm))
         Text(
             text = errorString ?: stringResource(error),
             style = MifosTypography.titleSmallEmphasized,
@@ -81,17 +80,17 @@ fun EmptyDataView(
         image?.let {
             Icon(
                 modifier = Modifier
-                    .size(100.dp)
-                    .padding(bottom = 12.dp),
+                    .size(DesignToken.sizes.iconDp100)
+                    .padding(bottom = DesignToken.padding.medium),
                 painter = painterResource(it),
                 contentDescription = null,
             )
         }
 
         Text(
-            modifier = Modifier.padding(horizontal = 20.dp),
+            modifier = Modifier.padding(horizontal = DesignToken.padding.largeIncreased),
             text = errorString ?: stringResource(error),
-            style = MaterialTheme.typography.labelMedium,
+            style = KptTheme.typography.labelMedium,
             textAlign = TextAlign.Center,
         )
     }

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/FaqItemHolder.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/FaqItemHolder.kt
@@ -21,19 +21,18 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
-import androidx.compose.ui.unit.dp
 import org.mifos.mobile.core.designsystem.component.MifosCustomCard
 import org.mifos.mobile.core.designsystem.icon.MifosIcons
 import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
 import org.mifos.mobile.core.ui.utils.DevicePreview
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun FaqItemHolder(
@@ -48,9 +47,9 @@ fun FaqItemHolder(
         modifier = modifier
             .fillMaxWidth()
             .border(
-                width = 1.dp,
-                color = MaterialTheme.colorScheme.primary,
-                shape = MaterialTheme.shapes.medium,
+                width = DesignToken.strokes.thin,
+                color = KptTheme.colorScheme.primary,
+                shape = KptTheme.shapes.medium,
             ),
     ) {
         Row(
@@ -67,7 +66,7 @@ fun FaqItemHolder(
                 modifier = Modifier
                     .fillMaxWidth()
                     .weight(1f),
-                color = MaterialTheme.colorScheme.primary,
+                color = KptTheme.colorScheme.primary,
             )
 
             Icon(
@@ -88,7 +87,7 @@ fun FaqItemHolder(
         ) {
             Text(
                 text = answer.orEmpty(),
-                style = MaterialTheme.typography.bodyMedium,
+                style = KptTheme.typography.bodyMedium,
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(all = DesignToken.padding.medium),

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/FiterTopSection.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/FiterTopSection.kt
@@ -15,12 +15,10 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import mifos_mobile.core.ui.generated.resources.Res
 import mifos_mobile.core.ui.generated.resources.feature_savings_apply
 import mifos_mobile.core.ui.generated.resources.feature_savings_filter
@@ -29,6 +27,7 @@ import org.jetbrains.compose.resources.stringResource
 import org.mifos.mobile.core.designsystem.icon.MifosIcons
 import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun FilterTopSection(
@@ -39,9 +38,9 @@ fun FilterTopSection(
     modifier: Modifier = Modifier,
 ) {
     val resetColor = if (isAnyFilterSelected) {
-        MaterialTheme.colorScheme.primary
+        KptTheme.colorScheme.primary
     } else {
-        MaterialTheme.colorScheme.inversePrimary
+        KptTheme.colorScheme.inversePrimary
     }
     Row(
         modifier = modifier.fillMaxWidth(),
@@ -49,11 +48,11 @@ fun FilterTopSection(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Row(
-            horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.small),
+            horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.sm),
         ) {
             Icon(
                 modifier = Modifier
-                    .size(20.dp)
+                    .size(DesignToken.sizes.iconDp20)
                     .clickable { dismissDialog.invoke() },
                 imageVector = MifosIcons.Dismiss,
                 contentDescription = null,
@@ -61,7 +60,7 @@ fun FilterTopSection(
             Text(
                 text = stringResource(Res.string.feature_savings_filter),
                 style = MifosTypography.titleMedium,
-                color = MaterialTheme.colorScheme.onBackground,
+                color = KptTheme.colorScheme.onBackground,
             )
         }
 
@@ -91,7 +90,7 @@ fun FilterTopSection(
                 )
 
                 Icon(
-                    modifier = Modifier.size(20.dp),
+                    modifier = Modifier.size(DesignToken.sizes.iconDp20),
                     imageVector = MifosIcons.ArrowCounterClockWise,
                     contentDescription = null,
                     tint = resetColor,
@@ -111,11 +110,11 @@ fun FilterTopSection(
 
                     text = stringResource(Res.string.feature_savings_apply),
                     style = MifosTypography.bodySmallEmphasized,
-                    color = MaterialTheme.colorScheme.primary,
+                    color = KptTheme.colorScheme.primary,
                 )
 
                 Icon(
-                    modifier = Modifier.size(20.dp),
+                    modifier = Modifier.size(DesignToken.sizes.iconDp20),
                     imageVector = MifosIcons.CheckMark,
                     contentDescription = null,
                 )

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MFStepProcess.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MFStepProcess.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
+import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.ui.utils.DevicePreview
 
@@ -45,6 +46,7 @@ fun MFStepProcess(
     processState: StepProcessState = StepProcessState.INACTIVE,
     content: @Composable (Modifier) -> Unit,
 ) {
+    // TODO use DesignToken, currently it throws error
     var barHeight by remember { mutableStateOf(0.dp) }
     val localDensity = LocalDensity.current
 
@@ -52,7 +54,7 @@ fun MFStepProcess(
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Column(
                 modifier = Modifier
-                    .size(40.dp)
+                    .size(DesignToken.sizes.stepIndicatorDp40)
                     .clip(CircleShape)
                     .background(
                         color = if (processState == StepProcessState.INACTIVE) {
@@ -72,7 +74,7 @@ fun MFStepProcess(
                 Box(
                     modifier = Modifier
                         .height(barHeight)
-                        .width(4.dp)
+                        .width(DesignToken.sizes.boxDp4)
                         .background(
                             color = if (processState == StepProcessState.INACTIVE) {
                                 deactivateColor
@@ -85,7 +87,7 @@ fun MFStepProcess(
         }
         content(
             Modifier
-                .padding(start = 10.dp, end = 6.dp)
+                .padding(start = DesignToken.padding.dp10, end = DesignToken.padding.dp6)
                 .onGloballyPositioned { barHeight = with(localDensity) { it.size.height.toDp() } },
         )
     }

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosAccountCard.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosAccountCard.kt
@@ -23,20 +23,19 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.mifos.mobile.core.designsystem.icon.MifosIcons
 import org.mifos.mobile.core.designsystem.theme.AppColors
 import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun MifosAccountCard(
@@ -64,13 +63,13 @@ fun MifosAccountCard(
             Icon(
                 imageVector = icon,
                 contentDescription = "Person Account",
-                tint = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.3f),
+                tint = KptTheme.colorScheme.onBackground.copy(alpha = 0.3f),
                 modifier = Modifier
                     .background(
-                        color = MaterialTheme.colorScheme.background.copy(alpha = 0.5f),
+                        color = KptTheme.colorScheme.background.copy(alpha = 0.5f),
                         shape = CircleShape,
                     )
-                    .padding(DesignToken.padding.small),
+                    .padding(KptTheme.spacing.sm),
 
             )
 
@@ -82,12 +81,12 @@ fun MifosAccountCard(
                 Text(
                     text = accountNumber ?: "",
                     style = MifosTypography.titleSmallEmphasized,
-                    color = MaterialTheme.colorScheme.onBackground,
+                    color = KptTheme.colorScheme.onBackground,
                 )
                 Text(
                     text = accountType ?: "",
                     style = MifosTypography.bodySmall,
-                    color = MaterialTheme.colorScheme.secondary,
+                    color = KptTheme.colorScheme.secondary,
                 )
             }
 
@@ -95,7 +94,7 @@ fun MifosAccountCard(
 
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(DesignToken.spacing.extraSmall),
+                horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.xs),
             ) {
                 Text(
                     text = accountStatus,
@@ -105,7 +104,7 @@ fun MifosAccountCard(
                 Icon(
                     imageVector = MifosIcons.ChevronRight,
                     contentDescription = null,
-                    modifier = Modifier.size(20.dp),
+                    modifier = Modifier.size(DesignToken.sizes.iconDp20),
                 )
             }
         }
@@ -119,7 +118,7 @@ private fun Savings_Account_Preview() {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(DesignToken.padding.large),
+                .padding(KptTheme.spacing.md),
         ) {
             MifosAccountCard(
                 accountId = 1L,

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosActionCard.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosActionCard.kt
@@ -23,13 +23,11 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.unit.dp
 import mifos_mobile.core.ui.generated.resources.Res
 import mifos_mobile.core.ui.generated.resources.savings_account
 import org.jetbrains.compose.resources.StringResource
@@ -39,6 +37,7 @@ import org.mifos.mobile.core.designsystem.icon.MifosIcons
 import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun MifosActionCard(
@@ -63,13 +62,13 @@ fun MifosActionCard(
             Icon(
                 imageVector = icon,
                 contentDescription = null,
-                tint = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
+                tint = KptTheme.colorScheme.onBackground.copy(alpha = 0.5f),
                 modifier = Modifier
                     .background(
-                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.1f),
+                        color = KptTheme.colorScheme.onBackground.copy(alpha = 0.1f),
                         shape = CircleShape,
                     )
-                    .padding(DesignToken.padding.small),
+                    .padding(KptTheme.spacing.sm),
 
             )
 
@@ -81,12 +80,12 @@ fun MifosActionCard(
                 Text(
                     text = stringResource(title),
                     style = MifosTypography.titleSmallEmphasized,
-                    color = MaterialTheme.colorScheme.onBackground,
+                    color = KptTheme.colorScheme.onBackground,
                 )
                 Text(
                     text = stringResource(subTitle),
                     style = MifosTypography.bodySmall,
-                    color = MaterialTheme.colorScheme.secondary,
+                    color = KptTheme.colorScheme.secondary,
                 )
             }
 
@@ -95,7 +94,7 @@ fun MifosActionCard(
             Icon(
                 imageVector = MifosIcons.ChevronRight,
                 contentDescription = null,
-                modifier = Modifier.size(20.dp),
+                modifier = Modifier.size(DesignToken.sizes.iconDp20),
             )
         }
     }
@@ -108,7 +107,7 @@ private fun Savings_Action_Preview() {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(DesignToken.padding.large),
+                .padding(KptTheme.spacing.md),
         ) {
             MifosActionCard(
                 title = Res.string.savings_account,

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosDashboardCard.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosDashboardCard.kt
@@ -28,11 +28,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -41,7 +39,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import mifos_mobile.core.ui.generated.resources.Res
 import mifos_mobile.core.ui.generated.resources.feature_dashboard_no_accounts_description
 import mifos_mobile.core.ui.generated.resources.feature_dashboard_no_accounts_title
@@ -60,6 +57,7 @@ import org.mifos.mobile.core.designsystem.theme.AppColors
 import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
+import template.core.base.designsystem.theme.KptTheme
 
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
@@ -76,8 +74,8 @@ fun MifosDashboardCard(
 ) {
     Box(
         modifier = modifier
-            .clip(RoundedCornerShape(16.dp))
-            .height(if (isSingleLine) 76.dp else 128.dp)
+            .clip(KptTheme.shapes.large)
+            .height(if (isSingleLine) DesignToken.sizes.boxDp76 else DesignToken.sizes.boxDp128)
             .fillMaxWidth(),
     ) {
         Image(
@@ -90,7 +88,7 @@ fun MifosDashboardCard(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(DesignToken.padding.small),
+                .padding(KptTheme.spacing.sm),
             horizontalArrangement = Arrangement.spacedBy(
                 DesignToken.spacing.medium,
                 Alignment.End,
@@ -107,7 +105,7 @@ fun MifosDashboardCard(
                         Text(
                             text = stringResource(loanAccount),
                             style = MifosTypography.bodySmall,
-//                            color = MaterialTheme.colorScheme.secondary.copy(alpha = 0.7f),
+//                            color = KptTheme.colorScheme.secondary.copy(alpha = 0.7f),
                             color = AppColors.customWhite.copy(alpha = 0.5f),
                         )
                         AnimatedContent(
@@ -131,7 +129,7 @@ fun MifosDashboardCard(
                         Text(
                             text = stringResource(savingsAccount),
                             style = MifosTypography.bodySmall,
-//                            color = MaterialTheme.colorScheme.secondary,
+//                            color = KptTheme.colorScheme.secondary,
                             color = AppColors.customWhite.copy(alpha = 0.5f),
                         )
                         AnimatedContent(
@@ -156,7 +154,7 @@ fun MifosDashboardCard(
             onClick = onVisibilityToggle,
             modifier = Modifier
                 .align(Alignment.BottomEnd)
-                .padding(12.dp),
+                .padding(DesignToken.padding.medium),
         ) {
             Icon(
                 imageVector = if (isVisible) MifosIcons.Eye else MifosIcons.EyeOff,
@@ -176,22 +174,22 @@ fun MifosAccountApplyDashboard(
         modifier = modifier
             .padding(horizontal = DesignToken.padding.largeIncreased)
             .border(
-                0.5.dp,
-                MaterialTheme.colorScheme.primary,
-                DesignToken.shapes.medium,
+                DesignToken.strokes.dpPoint5,
+                KptTheme.colorScheme.primary,
+                KptTheme.shapes.medium,
             ),
         variant = CardVariant.OUTLINED,
         enabled = false,
         onClick = onOpenAccountClick,
         colors = CardDefaults.cardColors(
             containerColor = Color.Transparent,
-            contentColor = MaterialTheme.colorScheme.onSurface,
+            contentColor = KptTheme.colorScheme.onSurface,
         ),
     ) {
         Column(
             modifier = Modifier
                 .background(
-                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.01f),
+                    KptTheme.colorScheme.onSurface.copy(alpha = 0.01f),
                 )
                 .fillMaxWidth()
                 .padding(DesignToken.padding.extraLarge),
@@ -208,14 +206,14 @@ fun MifosAccountApplyDashboard(
             Text(
                 text = stringResource(Res.string.feature_dashboard_no_accounts_title),
                 style = MifosTypography.titleMediumEmphasized,
-                color = MaterialTheme.colorScheme.onSurface,
+                color = KptTheme.colorScheme.onSurface,
                 textAlign = TextAlign.Center,
             )
 
             Text(
                 text = stringResource(Res.string.feature_dashboard_no_accounts_description),
                 style = MifosTypography.bodySmall,
-                color = MaterialTheme.colorScheme.secondary,
+                color = KptTheme.colorScheme.secondary,
                 textAlign = TextAlign.Center,
             )
 
@@ -242,7 +240,7 @@ private fun MifosDashboardCard() {
     MifosMobileTheme {
         Column(
             modifier = Modifier.fillMaxSize(),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
+            verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.md),
         ) {
             MifosDashboardCard(
                 isVisible = true,

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosDetailsCard.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosDetailsCard.kt
@@ -15,18 +15,17 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 import org.mifos.mobile.core.designsystem.component.CardVariant
 import org.mifos.mobile.core.designsystem.component.MifosCustomCard
 import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
+import template.core.base.designsystem.theme.KptTheme
 import kotlin.collections.component1
 import kotlin.collections.component2
 
@@ -40,18 +39,18 @@ fun MifosDetailsCard(
         modifier = modifier
             .fillMaxWidth()
             .border(
-                1.dp,
-                MaterialTheme.colorScheme.secondaryContainer,
-                DesignToken.shapes.medium,
+                DesignToken.strokes.thin,
+                KptTheme.colorScheme.secondaryContainer,
+                KptTheme.shapes.medium,
             ),
-        shape = DesignToken.shapes.medium,
+        shape = KptTheme.shapes.medium,
     ) {
-        Column(modifier = Modifier.padding(DesignToken.padding.large)) {
+        Column(modifier = Modifier.padding(KptTheme.spacing.md)) {
             keyValuePairs.forEach { (key, value) ->
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(vertical = DesignToken.padding.small),
+                        .padding(vertical = KptTheme.spacing.sm),
                     horizontalArrangement = Arrangement.SpaceBetween,
                 ) {
                     Text(

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosDropDownPayFromComponent.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosDropDownPayFromComponent.kt
@@ -24,9 +24,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -37,7 +35,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import mifos_mobile.core.ui.generated.resources.Res
 import mifos_mobile.core.ui.generated.resources.available_balance
@@ -53,6 +50,7 @@ import org.mifos.mobile.core.designsystem.theme.AppColors
 import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun MifosPayFromDropdownUI(
@@ -87,11 +85,11 @@ fun MifosDropDownPayFromComponent(
     label: String,
     modifier: Modifier = Modifier,
 ) {
-    Box(modifier = modifier.padding(top = DesignToken.padding.small)) {
+    Box(modifier = modifier.padding(top = KptTheme.spacing.sm)) {
         Box(
             modifier = Modifier
-                .clip(DesignToken.shapes.large)
-                .height(128.dp)
+                .clip(KptTheme.shapes.large)
+                .height(DesignToken.sizes.boxDp128)
                 .fillMaxWidth(),
         ) {
             Image(
@@ -105,7 +103,7 @@ fun MifosDropDownPayFromComponent(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(
-                        horizontal = DesignToken.padding.large,
+                        horizontal = KptTheme.spacing.md,
                         vertical = DesignToken.padding.largeIncreased,
                     ),
                 verticalArrangement = Arrangement.SpaceBetween,
@@ -140,18 +138,18 @@ fun MifosDropDownPayFromComponent(
         Box(
             modifier = Modifier
                 .align(Alignment.TopStart)
-                .offset(x = 16.dp, y = (-DesignToken.padding.small))
+                .offset(x = KptTheme.spacing.md, y = (-KptTheme.spacing.sm))
                 .zIndex(1f)
                 .background(
-                    color = MaterialTheme.colorScheme.background,
-                    shape = DesignToken.shapes.medium,
+                    color = KptTheme.colorScheme.background,
+                    shape = KptTheme.shapes.medium,
                 )
-                .padding(horizontal = DesignToken.padding.small),
+                .padding(horizontal = KptTheme.spacing.sm),
         ) {
             Text(
                 text = label,
                 style = MifosTypography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                color = KptTheme.colorScheme.onSurfaceVariant,
             )
         }
     }
@@ -173,13 +171,13 @@ fun AccountDropdownItem(
         Text(
             text = accountNumber,
             style = MifosTypography.titleMediumEmphasized,
-            color = MaterialTheme.colorScheme.onPrimary,
+            color = KptTheme.colorScheme.onPrimary,
         )
-        Spacer(modifier = Modifier.height(DesignToken.padding.extraSmall))
+        Spacer(modifier = Modifier.height(KptTheme.spacing.xs))
         Text(
             text = balance,
             style = MifosTypography.bodySmall,
-            color = MaterialTheme.colorScheme.onPrimary,
+            color = KptTheme.colorScheme.onPrimary,
         )
     }
 }
@@ -196,8 +194,8 @@ fun AccountDropdownList(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(bottomStart = 12.dp, bottomEnd = 12.dp))
-            .background(MaterialTheme.colorScheme.tertiary),
+            .clip(DesignToken.shapes.bottomCornerDp12)
+            .background(KptTheme.colorScheme.tertiary),
     ) {
         Column(
             Modifier.fillMaxWidth(),
@@ -205,17 +203,17 @@ fun AccountDropdownList(
             Box(
                 Modifier
                     .fillMaxWidth()
-                    .height(DesignToken.padding.small)
-                    .clip(RoundedCornerShape(bottomStart = 12.dp, bottomEnd = 12.dp))
-                    .background(MaterialTheme.colorScheme.background),
+                    .height(KptTheme.spacing.sm)
+                    .clip(DesignToken.shapes.bottomCornerDp12)
+                    .background(KptTheme.colorScheme.background),
             )
             Row(
                 modifier = Modifier
-                    .padding(DesignToken.padding.small)
+                    .padding(KptTheme.spacing.sm)
                     .clickable { expanded = !expanded }
                     .align(Alignment.CenterHorizontally),
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(DesignToken.padding.extraSmall),
+                horizontalArrangement = Arrangement.spacedBy(KptTheme.spacing.xs),
             ) {
                 Text(
                     text = stringResource(Res.string.select_other_payment_account),
@@ -225,7 +223,7 @@ fun AccountDropdownList(
                 Icon(
                     imageVector = if (expanded) MifosIcons.ChevronUp else MifosIcons.ChevronDown,
                     contentDescription = "Arrow icon",
-                    modifier = Modifier.size(12.dp),
+                    modifier = Modifier.size(DesignToken.sizes.iconTiny),
                     tint = AppColors.customWhite,
                 )
             }
@@ -241,9 +239,9 @@ fun AccountDropdownList(
                         accountNumber = accountNumber,
                         balance = balance,
                         modifier = if (selectedAccount == accountNumber) {
-                            Modifier.background(MaterialTheme.colorScheme.onTertiaryContainer)
+                            Modifier.background(KptTheme.colorScheme.onTertiaryContainer)
                         } else {
-                            Modifier.background(MaterialTheme.colorScheme.tertiary)
+                            Modifier.background(KptTheme.colorScheme.tertiary)
                         },
                         onClick = {
                             expanded = !expanded
@@ -263,7 +261,7 @@ private fun MifosDropDownPayFromComponentPreview() {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(DesignToken.padding.large),
+                .padding(KptTheme.spacing.md),
         ) {
             MifosPayFromDropdownUI(
                 accounts = listOf(

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosDropDownTextField.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosDropDownTextField.kt
@@ -18,10 +18,8 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
-import androidx.compose.material3.OutlinedTextFieldDefaults.colors
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -32,14 +30,15 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.unit.dp
 import mifos_mobile.core.ui.generated.resources.Res
 import mifos_mobile.core.ui.generated.resources.retry
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 import org.mifos.mobile.core.designsystem.icon.MifosIcons
+import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.ui.utils.DevicePreview
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun MifosDropDownTextField(
@@ -72,7 +71,7 @@ fun MifosDropDownTextField(
                 .fillMaxWidth(),
             readOnly = true,
             enabled = isEnabled,
-            textStyle = MaterialTheme.typography.labelMedium,
+            textStyle = KptTheme.typography.labelMedium,
             supportingText = { if (error) Text(text = supportingText ?: "") },
             isError = error,
             trailingIcon = {
@@ -90,9 +89,9 @@ fun MifosDropDownTextField(
                 )
             },
             colors = OutlinedTextFieldDefaults.colors(
-                focusedBorderColor = MaterialTheme.colorScheme.secondaryContainer,
-                unfocusedBorderColor = MaterialTheme.colorScheme.secondaryContainer,
-                errorBorderColor = MaterialTheme.colorScheme.error,
+                focusedBorderColor = KptTheme.colorScheme.secondaryContainer,
+                unfocusedBorderColor = KptTheme.colorScheme.secondaryContainer,
+                errorBorderColor = KptTheme.colorScheme.error,
             ),
         )
 
@@ -100,7 +99,7 @@ fun MifosDropDownTextField(
             expanded = expanded && isEnabled,
             modifier = Modifier
                 .fillMaxWidth(0.92f)
-                .heightIn(max = 200.dp),
+                .heightIn(max = DesignToken.sizes.dropDownMenuHeightInDp200),
             onDismissRequest = { expanded = false },
         ) {
             optionsList.forEachIndexed { index, item ->
@@ -147,7 +146,7 @@ fun MifosDropDownDoubleTextField(
                 .fillMaxWidth(),
             readOnly = true,
             enabled = isEnabled,
-            textStyle = MaterialTheme.typography.labelSmall,
+            textStyle = KptTheme.typography.labelSmall,
             supportingText = { if (error) Text(text = supportingText ?: "") },
             isError = error,
             trailingIcon = {
@@ -165,9 +164,9 @@ fun MifosDropDownDoubleTextField(
                 )
             },
             colors = OutlinedTextFieldDefaults.colors(
-                focusedBorderColor = MaterialTheme.colorScheme.secondaryContainer,
-                unfocusedBorderColor = MaterialTheme.colorScheme.secondaryContainer,
-                errorBorderColor = MaterialTheme.colorScheme.error,
+                focusedBorderColor = KptTheme.colorScheme.secondaryContainer,
+                unfocusedBorderColor = KptTheme.colorScheme.secondaryContainer,
+                errorBorderColor = KptTheme.colorScheme.error,
             ),
         )
 
@@ -175,7 +174,7 @@ fun MifosDropDownDoubleTextField(
             expanded = expanded && isEnabled,
             modifier = Modifier
                 .fillMaxWidth(0.92f)
-                .heightIn(max = 200.dp),
+                .heightIn(max = DesignToken.sizes.dropDownMenuHeightInDp200),
             onDismissRequest = { expanded = false },
         ) {
             optionsList.forEachIndexed { index, item ->

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosErrorComponent.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosErrorComponent.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -26,7 +25,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import mifos_mobile.core.ui.generated.resources.Res
 import mifos_mobile.core.ui.generated.resources.no_data
@@ -40,6 +38,7 @@ import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
 import org.mifos.mobile.core.ui.utils.DevicePreview
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun MifosErrorComponent(
@@ -95,7 +94,7 @@ fun NoInternetComponent(
                     .height(DesignToken.sizes.buttonHeight)
                     .align(Alignment.CenterHorizontally),
                 onClick = { onRetry.invoke() },
-                shape = DesignToken.shapes.medium,
+                shape = KptTheme.shapes.medium,
             ) {
                 Text(
                     text = stringResource(Res.string.retry),
@@ -116,7 +115,7 @@ fun EmptyDataComponent(
 ) {
     Column(
         modifier = modifier.fillMaxSize()
-            .padding(DesignToken.padding.large),
+            .padding(KptTheme.spacing.md),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
@@ -146,7 +145,7 @@ fun EmptyDataComponent(
                     .height(DesignToken.sizes.inputHeight)
                     .align(Alignment.CenterHorizontally),
                 onClick = { onRetry.invoke() },
-                shape = DesignToken.shapes.medium,
+                shape = KptTheme.shapes.medium,
             ) {
                 Text(
                     text = stringResource(Res.string.retry),
@@ -171,18 +170,18 @@ fun EmptyDataComponentWithModifiedMessageAndIcon(
     ) {
         Icon(
             modifier = Modifier
-                .size(100.dp)
-                .padding(bottom = 12.dp),
+                .size(DesignToken.sizes.iconDp100)
+                .padding(bottom = DesignToken.padding.medium),
             imageVector = if (isEmptyData) icon else MifosIcons.Info,
             contentDescription = "Info Icon",
         )
 
         Text(
-            modifier = Modifier.padding(horizontal = 20.dp),
+            modifier = Modifier.padding(horizontal = DesignToken.padding.largeIncreased),
             text = if (isEmptyData) message else stringResource(Res.string.something_went_wrong),
             style = TextStyle(fontSize = 20.sp),
             textAlign = TextAlign.Center,
-            color = MaterialTheme.colorScheme.error,
+            color = KptTheme.colorScheme.error,
 
         )
     }

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosHiddenTextRow.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosHiddenTextRow.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -27,13 +26,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import mifos_mobile.core.ui.generated.resources.Res
 import mifos_mobile.core.ui.generated.resources.core_ui_money_in
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.painterResource
+import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.ui.utils.DevicePreview
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun MifosHiddenTextRow(
@@ -54,7 +54,7 @@ fun MifosHiddenTextRow(
     ) {
         Text(
             text = title,
-            style = MaterialTheme.typography.labelMedium,
+            style = KptTheme.typography.labelMedium,
             modifier = Modifier
                 .alpha(0.7f)
                 .weight(1f),
@@ -65,15 +65,15 @@ fun MifosHiddenTextRow(
             } else {
                 hiddenText
             },
-            style = MaterialTheme.typography.bodyLarge,
+            style = KptTheme.typography.bodyLarge,
             fontWeight = FontWeight.Bold,
             color = hiddenColor,
         )
         IconButton(
             onClick = { isHidden = !isHidden },
             modifier = Modifier
-                .padding(start = 6.dp)
-                .size(24.dp),
+                .padding(start = DesignToken.padding.dp6)
+                .size(DesignToken.sizes.iconMedium),
         ) {
             Icon(
                 painter = if (isHidden) {
@@ -96,7 +96,7 @@ fun MifosHiddenTextRowPreview(
         MifosHiddenTextRow(
             title = "Title",
             hiddenText = "Hidden Text",
-            hiddenColor = MaterialTheme.colorScheme.primary,
+            hiddenColor = KptTheme.colorScheme.primary,
             hidingText = "Hiding Text",
             visibilityIconId = Res.drawable.core_ui_money_in,
             visibilityOffIconId = Res.drawable.core_ui_money_in,

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosItemCard.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosItemCard.kt
@@ -12,7 +12,6 @@ package org.mifos.mobile.core.ui.component
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Text
@@ -20,16 +19,16 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.ui.utils.DevicePreview
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun MifosItemCard(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    elevation: Dp = 1.dp,
-    shape: Shape = RoundedCornerShape(8.dp),
+    elevation: Dp = KptTheme.elevation.level1,
+    shape: Shape = KptTheme.shapes.small,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     Card(

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosLabelValueCard.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosLabelValueCard.kt
@@ -15,13 +15,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.mifos.mobile.core.designsystem.component.CardVariant
 import org.mifos.mobile.core.designsystem.component.MifosCustomCard
@@ -29,6 +27,7 @@ import org.mifos.mobile.core.designsystem.theme.AppColors
 import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun MifosLabelValueCard(
@@ -41,26 +40,26 @@ fun MifosLabelValueCard(
         variant = CardVariant.OUTLINED,
         modifier = modifier
             .border(
-                1.dp,
-                MaterialTheme.colorScheme.secondaryContainer,
-                DesignToken.shapes.medium,
+                DesignToken.strokes.thin,
+                KptTheme.colorScheme.secondaryContainer,
+                KptTheme.shapes.medium,
             ),
-        shape = DesignToken.shapes.medium,
+        shape = KptTheme.shapes.medium,
         colors = CardDefaults.outlinedCardColors(
             containerColor = Color.Transparent,
-            contentColor = MaterialTheme.colorScheme.onSurface,
+            contentColor = KptTheme.colorScheme.onSurface,
         ),
     ) {
         Column(
             modifier = Modifier
                 .padding(DesignToken.padding.medium),
-            verticalArrangement = Arrangement.spacedBy(DesignToken.spacing.extraSmall),
+            verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.xs),
             horizontalAlignment = Alignment.Start,
         ) {
             Text(
                 text = label,
                 style = MifosTypography.bodySmall,
-                color = MaterialTheme.colorScheme.secondary,
+                color = KptTheme.colorScheme.secondary,
 
             )
 
@@ -80,13 +79,13 @@ private fun Mifos_Label_Card_Preview() {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
+                .padding(KptTheme.spacing.md),
+            verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.md),
         ) {
             MifosLabelValueCard(
                 label = "Account Number",
                 value = "268978976666",
-                color = MaterialTheme.colorScheme.onBackground,
+                color = KptTheme.colorScheme.onBackground,
 
             )
 

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosLinkText.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosLinkText.kt
@@ -11,14 +11,14 @@ package org.mifos.mobile.core.ui.component
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextDecoration
-import androidx.compose.ui.unit.dp
+import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.ui.utils.DevicePreview
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun MifosLinkText(
@@ -29,11 +29,11 @@ fun MifosLinkText(
 ) {
     Text(
         text = text,
-        style = MaterialTheme.typography.bodyMedium.copy(
+        style = KptTheme.typography.bodyMedium.copy(
             textDecoration = if (isUnderlined) TextDecoration.Underline else null,
         ),
         modifier = modifier
-            .padding(vertical = 2.dp)
+            .padding(vertical = DesignToken.padding.dp2)
             .clickable {
                 onClick()
             },

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosMobileIcon.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosMobileIcon.kt
@@ -16,11 +16,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import mifos_mobile.core.ui.generated.resources.Res
 import mifos_mobile.core.ui.generated.resources.core_ui_money_in
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.painterResource
+import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.ui.utils.DevicePreview
 
@@ -36,7 +36,7 @@ fun MifosMobileIcon(
             modifier = Modifier
                 .fillMaxWidth()
                 .align(Alignment.CenterHorizontally)
-                .padding(0.dp, 56.dp),
+                .padding(DesignToken.padding.none, DesignToken.padding.dp56),
         )
     }
 }

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosOutlineDropDown.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosOutlineDropDown.kt
@@ -21,7 +21,6 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
@@ -34,7 +33,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.mifos.mobile.core.designsystem.component.MifosOutlinedTextField
@@ -42,6 +40,7 @@ import org.mifos.mobile.core.designsystem.component.MifosTextFieldConfig
 import org.mifos.mobile.core.designsystem.icon.MifosIcons
 import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
+import template.core.base.designsystem.theme.KptTheme
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3Api::class)
 @Composable
@@ -72,9 +71,9 @@ fun MifosOutlineDropdown(
                         imageVector = if (expanded) MifosIcons.CaretUp else MifosIcons.CaretDown,
                         contentDescription = null,
                         tint = if (enabled) {
-                            MaterialTheme.colorScheme.onSurface
+                            KptTheme.colorScheme.onSurface
                         } else {
-                            MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+                            KptTheme.colorScheme.onSurface.copy(alpha = 0.3f)
                         },
                     )
                 },
@@ -90,11 +89,11 @@ fun MifosOutlineDropdown(
                     textFieldSize = it.size.toSize()
                 }
                 .then(if (enabled) Modifier.clickable { expanded = true } else Modifier),
-            shape = DesignToken.shapes.medium,
+            shape = KptTheme.shapes.medium,
             colors = OutlinedTextFieldDefaults.colors(
-                focusedBorderColor = MaterialTheme.colorScheme.secondaryContainer,
-                unfocusedBorderColor = MaterialTheme.colorScheme.secondaryContainer,
-                errorBorderColor = MaterialTheme.colorScheme.error,
+                focusedBorderColor = KptTheme.colorScheme.secondaryContainer,
+                unfocusedBorderColor = KptTheme.colorScheme.secondaryContainer,
+                errorBorderColor = KptTheme.colorScheme.error,
             ),
         )
 
@@ -104,22 +103,22 @@ fun MifosOutlineDropdown(
             modifier = Modifier
                 .width(with(LocalDensity.current) { textFieldSize.width.toDp() })
                 .border(
-                    width = 1.dp,
-                    color = MaterialTheme.colorScheme.secondaryContainer,
-                    shape = DesignToken.shapes.medium,
+                    width = DesignToken.strokes.thin,
+                    color = KptTheme.colorScheme.secondaryContainer,
+                    shape = KptTheme.shapes.medium,
                 ),
-            tonalElevation = 2.dp,
-            shadowElevation = 2.dp,
-            containerColor = MaterialTheme.colorScheme.inverseOnSurface,
-            shape = DesignToken.shapes.large,
+            tonalElevation = DesignToken.elevation.dp2,
+            shadowElevation = DesignToken.elevation.dp2,
+            containerColor = KptTheme.colorScheme.inverseOnSurface,
+            shape = KptTheme.shapes.large,
         ) {
             items.forEach { (productID, product) ->
                 DropdownMenuItem(
                     text = {
                         Text(
                             text = product,
-                            style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            style = KptTheme.typography.bodyLarge,
+                            color = KptTheme.colorScheme.onSurfaceVariant,
                         )
                     },
                     onClick = {
@@ -140,7 +139,7 @@ private fun MifosOutlinedDropdownPreview() {
 
     MifosMobileTheme {
         Column(
-            modifier = Modifier.fillMaxSize().padding(16.dp),
+            modifier = Modifier.fillMaxSize().padding(KptTheme.spacing.md),
         ) {
             MifosOutlineDropdown(
                 selectedText = selected,

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosPoweredCard.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosPoweredCard.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -35,6 +34,7 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun MifosPoweredCard(
@@ -47,11 +47,11 @@ fun MifosPoweredCard(
             .shadow(
                 elevation = DesignToken.elevation.elevation,
                 shape = DesignToken.shapes.bottomSheet,
-                ambientColor = MaterialTheme.colorScheme.onSurface,
-                spotColor = MaterialTheme.colorScheme.onSurface,
+                ambientColor = KptTheme.colorScheme.onSurface,
+                spotColor = KptTheme.colorScheme.onSurface,
                 clip = false,
             )
-            .background(MaterialTheme.colorScheme.surface, shape = DesignToken.shapes.bottomSheet),
+            .background(KptTheme.colorScheme.surface, shape = DesignToken.shapes.bottomSheet),
     ) {
         Row(
             modifier = Modifier
@@ -62,9 +62,9 @@ fun MifosPoweredCard(
             Text(
                 text = text ?: "",
                 style = MifosTypography.tag,
-                color = MaterialTheme.colorScheme.primary,
+                color = KptTheme.colorScheme.primary,
             )
-            Spacer(modifier = Modifier.width(DesignToken.spacing.extraSmall))
+            Spacer(modifier = Modifier.width(KptTheme.spacing.xs))
             if (icon != null) {
                 Image(
                     painter = painterResource(

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosProgressIndicator.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosProgressIndicator.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -29,6 +28,7 @@ import mifos_mobile.core.ui.generated.resources.Res
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.ui.utils.LottieConstants
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun MifosProgressIndicator(
@@ -76,7 +76,7 @@ fun MifosProgressIndicatorOverlay(
 
     Box(
         modifier = modifier
-            .background(MaterialTheme.colorScheme.background.copy(alpha = 0.7f))
+            .background(KptTheme.colorScheme.background.copy(alpha = 0.7f))
             .clickable(
                 enabled = false,
                 indication = null,

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosRadioButtonAlertDialog.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosRadioButtonAlertDialog.kt
@@ -25,13 +25,14 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import mifos_mobile.core.ui.generated.resources.Res
 import mifos_mobile.core.ui.generated.resources.core_common_working
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
+import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.ui.utils.DevicePreview
+import template.core.base.designsystem.theme.KptTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -48,12 +49,12 @@ fun MifosRadioButtonDialog(
         modifier = modifier,
     ) {
         Card {
-            Column(modifier = Modifier.padding(20.dp)) {
+            Column(modifier = Modifier.padding(DesignToken.padding.largeIncreased)) {
                 Text(text = stringResource(titleResId))
                 LazyColumn(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .heightIn(max = 500.dp),
+                        .heightIn(max = DesignToken.sizes.lazyColHeightInDp500),
                 ) {
                     itemsIndexed(items = items) { index, item ->
                         Row(
@@ -74,7 +75,7 @@ fun MifosRadioButtonDialog(
                             )
                             Text(
                                 text = item,
-                                modifier = Modifier.padding(start = 4.dp),
+                                modifier = Modifier.padding(start = KptTheme.spacing.xs),
                             )
                         }
                     }

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosRoundIcon.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosRoundIcon.kt
@@ -16,11 +16,11 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.unit.dp
 import mifos_mobile.core.ui.generated.resources.Res
 import mifos_mobile.core.ui.generated.resources.core_ui_money_in
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.painterResource
+import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.ui.utils.DevicePreview
 
@@ -34,7 +34,7 @@ fun MifosRoundIcon(
             .clip(CircleShape),
     ) {
         Image(
-            modifier = Modifier.padding(all = 6.dp),
+            modifier = Modifier.padding(all = DesignToken.padding.dp6),
             painter = painterResource(iconId),
             contentDescription = "Icon",
         )

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosStatusComponent.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosStatusComponent.kt
@@ -18,13 +18,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import mifos_mobile.core.ui.generated.resources.Res
 import mifos_mobile.core.ui.generated.resources.ic_icon_error
 import mifos_mobile.core.ui.generated.resources.ic_icon_success
@@ -35,6 +33,7 @@ import org.mifos.mobile.core.designsystem.component.MifosButton
 import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun MifosStatusComponent(
@@ -53,8 +52,8 @@ fun MifosStatusComponent(
     ) {
         Image(
             modifier = Modifier
-                .height(96.dp)
-                .width(96.dp),
+                .height(DesignToken.sizes.imageDp96)
+                .width(DesignToken.sizes.imageDp96),
             painter = painterResource(icon),
             contentDescription = "Status icon",
         )
@@ -64,7 +63,7 @@ fun MifosStatusComponent(
         Text(
             text = title,
             style = MifosTypography.headlineSmallEmphasized,
-            color = MaterialTheme.colorScheme.onSurface,
+            color = KptTheme.colorScheme.onSurface,
             textAlign = TextAlign.Center,
         )
 
@@ -73,7 +72,7 @@ fun MifosStatusComponent(
         Text(
             text = subTitle,
             style = MifosTypography.bodySmall,
-            color = MaterialTheme.colorScheme.secondary,
+            color = KptTheme.colorScheme.secondary,
             textAlign = TextAlign.Center,
         )
 
@@ -83,7 +82,7 @@ fun MifosStatusComponent(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(DesignToken.sizes.buttonHeight),
-            shape = DesignToken.shapes.medium,
+            shape = KptTheme.shapes.medium,
             text = {
                 Text(
                     text = buttonText,
@@ -102,7 +101,7 @@ private fun Mifos_Status_Component() {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(DesignToken.padding.large),
+                .padding(KptTheme.spacing.md),
             verticalArrangement = Arrangement.Center,
         ) {
             MifosStatusComponent(

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosSuccessDialog.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosSuccessDialog.kt
@@ -23,8 +23,8 @@ import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.mifos.mobile.core.designsystem.component.MifosButton
-import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun MifosSuccessDialog(
@@ -75,7 +75,7 @@ fun MifosSuccessDialog(
                     )
                 }
             },
-            shape = DesignToken.shapes.large,
+            shape = KptTheme.shapes.large,
         )
     }
 }

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosTextButtonWithTopDrawable.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosTextButtonWithTopDrawable.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import mifos_mobile.core.ui.generated.resources.Res
 import mifos_mobile.core.ui.generated.resources.core_common_working
 import org.jetbrains.compose.resources.StringResource
@@ -29,6 +28,7 @@ import org.mifos.mobile.core.designsystem.component.MifosTextButton
 import org.mifos.mobile.core.designsystem.icon.MifosIcons
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.ui.utils.DevicePreview
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun MifosTextButtonWithTopDrawable(
@@ -50,7 +50,7 @@ fun MifosTextButtonWithTopDrawable(
                     imageVector = icon,
                     contentDescription = contentDescription,
                 )
-                Spacer(modifier = Modifier.height(4.dp))
+                Spacer(modifier = Modifier.height(KptTheme.spacing.xs))
                 Text(
                     text = stringResource(textResourceId),
                     textAlign = TextAlign.Center,

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosTexts.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosTexts.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -26,13 +25,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import mifos_mobile.core.ui.generated.resources.Res
 import mifos_mobile.core.ui.generated.resources.core_ui_money_in
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.painterResource
+import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.ui.utils.DevicePreview
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun MifosTextTitleDescSingleLine(
@@ -46,14 +46,14 @@ fun MifosTextTitleDescSingleLine(
         modifier = modifier.fillMaxWidth(),
     ) {
         Text(
-            style = MaterialTheme.typography.labelMedium,
+            style = KptTheme.typography.labelMedium,
             text = title,
             modifier = Modifier
                 .alpha(0.7f),
         )
 
         Text(
-            style = MaterialTheme.typography.bodyMedium,
+            style = KptTheme.typography.bodyMedium,
             text = description,
         )
     }
@@ -69,7 +69,7 @@ fun MifosTextTitleDescDoubleLine(
     Column(modifier = modifier.fillMaxWidth()) {
         Text(
             text = title,
-            style = MaterialTheme.typography.labelMedium,
+            style = KptTheme.typography.labelMedium,
             modifier = Modifier
                 .alpha(0.7f)
                 .fillMaxWidth(),
@@ -88,7 +88,7 @@ fun MifosTextTitleDescDrawableSingleLine(
     description: String,
     imageResId: DrawableResource,
     modifier: Modifier = Modifier,
-    imageSize: Dp = 14.dp,
+    imageSize: Dp = DesignToken.sizes.imageDp14,
     onDrawableClick: () -> Unit = {},
 ) {
     Row(
@@ -97,17 +97,17 @@ fun MifosTextTitleDescDrawableSingleLine(
         modifier = modifier.fillMaxWidth(),
     ) {
         Text(
-            style = MaterialTheme.typography.labelMedium,
+            style = KptTheme.typography.labelMedium,
             text = title,
             modifier = Modifier
                 .weight(1f)
                 .alpha(0.7f),
         )
         Text(
-            style = MaterialTheme.typography.bodyMedium,
+            style = KptTheme.typography.bodyMedium,
             text = description,
         )
-        Spacer(modifier = Modifier.width(5.dp))
+        Spacer(modifier = Modifier.width(DesignToken.spacing.dp5))
         Image(
             painter = painterResource(imageResId),
             contentDescription = "Image",
@@ -130,7 +130,7 @@ fun MifosTitleDescSingleLineEqual(
         modifier = modifier.fillMaxWidth(),
     ) {
         Text(
-            style = MaterialTheme.typography.labelMedium,
+            style = KptTheme.typography.labelMedium,
             text = title,
             modifier = Modifier
                 .alpha(0.7f)
@@ -138,7 +138,7 @@ fun MifosTitleDescSingleLineEqual(
         )
 
         Text(
-            style = MaterialTheme.typography.bodyMedium,
+            style = KptTheme.typography.bodyMedium,
             text = description,
             modifier = Modifier.weight(1f),
         )
@@ -168,7 +168,7 @@ fun MifosTextTitleDescDoubleLinePreview(
         MifosTextTitleDescDoubleLine(
             title = "MifosTextTitleDescDoubleLine Title",
             description = "MifosTextTitleDescDoubleLine Description",
-            descriptionStyle = MaterialTheme.typography.bodyMedium,
+            descriptionStyle = KptTheme.typography.bodyMedium,
             modifier = modifier,
         )
     }

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosTitleSearchCard.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosTitleSearchCard.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -26,7 +25,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import mifos_mobile.core.ui.generated.resources.Res
 import mifos_mobile.core.ui.generated.resources.core_common_working
 import org.jetbrains.compose.resources.StringResource
@@ -35,6 +33,7 @@ import org.mifos.mobile.core.designsystem.component.MifosSearchTextField
 import org.mifos.mobile.core.designsystem.icon.MifosIcons
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.ui.utils.DevicePreview
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun MifosTitleSearchCard(
@@ -58,7 +57,7 @@ fun MifosTitleSearchCard(
         ) {
             Text(
                 text = stringResource(titleResourceId),
-                style = MaterialTheme.typography.titleMedium,
+                style = KptTheme.typography.titleMedium,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.weight(1f),
@@ -74,7 +73,7 @@ fun MifosTitleSearchCard(
     } else {
         Row(
             modifier = Modifier
-                .padding(horizontal = 4.dp),
+                .padding(horizontal = KptTheme.spacing.xs),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             MifosSearchTextField(

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MonitorListItemWithIcon.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MonitorListItemWithIcon.kt
@@ -17,13 +17,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.unit.dp
 import mifos_mobile.core.ui.generated.resources.Res
 import mifos_mobile.core.ui.generated.resources.core_common_working
 import mifos_mobile.core.ui.generated.resources.core_ui_money_in
@@ -31,8 +29,10 @@ import mifos_mobile.core.ui.generated.resources.something_went_wrong
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
+import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.ui.utils.DevicePreview
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun MonitorListItemWithIcon(
@@ -45,23 +45,23 @@ fun MonitorListItemWithIcon(
     Row(
         modifier = modifier
             .clickable { onClick.invoke() }
-            .padding(8.dp),
+            .padding(KptTheme.spacing.sm),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         MifosRoundIcon(
             iconId = iconId,
-            modifier = Modifier.size(39.dp),
+            modifier = Modifier.size(DesignToken.sizes.iconDp39),
         )
-        Spacer(modifier = Modifier.width(8.dp))
+        Spacer(modifier = Modifier.width(KptTheme.spacing.sm))
         Column {
             Text(
                 text = stringResource(titleId),
-                style = MaterialTheme.typography.bodyLarge,
+                style = KptTheme.typography.bodyLarge,
                 modifier = Modifier.fillMaxWidth(),
             )
             Text(
                 text = stringResource(subTitleId),
-                style = MaterialTheme.typography.bodyMedium,
+                style = KptTheme.typography.bodyMedium,
                 modifier = Modifier
                     .alpha(0.7f)
                     .fillMaxWidth(),

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/NoInternet.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/NoInternet.kt
@@ -24,13 +24,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import mifos_mobile.core.ui.generated.resources.Res
 import mifos_mobile.core.ui.generated.resources.no_internet
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 import org.mifos.mobile.core.designsystem.icon.MifosIcons
+import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.ui.utils.DevicePreview
 
@@ -50,8 +50,8 @@ fun NoInternet(
     ) {
         Icon(
             modifier = Modifier
-                .size(100.dp)
-                .padding(bottom = 12.dp),
+                .size(DesignToken.sizes.iconDp100)
+                .padding(bottom = DesignToken.padding.medium),
             imageVector = icon,
             contentDescription = "No Internet Icon",
         )
@@ -61,7 +61,7 @@ fun NoInternet(
             style = TextStyle(fontSize = 20.sp),
         )
 
-        Spacer(modifier = Modifier.height(12.dp))
+        Spacer(modifier = Modifier.height(DesignToken.spacing.medium))
         if (isRetryEnabled) {
             FilledTonalButton(onClick = { retry.invoke() }) {
                 Text(text = "Retry")

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/TransactionScreenItem.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/TransactionScreenItem.kt
@@ -23,18 +23,17 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.mifos.mobile.core.designsystem.icon.MifosIcons
 import org.mifos.mobile.core.designsystem.theme.AppColors
 import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun TransactionScreenItem(
@@ -66,31 +65,31 @@ fun TransactionScreenItem(
                     MifosIcons.DrawerSubtract
                 },
                 contentDescription = "Symbol",
-                tint = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.3f),
+                tint = KptTheme.colorScheme.onBackground.copy(alpha = 0.3f),
                 modifier = Modifier
-                    .size(36.dp)
+                    .size(DesignToken.sizes.iconExtraLarge)
                     .background(
-                        color = MaterialTheme.colorScheme.background.copy(alpha = 0.2f),
+                        color = KptTheme.colorScheme.background.copy(alpha = 0.2f),
                         shape = CircleShape,
                     )
-                    .padding(DesignToken.padding.small),
+                    .padding(KptTheme.spacing.sm),
             )
 
             Spacer(modifier = Modifier.width(DesignToken.spacing.medium))
 
             Column(
                 modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(DesignToken.padding.extraSmall),
+                verticalArrangement = Arrangement.spacedBy(KptTheme.spacing.xs),
             ) {
                 Text(
                     text = title,
                     style = MifosTypography.titleSmallEmphasized,
-                    color = MaterialTheme.colorScheme.onSurface,
+                    color = KptTheme.colorScheme.onSurface,
                 )
                 Text(
                     text = if (time.isNotEmpty()) "$time; $date" else date,
                     style = MifosTypography.bodySmall,
-                    color = MaterialTheme.colorScheme.secondary,
+                    color = KptTheme.colorScheme.secondary,
                 )
             }
 
@@ -106,7 +105,7 @@ fun TransactionScreenItem(
                 color = if (isCredited) {
                     AppColors.customEnable
                 } else {
-                    MaterialTheme.colorScheme.error
+                    KptTheme.colorScheme.error
                 },
             )
         }
@@ -120,7 +119,7 @@ private fun TransactionScreenItem_Preview() {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(DesignToken.padding.large),
+                .padding(KptTheme.spacing.md),
         ) {
             TransactionScreenItem(
                 title = "Add-Money Bank Card",

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/UserProfileField.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/UserProfileField.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import mifos_mobile.core.ui.generated.resources.Res
 import mifos_mobile.core.ui.generated.resources.core_common_working
@@ -33,6 +32,7 @@ import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.ui.utils.DevicePreview
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun UserProfileField(
@@ -45,7 +45,7 @@ fun UserProfileField(
         modifier = modifier
             .fillMaxWidth()
             .clickable(onClick = onClick)
-            .padding(16.dp),
+            .padding(KptTheme.spacing.md),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -70,7 +70,7 @@ fun UserProfileField(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(16.dp),
+            .padding(KptTheme.spacing.md),
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
         Text(

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/navigation/MifosBottomBar.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/navigation/MifosBottomBar.kt
@@ -14,11 +14,11 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.BottomAppBar
 import androidx.compose.material3.BottomAppBarDefaults
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun MifosBottomBar(
@@ -29,8 +29,8 @@ fun MifosBottomBar(
     windowInsets: WindowInsets = BottomAppBarDefaults.windowInsets,
 ) {
     BottomAppBar(
-        containerColor = MaterialTheme.colorScheme.surface,
-        contentColor = MaterialTheme.colorScheme.onSurface,
+        containerColor = KptTheme.colorScheme.surface,
+        contentColor = KptTheme.colorScheme.onSurface,
         windowInsets = windowInsets,
         modifier = modifier
             .fillMaxWidth()
@@ -39,7 +39,7 @@ fun MifosBottomBar(
 //                spotColor = Color(0xFF5D5D5D),
 //                ambientColor = Color.Black,
 //            )
-            .background(MaterialTheme.colorScheme.surface),
+            .background(KptTheme.colorScheme.surface),
         tonalElevation = 0.dp,
     ) {
         navigationItems.forEach { navigationItem ->

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/navigation/MifosNavigationBarItem.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/navigation/MifosNavigationBarItem.kt
@@ -12,18 +12,17 @@ package org.mifos.mobile.core.ui.navigation
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun RowScope.MifosNavigationBarItem(
@@ -44,20 +43,20 @@ fun RowScope.MifosNavigationBarItem(
         },
         label = {
             Text(
-                modifier = Modifier.padding(DesignToken.padding.extraSmall),
+                modifier = Modifier.padding(KptTheme.spacing.xs),
                 text = stringResource(label),
                 style = MifosTypography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurface,
+                color = KptTheme.colorScheme.onSurface,
             )
         },
         selected = isSelected,
         alwaysShowLabel = true,
         onClick = onClick,
-        modifier = modifier.padding(vertical = 6.dp),
+        modifier = modifier.padding(vertical = DesignToken.padding.dp6),
         colors = NavigationBarItemDefaults.colors(
-            selectedIconColor = MaterialTheme.colorScheme.primary,
-            unselectedIconColor = MaterialTheme.colorScheme.primary,
-            indicatorColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.3f),
+            selectedIconColor = KptTheme.colorScheme.primary,
+            unselectedIconColor = KptTheme.colorScheme.primary,
+            indicatorColor = KptTheme.colorScheme.primary.copy(alpha = 0.3f),
         ),
     )
 }

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/navigation/MifosNavigationRail.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/navigation/MifosNavigationRail.kt
@@ -19,15 +19,14 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationRailDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.unit.dp
 import org.mifos.mobile.core.designsystem.theme.DesignToken
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun MifosNavigationRail(
@@ -38,21 +37,21 @@ fun MifosNavigationRail(
     windowInsets: WindowInsets = NavigationRailDefaults.windowInsets,
 ) {
     Surface(
-        color = MaterialTheme.colorScheme.surface,
-        contentColor = MaterialTheme.colorScheme.onSurface,
+        color = KptTheme.colorScheme.surface,
+        contentColor = KptTheme.colorScheme.onSurface,
         modifier = modifier,
     ) {
         Column(
             modifier = Modifier
                 .fillMaxHeight()
                 .windowInsetsPadding(insets = windowInsets)
-                .widthIn(min = 80.dp)
-                .padding(vertical = DesignToken.padding.extraSmall)
+                .widthIn(min = DesignToken.sizes.surfaceColWidthInDp80)
+                .padding(vertical = KptTheme.spacing.xs)
                 .selectableGroup()
                 .verticalScroll(state = rememberScrollState()),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(
-                space = DesignToken.spacing.large,
+                space = KptTheme.spacing.md,
                 alignment = Alignment.CenterVertically,
             ),
         ) {

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/navigation/MifosNavigationRailItem.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/navigation/MifosNavigationRailItem.kt
@@ -12,7 +12,6 @@ package org.mifos.mobile.core.ui.navigation
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationRailItem
 import androidx.compose.material3.NavigationRailItemDefaults
 import androidx.compose.material3.Text
@@ -21,8 +20,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
-import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun ColumnScope.MifosNavigationRailItem(
@@ -43,19 +42,19 @@ fun ColumnScope.MifosNavigationRailItem(
         },
         label = {
             Text(
-                modifier = Modifier.padding(DesignToken.padding.extraSmall),
+                modifier = Modifier.padding(KptTheme.spacing.xs),
                 text = stringResource(label),
                 style = MifosTypography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurface,
+                color = KptTheme.colorScheme.onSurface,
             )
         },
         selected = isSelected,
         alwaysShowLabel = true,
         onClick = onClick,
         colors = NavigationRailItemDefaults.colors(
-            selectedIconColor = MaterialTheme.colorScheme.primary,
-            unselectedIconColor = MaterialTheme.colorScheme.primary,
-            indicatorColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.3f),
+            selectedIconColor = KptTheme.colorScheme.primary,
+            unselectedIconColor = KptTheme.colorScheme.primary,
+            indicatorColor = KptTheme.colorScheme.primary.copy(alpha = 0.3f),
         ),
 
         modifier = modifier,

--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/utils/NetworkBannerStatus.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/utils/NetworkBannerStatus.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -30,8 +29,8 @@ import mifos_mobile.core.ui.generated.resources.back_online
 import mifos_mobile.core.ui.generated.resources.no_internet
 import org.jetbrains.compose.resources.stringResource
 import org.mifos.mobile.core.designsystem.theme.AppColors
-import org.mifos.mobile.core.designsystem.theme.DesignToken
 import org.mifos.mobile.core.designsystem.theme.MifosTypography
+import template.core.base.designsystem.theme.KptTheme
 
 @Composable
 fun NetworkBanner(
@@ -43,7 +42,7 @@ fun NetworkBanner(
 
     when (bannerState) {
         NetworkBannerState.Offline -> {
-            bannerColor = MaterialTheme.colorScheme.error
+            bannerColor = KptTheme.colorScheme.error
             bannerText = stringResource(Res.string.no_internet)
         }
         NetworkBannerState.BackOnline -> {
@@ -71,7 +70,7 @@ fun NetworkBanner(
             modifier = Modifier
                 .fillMaxWidth()
                 .background(bannerColor)
-                .padding(DesignToken.padding.extraSmall),
+                .padding(KptTheme.spacing.xs),
             horizontalArrangement = Arrangement.Center,
         ) {
             Text(


### PR DESCRIPTION
Fixes - [Jira-#MM-388](https://mifosforge.jira.com/browse/MM-388), [Jira-#MM-476](https://mifosforge.jira.com/browse/MM-476)

Summary of changes:
- Replaced MaterialTheme with KptTheme for Typography and Color Scheme
- Used KptTheme for shapes, spacing, padding which matched with DesignToken, remaining uses DesignToken
- Non-standard values have been replaced with DesignToken's custom values

https://github.com/user-attachments/assets/e072dae9-0d9e-4430-82b4-533ff43d5398

Didn't create a Jira ticket, click [here](https://mifosforge.jira.com/jira/software/c/projects/MM/issues/) to create new.

Please Add Screenshots If there are any UI changes.

| Before                                     | After                                  |
|--------------------------------------------|----------------------------------------|
|                                            |                                        |


Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the static analysis check `./gradlew check` or `ci-prepush.sh` to make sure you didn't break anything

- [ ] If you have multiple commits please combine them into one commit by squashing them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated design system theming infrastructure across UI components, improving visual consistency and maintainability throughout the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->