### PR TITLE
fix: display server response message in error dialogs and status screens

### DIFF
--- a/feature/beneficiary/src/commonMain/kotlin/org/mifos/mobile/feature/beneficiary/beneficiaryDetail/BeneficiaryDetailScreen.kt
+++ b/feature/beneficiary/src/commonMain/kotlin/org/mifos/mobile/feature/beneficiary/beneficiaryDetail/BeneficiaryDetailScreen.kt
@@ -93,7 +93,7 @@ private fun BeneficiaryDialogs(
         is BeneficiaryDetailState.DialogState.Error -> {
             MifosBasicDialog(
                 visibilityState = BasicDialogState.Shown(
-                    message = stringResource(state.beneficiaryDialog.message),
+                    message = state.beneficiaryDialog.message,
                 ),
                 onDismissRequest = { onAction(BeneficiaryDetailAction.ErrorDialogDismiss) },
             )

--- a/feature/beneficiary/src/commonMain/kotlin/org/mifos/mobile/feature/beneficiary/beneficiaryDetail/BeneficiaryDetailViewModel.kt
+++ b/feature/beneficiary/src/commonMain/kotlin/org/mifos/mobile/feature/beneficiary/beneficiaryDetail/BeneficiaryDetailViewModel.kt
@@ -19,7 +19,6 @@ import kotlinx.io.IOException
 import mifos_mobile.feature.beneficiary.generated.resources.Res
 import mifos_mobile.feature.beneficiary.generated.resources.delete_beneficiary_confirmation
 import mifos_mobile.feature.beneficiary.generated.resources.feature_generic_error_server
-import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.getString
 import org.mifos.mobile.core.common.DataState
 import org.mifos.mobile.core.data.repository.BeneficiaryRepository
@@ -220,7 +219,7 @@ internal class BeneficiaryDetailViewModel(
                     }
                     setDialogState(
                         BeneficiaryDetailState.DialogState.Error(
-                            Res.string.feature_generic_error_server,
+                            response.message,
                         ),
                     )
                 }
@@ -299,7 +298,7 @@ data class BeneficiaryDetailState(
     val showOverlay: Boolean = false,
 ) {
     sealed interface DialogState {
-        data class Error(val message: StringResource) : DialogState
+        data class Error(val message: String) : DialogState
 
         data class Confirmation(val message: String) : DialogState
     }

--- a/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/confirmDetails/ConfirmDetailsViewModel.kt
+++ b/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/confirmDetails/ConfirmDetailsViewModel.kt
@@ -23,7 +23,6 @@ import mifos_mobile.feature.loan_application.generated.resources.feature_apply_l
 import mifos_mobile.feature.loan_application.generated.resources.feature_apply_loan_label_purpose
 import mifos_mobile.feature.loan_application.generated.resources.feature_apply_loan_status_failure
 import mifos_mobile.feature.loan_application.generated.resources.feature_apply_loan_status_failure_action
-import mifos_mobile.feature.loan_application.generated.resources.feature_apply_loan_status_failure_tip
 import mifos_mobile.feature.loan_application.generated.resources.feature_apply_loan_status_success
 import mifos_mobile.feature.loan_application.generated.resources.feature_apply_loan_status_success_action
 import mifos_mobile.feature.loan_application.generated.resources.feature_apply_loan_status_success_tip
@@ -289,7 +288,7 @@ internal class ConfirmDetailsViewModel(
                         eventType = EventType.FAILURE.name,
                         eventDestination = StatusNavigationDestination.PREVIOUS_SCREEN.name,
                         title = getString(Res.string.feature_apply_loan_status_failure),
-                        subtitle = getString(Res.string.feature_apply_loan_status_failure_tip),
+                        subtitle = status.message,
                         buttonText = getString(Res.string.feature_apply_loan_status_failure_action),
                     ),
                 )

--- a/feature/savings-application/src/commonMain/kotlin/org/mifos/mobile/feature/savings/application/fillApplication/FillApplicationViewModel.kt
+++ b/feature/savings-application/src/commonMain/kotlin/org/mifos/mobile/feature/savings/application/fillApplication/FillApplicationViewModel.kt
@@ -580,10 +580,10 @@ internal class SavingsFillApplicationViewModel(
                         eventType = EventType.FAILURE.name,
                         eventDestination = StatusNavigationDestination.PREVIOUS_SCREEN.name,
                         title = getString(Res.string.feature_apply_savings_status_failure),
-                        subtitle = getString(
+                        subtitle = "${response.message}, ${getString(
                             Res.string.feature_apply_savings_status_failure_tip,
                             state.fieldOfficerName,
-                        ),
+                        )}",
                         buttonText = getString(Res.string.feature_apply_savings_status_failure_action),
                     ),
                 )

--- a/feature/savings-application/src/commonMain/kotlin/org/mifos/mobile/feature/savings/application/fillApplication/FillApplicationViewModel.kt
+++ b/feature/savings-application/src/commonMain/kotlin/org/mifos/mobile/feature/savings/application/fillApplication/FillApplicationViewModel.kt
@@ -580,10 +580,22 @@ internal class SavingsFillApplicationViewModel(
                         eventType = EventType.FAILURE.name,
                         eventDestination = StatusNavigationDestination.PREVIOUS_SCREEN.name,
                         title = getString(Res.string.feature_apply_savings_status_failure),
-                        subtitle = "${response.message}, ${getString(
-                            Res.string.feature_apply_savings_status_failure_tip,
-                            state.fieldOfficerName,
-                        )}",
+                        subtitle = buildString {
+                            val serverMessage = response.message.takeIf { it.isNotBlank() }
+                            if (serverMessage != null) {
+                                append(serverMessage)
+                                if (!serverMessage.endsWith(".") && !serverMessage.endsWith("!")) {
+                                    append(".")
+                                }
+                                append(" ")
+                            }
+                            append(
+                                getString(
+                                    Res.string.feature_apply_savings_status_failure_tip,
+                                    state.fieldOfficerName,
+                                ),
+                            )
+                        },
                         buttonText = getString(Res.string.feature_apply_savings_status_failure_action),
                     ),
                 )

--- a/feature/share-application/src/commonMain/kotlin/org/mifos/mobile/feature/share/application/fillApplication/FillApplicationViewModel.kt
+++ b/feature/share-application/src/commonMain/kotlin/org/mifos/mobile/feature/share/application/fillApplication/FillApplicationViewModel.kt
@@ -652,10 +652,10 @@ internal class ShareFillApplicationViewModel(
                         eventType = EventType.FAILURE.name,
                         eventDestination = StatusNavigationDestination.PREVIOUS_SCREEN.name,
                         title = getString(Res.string.feature_apply_share_status_failure),
-                        subtitle = getString(
+                        subtitle = "${response.message}, ${getString(
                             Res.string.feature_apply_share_status_failure_tip,
                             state.shareProductName,
-                        ),
+                        )}",
                         buttonText = getString(Res.string.feature_apply_share_status_failure_action),
                     ),
                 )


### PR DESCRIPTION
Fixes - [Jira-#471](https://mifosforge.jira.com/browse/MM-471)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Error dialogs now show server-provided messages for beneficiary details instead of generic localized text.
  * Loan, savings, and share application failure screens now include the server error message in their subtitles for clearer feedback.
  * Savings/share flows preserve punctuation and combine server messages with existing guidance for more readable failure text.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->