### PR TITLE
chore: add iOS generated files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,10 @@ playStorePublishServiceCredentialsFile.json
 # Ruby stuff we don't care about
 .bundle/
 vendor/
+
+# iOS / Xcode
+cmp-ios/Pods/
+cmp-ios/iosApp.xcodeproj/xcuserdata/
+cmp-ios/iosApp.xcworkspace/xcuserdata/
+*.xcuserstate
+*.xcuserdatad/


### PR DESCRIPTION
## Summary

Adds iOS/Xcode generated files to `.gitignore` to prevent accidental commits.

## Changes

Added entries for:
- `cmp-ios/Pods/` - CocoaPods dependencies (installed via `pod install`)
- `cmp-ios/iosApp.xcodeproj/xcuserdata/` - User-specific Xcode project settings
- `cmp-ios/iosApp.xcworkspace/xcuserdata/` - User-specific workspace settings
- `*.xcuserstate` - Xcode user interface state
- `*.xcuserdatad/` - User data directories

## Why

These files are:
- Generated locally during development
- User-specific (breakpoints, window positions, etc.)
- Should not be shared across team members

## Test plan

- [x] Files are correctly ignored after update
- [x] No impact on iOS build process

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to improve source control management for development environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->