### PR TITLE
fix(core-base/platform): prevent crash on Profile tab tap

### DIFF
--- a/core-base/platform/src/commonMain/kotlin/template/core/base/platform/LocalManagerProviders.kt
+++ b/core-base/platform/src/commonMain/kotlin/template/core/base/platform/LocalManagerProviders.kt
@@ -42,7 +42,7 @@ expect fun LocalManagerProvider(
  * Provides access to the app review manager throughout the app.
  */
 val LocalAppReviewManager: ProvidableCompositionLocal<AppReviewManager> = compositionLocalOf {
-    error("CompositionLocal AppReviewManager not present")
+    NoOpAppReviewManager
 }
 
 /**
@@ -57,4 +57,9 @@ val LocalIntentManager: ProvidableCompositionLocal<IntentManager> = compositionL
  */
 val LocalAppUpdateManager: ProvidableCompositionLocal<AppUpdateManager> = compositionLocalOf {
     error("CompositionLocal LocalAppUpdateManager not present")
+}
+
+object NoOpAppReviewManager : AppReviewManager {
+    override fun promptForReview() = Unit
+    override fun promptForCustomReview() = Unit
 }


### PR DESCRIPTION
### Fixes
Fixes – [MM-532](https://mifosforge.jira.com/browse/MM-532)

### Description
This PR fixes a crash on **non-Android platforms (iOS)** that occurred when the user clicked on the **Profile tab**.  
The issue was specific to the non-Android platform implementation and did not affect Android.

The crash was caused by a **missing platform-specific implementation** of `AppReviewManager` that was referenced from shared Compose UI code. Since this implementation existed only on Android, accessing it on iOS resulted in a runtime crash.

### Behavior Changes
| Before | After |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/6db5ced4-fc79-43ce-be3b-f5693b506bd2" width="200" alt="Before"> | <img src="https://github.com/user-attachments/assets/31f26b8e-b343-4bfb-8ce9-c4128c2eefe4" width="200" alt="After"> |

| Before | After |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/3cd43afd-efd8-448f-88a1-c81ee79e28d7" width="300" alt="Before"> | <img src="https://github.com/user-attachments/assets/fbf84b89-7daf-4545-8b2b-77a1d33f3905" width="300" alt="After"> |

### Fix
A **No-Op implementation** was introduced for non-Android platforms to safely satisfy the dependency.

- Added `NoOpAppReviewManager` as an empty implementation
- Ensured shared UI code does not crash due to missing platform-specific implementations

```kotlin
val LocalAppReviewManager: ProvidableCompositionLocal<AppReviewManager> =
    compositionLocalOf { NoOpAppReviewManager }


[MM-532]: https://mifosforge.jira.com/browse/MM-532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduces a safe, inert fallback for the app review handler so the app no longer fails when the review component is absent, ensuring stable behavior.
* **Bug Fix**
  * Prevents runtime errors related to missing review support, improving app resilience and the user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->