### PR TITLE
fix: language revert to system default after switching back from a custom language

### DIFF
--- a/cmp-android/src/main/kotlin/cmp/android/app/MainActivity.kt
+++ b/cmp-android/src/main/kotlin/cmp/android/app/MainActivity.kt
@@ -10,8 +10,8 @@
 package cmp.android.app
 
 import android.os.Bundle
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.os.LocaleListCompat
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
@@ -33,9 +33,9 @@ import kotlin.getValue
  * This class is used to set the content view of the activity.
  *
  * @constructor Create empty Main activity
- * @see ComponentActivity
+ * @see AppCompatActivity
  */
-class MainActivity : ComponentActivity() {
+class MainActivity : AppCompatActivity() {
     /**
      * Called when the activity is starting.
      * This is where most initialization should go: calling [setContentView(int)] to inflate the activity's UI,
@@ -70,9 +70,15 @@ class MainActivity : ComponentActivity() {
                         AppCompatDelegate.setDefaultNightMode(it)
                     },
                     handleAppLocale = {
-                        it?.let {
+                        if (it.isNullOrBlank()) {
                             AppCompatDelegate.setApplicationLocales(
-                                LocaleListCompat.forLanguageTags(it),
+                                LocaleListCompat.getEmptyLocaleList(),
+                            )
+                        } else {
+                            AppCompatDelegate.setApplicationLocales(
+                                LocaleListCompat.forLanguageTags(
+                                    it,
+                                ),
                             )
                             Locale.setDefault(Locale(it))
                         }


### PR DESCRIPTION
### Fixes - [Jira-#495](https://mifosforge.jira.com/browse/MM-495)

### Before 
https://github.com/user-attachments/assets/3d04005e-2b66-4a29-81f6-9b82ada4f217

### After 
https://github.com/user-attachments/assets/3c5add3a-94a1-41ef-a161-5f0e01a2d909

Please make sure these boxes are checked before submitting your pull request - thanks!
- [x] Run the static analysis check `./gradlew check` or `ci-prepush.sh` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.


----
### Explanation for the change 
**Problem** - The previous code didn’t trigger a proper configuration change to reset the language to the system default(null). `it?.let {...}` block is skipped entirely as a result UI stays in the previous locale. Even if this was fixed, the core issue was `MainActivity `extendng the `ComponentActivity`.  `ComponentActivity `**doesn't** :
- Override `attachBaseContext() `to apply the AppCompat locale wrapper
- Handle configuration changes in an AppCompat-aware way
- Handle Proper activity recreation and locale fallback mechanisms

Thus, it is migrated to `AppCompatActivity `which wraps the base context and applies Android's locale configuration rules. 

> [!NOTE] 
**Additional Fix - RTL Support:** : While the primary issue was language not reverting to the system default, using `AppCompatActivity` also enabled RTL support for languages like Urdu, which was previously not possible (Only changes strings- incomplete locale change)(_Check attachment_)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced locale handling to improve app language and regional settings management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->