### PR TITLE
MM-484 Transfer page doesn't allow to transfer amounts with decimals

### DIFF
--- a/feature/third-party-transfer/src/commonMain/kotlin/org/mifos/mobile/feature/third/party/transfer/thirdPartyTransfer/TptViewModel.kt
+++ b/feature/third-party-transfer/src/commonMain/kotlin/org/mifos/mobile/feature/third/party/transfer/thirdPartyTransfer/TptViewModel.kt
@@ -314,7 +314,7 @@ internal class TptViewModel(
      */
     private fun validateAmount(amount: String) = when {
         amount.isBlank() -> ValidationResult.Error(Res.string.feature_tpt_error_amount_required)
-        amount.toIntOrNull() == null -> ValidationResult.Error(Res.string.feature_tpt_error_amount_invalid)
+        amount.toFloatOrNull() == null -> ValidationResult.Error(Res.string.feature_tpt_error_amount_invalid)
         else -> ValidationResult.Success
     }
 

--- a/feature/third-party-transfer/src/commonMain/kotlin/org/mifos/mobile/feature/third/party/transfer/thirdPartyTransfer/TptViewModel.kt
+++ b/feature/third-party-transfer/src/commonMain/kotlin/org/mifos/mobile/feature/third/party/transfer/thirdPartyTransfer/TptViewModel.kt
@@ -314,7 +314,7 @@ internal class TptViewModel(
      */
     private fun validateAmount(amount: String) = when {
         amount.isBlank() -> ValidationResult.Error(Res.string.feature_tpt_error_amount_required)
-        amount.toFloatOrNull() == null -> ValidationResult.Error(Res.string.feature_tpt_error_amount_invalid)
+        amount.toDoubleOrNull() == null -> ValidationResult.Error(Res.string.feature_tpt_error_amount_invalid)
         else -> ValidationResult.Success
     }
 


### PR DESCRIPTION
Fixes - [MM-484](https://mifosforge.jira.com/browse/MM-484)

Transfer page doesn't allow to transfer amounts with decimals

**Before**
![old](https://github.com/user-attachments/assets/a740ba08-d328-4caa-9bc4-18c51fcdbacd)

**After**
![new](https://github.com/user-attachments/assets/f5153f62-9339-452e-8bc5-c944a1278733)


[MM-484]: https://mifosforge.jira.com/browse/MM-484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated amount validation for third-party transfers to accept decimal (floating-point) values instead of only integers, preventing false validation errors when users enter amounts with cents.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->