### PR TITLE
Adding centralized unauthorized handling on 401 responses

### DIFF
--- a/cmp-navigation/src/commonMain/kotlin/cmp/navigation/rootnav/RootNavViewModel.kt
+++ b/cmp-navigation/src/commonMain/kotlin/cmp/navigation/rootnav/RootNavViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import org.mifos.mobile.core.data.repository.UserDataRepository
 import org.mifos.mobile.core.datastore.model.AppSettings
 import org.mifos.mobile.core.model.AuthState
@@ -27,6 +28,16 @@ class RootNavViewModel(
 ) {
 
     init {
+        viewModelScope.launch {
+            userDataRepository.authState
+                .collect { authState ->
+                    if (authState is AuthState.Unauthenticated) {
+                        if (mutableStateFlow.value !is RootNavState.Auth) {
+                            mutableStateFlow.update { RootNavState.Auth }
+                        }
+                    }
+                }
+        }
         combine(
             userDataRepository.authState,
             userDataRepository.settingsState,

--- a/core/network/src/commonMain/kotlin/org/mifos/mobile/core/network/di/NetworkModule.kt
+++ b/core/network/src/commonMain/kotlin/org/mifos/mobile/core/network/di/NetworkModule.kt
@@ -28,6 +28,10 @@ val NetworkModule = module {
             install(Auth)
             install(KtorInterceptor) {
                 getToken = { preferencesRepository.token.value }
+
+                onUnauthorized = suspend {
+                    preferencesRepository.logOut()
+                }
             }
         }
     }

--- a/core/network/src/commonMain/kotlin/org/mifos/mobile/core/network/utils/KtorInterceptor.kt
+++ b/core/network/src/commonMain/kotlin/org/mifos/mobile/core/network/utils/KtorInterceptor.kt
@@ -13,11 +13,14 @@ import io.ktor.client.HttpClient
 import io.ktor.client.plugins.HttpClientPlugin
 import io.ktor.client.request.HttpRequestPipeline
 import io.ktor.client.request.header
+import io.ktor.client.statement.HttpResponsePipeline
+import io.ktor.http.HttpStatusCode
 import io.ktor.util.AttributeKey
 import org.mifos.mobile.core.datastore.UserPreferencesRepository
 
 class KtorInterceptor(
     private val getToken: () -> String?,
+    private val onUnauthorized: (suspend () -> Unit)?,
 ) {
     companion object Plugin : HttpClientPlugin<Config, KtorInterceptor> {
         private const val HEADER_TENANT = "Fineract-Platform-TenantId"
@@ -39,17 +42,31 @@ class KtorInterceptor(
                     }
                 }
             }
+            scope.responsePipeline.intercept(HttpResponsePipeline.After) {
+                if (context.response.status == HttpStatusCode.Unauthorized) {
+                    runCatching {
+                        plugin.onUnauthorized?.invoke()
+                    }.onFailure { throwable ->
+                        throwable.printStackTrace()
+                    }
+                }
+                proceed()
+            }
         }
 
         override fun prepare(block: Config.() -> Unit): KtorInterceptor {
             val config = Config().apply(block)
-            return KtorInterceptor(config.getToken)
+            return KtorInterceptor(
+                getToken = config.getToken,
+                onUnauthorized = config.onUnauthorized,
+            )
         }
     }
 }
 
 class Config {
     lateinit var getToken: () -> String?
+    var onUnauthorized: (suspend () -> Unit)? = null
 }
 
 class KtorInterceptorRe(

--- a/feature/home/src/commonMain/kotlin/org/mifos/mobile/feature/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/org/mifos/mobile/feature/home/HomeScreen.kt
@@ -74,6 +74,10 @@ internal fun HomeScreen(
 ) {
     val state by viewModel.stateFlow.collectAsStateWithLifecycle()
 
+    LaunchedEffect(Unit) {
+        viewModel.handleAuthCheckOnResume()
+    }
+
     EventsEffect(viewModel.eventFlow) { event ->
         when (event) {
             is HomeEvent.Navigate -> {

--- a/feature/home/src/commonMain/kotlin/org/mifos/mobile/feature/home/HomeViewModel.kt
+++ b/feature/home/src/commonMain/kotlin/org/mifos/mobile/feature/home/HomeViewModel.kt
@@ -55,6 +55,8 @@ internal class HomeViewModel(
     ),
 ) {
 
+    private var isHandlingNetworkChange = false
+
     init {
         observeNetworkStatus()
     }
@@ -69,7 +71,9 @@ internal class HomeViewModel(
             networkMonitor.isOnline
                 .distinctUntilChanged()
                 .collect { isOnline ->
+                    isHandlingNetworkChange = true
                     sendAction(HomeAction.ObserveNetworkStatus(isOnline))
+                    isHandlingNetworkChange = false
                 }
         }
     }
@@ -157,6 +161,30 @@ internal class HomeViewModel(
                 loadClientAccountDetails()
             }
         }
+    }
+
+    /**
+     * Handles authorization check when the Home screen re-enters composition.
+     *
+     * This function validates the user's session by checking if:
+     * - The device is currently online ([state.networkStatus]).
+     * - The network status is not currently being handled ([isHandlingNetworkChange]).
+     *
+     * If both conditions are met, it triggers [checkAuthorization] to verify the session.
+     * This prevents redundant auth checks when [handleNetworkStatus] is already fetching data.
+     */
+    suspend fun handleAuthCheckOnResume() {
+        if (!state.networkStatus) return
+        if (isHandlingNetworkChange) return
+        checkAuthorization()
+    }
+
+    private suspend fun checkAuthorization() {
+        homeRepositoryImpl.currentClient(clientId = state.clientId ?: 0)
+            .catch {
+                updateState { it.copy(uiState = HomeScreenState.Error(Res.string.feature_server_error)) }
+            }
+            .collect {}
     }
 
     /**


### PR DESCRIPTION
## Force logout and navigate to login on HTTP 401

### Fixes
- Jira: [MM-466](https://mifosforge.jira.com/jira/software/c/projects/MM/issues/MM-466)

### Overview
This PR ensures the app performs a clean logout and returns the user to the Auth/Login flow whenever the backend responds with `401 Unauthorized`.

<p align="center">
  <img src="https://github.com/user-attachments/assets/ad3081e4-92b9-48ea-86ea-c1b9c1f79b9b"
       width="200"
       alt="401 Unauthorized logout flow"/>
</p>

Unauthorized handling is centralized in the network layer via a Ktor interceptor callback (`onUnauthorized`). When a 401 is detected, the interceptor triggers `preferencesRepository.logOut()`. Since `authState` is derived from stored preferences, it automatically updates to `Unauthenticated`, and the root navigation reacts by switching to the Auth route.

### Key Changes
- Added/updated Ktor interceptor support for unauthorized handling via a suspend callback:
  - `onUnauthorized = suspend { preferencesRepository.logOut() }`
- Used the existing preference-driven `authState` to propagate logout state across the app (no extra event mechanism required).
- Updated `RootNavViewModel` to react to `AuthState.Unauthenticated` and navigate to the Auth/Login route.
- Home screen edge case: added a lightweight session validation API call when the Home screen enters composition/resumes so a stale/expired session can still trigger a 401 and force logout even if no other API calls are made.

### Technical Flow
401 Response -> Ktor interceptor -> `onUnauthorized` callback -> `preferencesRepository.logOut()` -> `authState` emits `Unauthenticated` -> Root navigation switches to `Auth`

[MM-466]: https://mifosforge.jira.com/browse/MM-466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App now detects invalid authentication and routes users to the auth flow automatically.
  * On-resume and on-composition authentication checks run to verify session validity.
  * Network client detects 401 responses and triggers a graceful logout.

* **Bug Fixes**
  * Avoids redundant authorization checks during ongoing network-change processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->