### PR TITLE
fix(core-ui): ensure dropdown menu items are visible on iOS

### DIFF
--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosDropDownTextField.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosDropDownTextField.kt
@@ -9,23 +9,20 @@
  */
 package org.mifos.mobile.core.ui.component
 
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsPressedAsState
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -40,6 +37,7 @@ import org.mifos.mobile.core.designsystem.theme.MifosMobileTheme
 import org.mifos.mobile.core.ui.utils.DevicePreview
 import template.core.base.designsystem.theme.KptTheme
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MifosDropDownTextField(
     onClick: (Int, String) -> Unit,
@@ -52,23 +50,23 @@ fun MifosDropDownTextField(
     selectedOption: String? = null,
 ) {
     var expanded by rememberSaveable { mutableStateOf(false) }
-    val interactionSource = remember { MutableInteractionSource() }
-    val isPressed by interactionSource.collectIsPressedAsState()
 
-    LaunchedEffect(key1 = isPressed) {
-        if (isPressed) expanded = true && isEnabled
-    }
-
-    Box(
-        modifier = modifier.alpha(if (!isEnabled) 0.4f else 1f),
+    ExposedDropdownMenuBox(
+        expanded = expanded && isEnabled,
+        onExpandedChange = {
+            if (isEnabled) {
+                expanded = !expanded
+            }
+        },
+        modifier = modifier.alpha(if (!isEnabled) 0.4f else 1f).fillMaxWidth(),
     ) {
         OutlinedTextField(
             value = selectedOption ?: "",
             onValueChange = { },
             label = { Text(stringResource(labelResId)) },
-            interactionSource = interactionSource,
             modifier = Modifier
-                .fillMaxWidth(),
+                .fillMaxWidth()
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable, true),
             readOnly = true,
             enabled = isEnabled,
             textStyle = KptTheme.typography.labelMedium,
@@ -95,12 +93,11 @@ fun MifosDropDownTextField(
             ),
         )
 
-        DropdownMenu(
+        ExposedDropdownMenu(
             expanded = expanded && isEnabled,
-            modifier = Modifier
-                .fillMaxWidth(0.92f)
-                .heightIn(max = DesignToken.sizes.dropDownMenuHeightInDp200),
             onDismissRequest = { expanded = false },
+            modifier = Modifier
+                .heightIn(max = DesignToken.sizes.dropDownMenuHeightInDp200),
         ) {
             optionsList.forEachIndexed { index, item ->
                 DropdownMenuItem(
@@ -115,6 +112,7 @@ fun MifosDropDownTextField(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MifosDropDownDoubleTextField(
     onClick: (Int, Pair<String, String>) -> Unit,
@@ -127,23 +125,23 @@ fun MifosDropDownDoubleTextField(
     selectedOption: String? = null,
 ) {
     var expanded by rememberSaveable { mutableStateOf(false) }
-    val interactionSource = remember { MutableInteractionSource() }
-    val isPressed by interactionSource.collectIsPressedAsState()
 
-    LaunchedEffect(key1 = isPressed) {
-        if (isPressed) expanded = true && isEnabled
-    }
-
-    Box(
-        modifier = modifier.alpha(if (!isEnabled) 0.4f else 1f),
+    ExposedDropdownMenuBox(
+        expanded = expanded && isEnabled,
+        onExpandedChange = {
+            if (isEnabled) {
+                expanded = !expanded
+            }
+        },
+        modifier = modifier.alpha(if (!isEnabled) 0.4f else 1f).fillMaxWidth(),
     ) {
         OutlinedTextField(
             value = selectedOption ?: "",
             onValueChange = { },
             label = { Text(stringResource(labelResId)) },
-            interactionSource = interactionSource,
             modifier = Modifier
-                .fillMaxWidth(),
+                .fillMaxWidth()
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable, true),
             readOnly = true,
             enabled = isEnabled,
             textStyle = KptTheme.typography.labelSmall,
@@ -170,12 +168,11 @@ fun MifosDropDownDoubleTextField(
             ),
         )
 
-        DropdownMenu(
+        ExposedDropdownMenu(
             expanded = expanded && isEnabled,
-            modifier = Modifier
-                .fillMaxWidth(0.92f)
-                .heightIn(max = DesignToken.sizes.dropDownMenuHeightInDp200),
             onDismissRequest = { expanded = false },
+            modifier = Modifier
+                .heightIn(max = DesignToken.sizes.dropDownMenuHeightInDp200),
         ) {
             optionsList.forEachIndexed { index, item ->
                 DropdownMenuItem(
@@ -189,7 +186,6 @@ fun MifosDropDownDoubleTextField(
                             Text(text = item.second)
                         }
                     },
-
                 )
             }
         }


### PR DESCRIPTION
### Title
Fix iOS Dropdown Interaction via `ExposedDropdownMenuBox`

Fixes [MM-545](https://mifosforge.jira.com/browse/MM-545)

## Description
This PR fixes a critical UI bug where dropdown menus were unresponsive on iOS devices in `MifosDropDownTextField` and `MifosDropDownDoubleTextField`.

### Behavior Changes
| Before | After |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/e715fafa-6ad0-497d-b5b1-9272ce48dda3" width="200" alt="Before"> | <img src="https://github.com/user-attachments/assets/85777d06-7e41-40db-92d5-68e55b380b5a" width="200" alt="After"> |

## The Issue: Touch Race Condition
The previous implementation relied on `interactionSource.collectIsPressedAsState()` to toggle the menu.

**Diagnosis:**
During debugging, **setting `expanded = true` by default resulted in the menu being fully visible on iOS.** This confirmed that the issue was not related to rendering coordinates or z-index (anchors), but rather a failure in the state toggling logic upon interaction.

**Root Cause:**
On iOS, clicking the text field triggered two conflicting events simultaneously:
1.  **Open Event:** The `interactionSource` detected a press and set `expanded = true`.
2.  **Dismiss Event:** The `DropdownMenu` logic detected a tap "outside" its active bounds (on the text field itself) and fired `onDismissRequest`, setting `expanded = false`.

The "Dismiss" event consistently overrode the "Open" event. This caused a race condition where the menu would close immediately upon opening, appearing to the user as if it never opened.

## The Fix
I have migrated both dropdown components to use the Material 3 **`ExposedDropdownMenuBox`** API (consistent with usage in `MifosOutlineDropDown`).

**Why this fixes it:**
The `ExposedDropdownMenuBox` replaces the raw `interactionSource` listener with dedicated state management logic. It correctly identifies that a click on the anchor (the text field) is a specific "Toggle" action rather than a generic "Outside Dismiss" action.

This ensures that clicking the arrow reliably toggles the state, effectively resolving the race condition between the open and dismiss events on iOS.

## Testing
* **Android:** Verified consistent behavior (No regressions).
<video src="https://github.com/user-attachments/assets/62528df1-bc8a-4ef0-ab0f-0d9fde0e3864" controls height="200"></video> 

* **Desktop:** Verified consistent behavior (No regressions).
<video src="https://github.com/user-attachments/assets/30e881e8-40cd-46e4-b6a2-8e60ea20733f" controls height="200"></video> 

* **iOS:** Verified that the dropdown now toggles reliably without flickering.

[MM-545]: https://mifosforge.jira.com/browse/MM-545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced dropdown menu components with improved interaction handling and Material3 styling for better responsiveness and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->