### PR TITLE
fix(thirdPartyTransfer): exclude loan accounts from transfer source selector

### DIFF
--- a/feature/third-party-transfer/src/commonMain/kotlin/org/mifos/mobile/feature/third/party/transfer/thirdPartyTransfer/TptViewModel.kt
+++ b/feature/third-party-transfer/src/commonMain/kotlin/org/mifos/mobile/feature/third/party/transfer/thirdPartyTransfer/TptViewModel.kt
@@ -33,6 +33,13 @@ import org.mifos.mobile.core.ui.utils.BaseViewModel
 import org.mifos.mobile.core.ui.utils.ScreenUiState
 
 /**
+ * Extension function to filter a list of AccountOptions to include only SAVINGS accounts.
+ */
+private fun List<AccountOption>.filterSavingsAccounts(): List<AccountOption> =
+    filter { it.accountType?.value == AccountType.SAVINGS.value }
+
+
+/**
  * ViewModel for the Make Transfer screen.
  *
  * This ViewModel handles the business logic for making a transfer, including fetching
@@ -161,7 +168,7 @@ internal class TptViewModel(
      */
     private fun handleFromAccountChange(fromAccount: String) {
         val fromAccountSelected = state.accountOptionsTemplate.fromAccountOptions
-            .filter { it.accountType?.value == AccountType.SAVINGS.value }
+            .filterSavingsAccounts()
             .find { it.accountNo == fromAccount }
 
         val toAccounts = state.accountOptionsTemplate.toAccountOptions
@@ -190,10 +197,8 @@ internal class TptViewModel(
             .find { it.accountNo == toAccount }
 
         val fromAccounts = state.accountOptionsTemplate.fromAccountOptions
-            .filter {
-                it.accountType?.value == AccountType.SAVINGS.value &&
-                    it.accountNo != toAccount
-            }
+            .filterSavingsAccounts()
+            .filter { it.accountNo != toAccount }
 
         updateState {
             it.copy(
@@ -423,9 +428,7 @@ internal class TptViewModel(
             is DataState.Success -> {
                 val template = dataState.data
 
-                val savingsFromAccounts = template.fromAccountOptions.filter {
-                    it.accountType?.value == AccountType.SAVINGS.value
-                }
+                val savingsFromAccounts = template.fromAccountOptions.filterSavingsAccounts()
 
                 updateState {
                     it.copy(

--- a/feature/third-party-transfer/src/commonMain/kotlin/org/mifos/mobile/feature/third/party/transfer/thirdPartyTransfer/TptViewModel.kt
+++ b/feature/third-party-transfer/src/commonMain/kotlin/org/mifos/mobile/feature/third/party/transfer/thirdPartyTransfer/TptViewModel.kt
@@ -38,7 +38,6 @@ import org.mifos.mobile.core.ui.utils.ScreenUiState
 private fun List<AccountOption>.filterSavingsAccounts(): List<AccountOption> =
     filter { it.accountType?.value == AccountType.SAVINGS.value }
 
-
 /**
  * ViewModel for the Make Transfer screen.
  *

--- a/feature/third-party-transfer/src/commonMain/kotlin/org/mifos/mobile/feature/third/party/transfer/thirdPartyTransfer/TptViewModel.kt
+++ b/feature/third-party-transfer/src/commonMain/kotlin/org/mifos/mobile/feature/third/party/transfer/thirdPartyTransfer/TptViewModel.kt
@@ -28,6 +28,7 @@ import org.mifos.mobile.core.datastore.UserPreferencesRepository
 import org.mifos.mobile.core.model.entity.payload.ReviewTransferPayload
 import org.mifos.mobile.core.model.entity.templates.account.AccountOption
 import org.mifos.mobile.core.model.entity.templates.account.AccountOptionsTemplate
+import org.mifos.mobile.core.model.enums.AccountType
 import org.mifos.mobile.core.ui.utils.BaseViewModel
 import org.mifos.mobile.core.ui.utils.ScreenUiState
 
@@ -160,11 +161,12 @@ internal class TptViewModel(
      */
     private fun handleFromAccountChange(fromAccount: String) {
         val fromAccountSelected = state.accountOptionsTemplate.fromAccountOptions
+            .filter { it.accountType?.value == AccountType.SAVINGS.value }
             .find { it.accountNo == fromAccount }
 
-        val toAccounts = state.accountOptionsTemplate.toAccountOptions.filter {
-            it.accountNo != fromAccount
-        }
+        val toAccounts = state.accountOptionsTemplate.toAccountOptions
+            .filter { it.accountNo != fromAccount }
+
         updateState {
             it.copy(
                 fromAccount = fromAccountSelected,
@@ -187,9 +189,11 @@ internal class TptViewModel(
         val toAccountSelected = state.accountOptionsTemplate.toAccountOptions
             .find { it.accountNo == toAccount }
 
-        val fromAccounts = state.accountOptionsTemplate.fromAccountOptions.filter {
-            it.accountNo != toAccount
-        }
+        val fromAccounts = state.accountOptionsTemplate.fromAccountOptions
+            .filter {
+                it.accountType?.value == AccountType.SAVINGS.value &&
+                    it.accountNo != toAccount
+            }
 
         updateState {
             it.copy(
@@ -417,10 +421,16 @@ internal class TptViewModel(
             DataState.Loading -> showLoading()
 
             is DataState.Success -> {
+                val template = dataState.data
+
+                val savingsFromAccounts = template.fromAccountOptions.filter {
+                    it.accountType?.value == AccountType.SAVINGS.value
+                }
+
                 updateState {
                     it.copy(
                         accountOptionsTemplate = dataState.data,
-                        fromAccountOptions = dataState.data.fromAccountOptions,
+                        fromAccountOptions = savingsFromAccounts,
                         toAccountOptions = dataState.data.toAccountOptions,
                         uiState = ScreenUiState.Success,
                     )

--- a/feature/third-party-transfer/src/commonMain/kotlin/org/mifos/mobile/feature/third/party/transfer/thirdPartyTransfer/TptViewModel.kt
+++ b/feature/third-party-transfer/src/commonMain/kotlin/org/mifos/mobile/feature/third/party/transfer/thirdPartyTransfer/TptViewModel.kt
@@ -33,12 +33,6 @@ import org.mifos.mobile.core.ui.utils.BaseViewModel
 import org.mifos.mobile.core.ui.utils.ScreenUiState
 
 /**
- * Extension function to filter a list of AccountOptions to include only SAVINGS accounts.
- */
-private fun List<AccountOption>.filterSavingsAccounts(): List<AccountOption> =
-    filter { it.accountType?.value == AccountType.SAVINGS.value }
-
-/**
  * ViewModel for the Make Transfer screen.
  *
  * This ViewModel handles the business logic for making a transfer, including fetching
@@ -608,3 +602,9 @@ internal sealed class ValidationResult {
      */
     data class Error(val message: StringResource) : ValidationResult()
 }
+
+/**
+ * Extension function to filter a list of AccountOptions to include only SAVINGS accounts.
+ */
+private fun List<AccountOption>.filterSavingsAccounts(): List<AccountOption> =
+    filter { it.accountType?.value == AccountType.SAVINGS.value }


### PR DESCRIPTION


Fixes - [MM-503](https://mifosforge.jira.com/jira/software/c/projects/MM/boards/65?selectedIssue=MM-503)

This PR ensures that **Loan Accounts** are excluded from the "From Account" selector in Transfer. Transfers should strictly be initiated from Savings Accounts only.

Please Add Screenshots If there are any UI changes.

| Before Fix | After Fix |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/2938469f-0d7c-4b41-8b53-3077e9a883d4" width="300" /> | <img src="https://github.com/user-attachments/assets/90e681ee-9ed5-48f5-a6e7-8047451edb67" width="300" /> |


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the static analysis check `./gradlew check` or `ci-prepush.sh` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.

[MM-503]: https://mifosforge.jira.com/browse/MM-503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * From-account choices in third-party transfers are now restricted to SAVINGS accounts to prevent invalid selections.
  * To-account lists consistently exclude the currently selected from-account to avoid duplicate or conflicting options.
  * Transfer templates now populate from-account choices using the same SAVINGS-only rule for consistent, non-confusing options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->