### PR TITLE
fix(workflows): correct sync directory workflow for scheduled runs

### DIFF
--- a/.github/workflows/sync-dirs.yaml
+++ b/.github/workflows/sync-dirs.yaml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   sync-directories:
+    if: github.repository != 'openMF/kmp-project-template'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -31,7 +32,8 @@ jobs:
 
       - name: Add upstream remote and fetch
         run: |
-          git remote add upstream ${{ inputs.upstream }} || true
+          UPSTREAM="${{ inputs.upstream || 'https://github.com/openMF/kmp-project-template.git' }}"
+          git remote add upstream "$UPSTREAM" || true
           git fetch upstream || exit 1
 
       - name: Check upstream/dev exists


### PR DESCRIPTION
Fixes - [Jira-#MM-496](https://mifosforge.jira.com/browse/MM-496)

Summary of changes:
- Added `upstream` address in shell command which was not being passed correctly during scheduled runs
- Added `if` statement for skipping `sync-dirs` workflow runs in the `kmp-project-template`

Didn't create a Jira ticket, click [here](https://mifosforge.jira.com/jira/software/c/projects/MM/issues/) to create new.

Please Add Screenshots If there are any UI changes.

| Before                                     | After                                  |
|--------------------------------------------|----------------------------------------|
|                                            |                                        |


Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the static analysis check `./gradlew check` or `ci-prepush.sh` to make sure you didn't break anything

- [ ] If you have multiple commits please combine them into one commit by squashing them.