### PR TITLE
fix(loan-account): Set fixed height for label value card

### DIFF
--- a/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/loanAccountDetails/LoanAccountDetailsScreen.kt
+++ b/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/loanAccountDetails/LoanAccountDetailsScreen.kt
@@ -12,9 +12,9 @@ package org.mifos.mobile.feature.loanaccount.loanAccountDetails
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
@@ -247,7 +247,7 @@ internal fun AccountDetailsGrid(
                 details.forEach { item ->
                     MifosLabelValueCard(
                         modifier = Modifier
-                            .defaultMinSize(minHeight = DesignToken.sizes.cardDp64)
+                            .height(DesignToken.sizes.cardDp64)
                             .weight(1f),
                         label = stringResource(item.label),
                         value = item.value,


### PR DESCRIPTION
Changed `defaultMinSize` to a fixed `height` for the `MifosLabelValueCard` in the loan account details screen.

Fixes - [Jira-#MM-552](https://mifosforge.jira.com/browse/MM-552)


Please Add Screenshots If there are any UI changes.

| Before | After |
|--------|-------|
| <img width="400" alt="Before" src="https://github.com/user-attachments/assets/b6c5c0b5-d29a-41f0-bc44-323774780d23" /> | <img width="400" alt="After" src="https://github.com/user-attachments/assets/ebe22212-9853-44b0-b862-fc6137d08e85" /> |



Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the static analysis check `./gradlew check` or `ci-prepush.sh` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined card layout rendering in the Loan Account Details screen for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->