### PR TITLE
MM-501: add cmp-navigation to sync workflow

### DIFF
--- a/.github/workflows/sync-dirs.yaml
+++ b/.github/workflows/sync-dirs.yaml
@@ -58,6 +58,7 @@ jobs:
             "cmp-ios"
             "cmp-web"
             "cmp-shared"
+            "cmp-navigation"
             "core-base"
             "build-logic"
             "fastlane"
@@ -248,6 +249,8 @@ jobs:
             - cmp-ios (excluding iosApp/Assets.xcassets)
             - cmp-web (excluding src/jsMain/resources, src/wasmJsMain/resources)
             - cmp-shared
+            - cmp-navigation
+            - core-base
             - build-logic
             - fastlane
             - scripts

--- a/sync-dirs.sh
+++ b/sync-dirs.sh
@@ -28,6 +28,7 @@ SYNC_DIRS=(
     "cmp-ios"
     "cmp-web"
     "cmp-shared"
+    "cmp-navigation"
     "core-base"
     "build-logic"
     "fastlane"


### PR DESCRIPTION
Fixes - [Jira-#MM-501](https://mifosforge.jira.com/browse/MM-501)

Please Add Screenshots If there are any UI changes.

| Before                                     | After                                  |
|--------------------------------------------|----------------------------------------|
|                                            |                                        |


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the static analysis check `./gradlew check` or `ci-prepush.sh` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated upstream synchronization now includes the navigation component directory and the core-base directory, so those files are included in regular syncs.
  * This is an additive change with no functional or API alterations; it simply ensures these components stay up to date as part of routine sync operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->