### PR TITLE
feat(i18n): add language-specific strings for multiple locales

### DIFF
--- a/cmp-shared/cmp_shared.podspec
+++ b/cmp-shared/cmp_shared.podspec
@@ -50,5 +50,5 @@ Pod::Spec.new do |spec|
             SCRIPT
         }
     ]
-    spec.resources = ['build\compose\cocoapods\compose-resources']
+    spec.resources = ['build/compose/cocoapods/compose-resources']
 end

--- a/cmp-shared/cmp_shared.podspec
+++ b/cmp-shared/cmp_shared.podspec
@@ -50,5 +50,5 @@ Pod::Spec.new do |spec|
             SCRIPT
         }
     ]
-    spec.resources = ['build/compose/cocoapods/compose-resources']
+    spec.resources = ['build\compose\cocoapods\compose-resources']
 end

--- a/feature/accounts/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/accounts/src/commonMain/composeResources/values-ar/strings.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_account_title">الحسابات</string>
+    <string name="feature_loan_account_title">حسابات القروض</string>
+    <string name="feature_saving_account_title">حسابات التوفير</string>
+    <string name="feature_share_account_title">حسابات الأسهم</string>
+
+    <string name="feature_accounts_filter_status">الحالة</string>
+    <string name="feature_accounts_filter_type">النوع</string>
+
+<string name="feature_loan_account_filter_active">نشط</string>
+    <string name="feature_loan_account_filter_approval_pending">بانتظار الموافقة</string>
+    <string name="feature_loan_account_filter_closed">مغلق</string>
+    <string name="feature_loan_account_filter_disburse">بانتظار الصرف</string>
+    <string name="feature_loan_account_filter_overpaid">مدفوع بالزيادة</string>
+    <string name="feature_loan_account_filter_in_arrears">متأخرات</string>
+    <string name="feature_loan_account_filter_withdrawn">مسحوب</string>
+    <string name="feature_loan_account_filter_matured">مستحق</string>
+    <string name="feature_loan_account_filter_rejected">مرفوض</string>
+
+    <string name="feature_loan_account_filter_personal">شخصي</string>
+    <string name="feature_loan_account_filter_bronze">برونزي</string>
+
+    <string name="feature_savings_filter_wallet_account">حساب المحفظة</string>
+    <string name="feature_savings_filter_bank_account">حساب بنكي</string>
+    <string name="feature_savings_filter_group_account">حساب مجموعة</string>
+    <string name="feature_savings_filter_nb_account">حساب NB</string>
+
+    <string name="feature_savings_filter_active_account">نشط</string>
+    <string name="feature_savings_filter_pending_account">بانتظار الموافقة</string>
+    <string name="feature_savings_filter_closed_account">مغلق</string>
+    <string name="feature_savings_filter_matured_account">مستحق</string>
+    <string name="feature_savings_filter_approved_account">تمت الموافقة</string>
+
+    <string name="feature_savings_filter">تصفية</string>
+    <string name="feature_savings_reset">إعادة تعيين</string>
+    <string name="feature_savings_apply">تطبيق</string>
+    <string name="feature_filters_count">%1$s تم التحديد</string>
+
+    <string name="feature_transaction_transaction_history">سجل المعاملات</string>
+    <string name="feature_transaction_statement">كشف حساب</string>
+    <string name="feature_transaction_download_icon_description">أيقونة التنزيل</string>
+    <string name="feature_transaction_filter">تصفية</string>
+    <string name="feature_transaction_filter_icon_description">أيقونة التصفية</string>
+
+    <string name="feature_transaction_filter_credit">إيداع</string>
+    <string name="feature_transaction_filter_debit">خصم</string>
+
+    <string name="feature_transaction_filter_past_month">الشهر الماضي</string>
+    <string name="feature_transaction_filter_past_3_months">آخر 3 أشهر</string>
+    <string name="feature_transaction_filter_past_6_months">آخر 6 أشهر</string>
+    <string name="feature_transaction_filter_past_1_year">آخر سنة</string>
+    <string name="feature_transaction_filter_past_2_years">آخر سنتين</string>
+
+    <string name="feature_transaction_type">نوع المعاملة</string>
+    <string name="feature_duration">المدة</string>
+    <string name="feature_no_transactions_found">لا توجد معاملات</string>
+    <string name="feature_no__filtered_transactions_found">لا توجد معاملات للتصفية المحددة</string>
+
+    <string name="feature_generic_error_server">مشكلة في الخادم من جانبنا، لا يمكن المتابعة، حاول مرة أخرى بعد قليل</string>
+
+    <string name="feature_transaction_details">تفاصيل المعاملة</string>
+    <string name="feature_transaction_detail_id">معرف المعاملة</string>
+    <string name="feature_transaction_detail_transfer_description">وصف التحويل</string>
+    <string name="feature_transaction_detail_date">التاريخ</string>
+    <string name="feature_transaction_detail_status">الحالة</string>
+    <string name="feature_transaction_detail_status_success">ناجحة</string>
+    <string name="feature_transaction_detail_account_ref">مرجع الحساب</string>
+    <string name="feature_transaction_detail_payment_method">طريقة الدفع</string>
+    <string name="feature_transaction_detail_type">النوع</string>
+    <string name="feature_transaction_detail_status_reversed">معكوسة</string>
+    <string name="feature_transaction_detail_receipt">رقم الإيصال</string>
+    <string name="feature_transaction_detail_external_id">المعرف الخارجي</string>
+    <string name="feature_transaction_detail_breakdown">التفاصيل</string>
+    <string name="feature_transaction_detail_principal">أصل المبلغ</string>
+    <string name="feature_transaction_detail_interest">الفائدة</string>
+    <string name="feature_transaction_detail_fees">الرسوم</string>
+    <string name="feature_transaction_detail_penalties">العقوبات</string>
+    <string name="feature_transaction_detail_balance">الرصيد المتبقي</string>
+    <string name="feature_transaction_detail_default_type">معاملة</string>
+
+</resources>

--- a/feature/accounts/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/accounts/src/commonMain/composeResources/values-ar/strings.xml
@@ -18,7 +18,7 @@
     <string name="feature_accounts_filter_status">الحالة</string>
     <string name="feature_accounts_filter_type">النوع</string>
 
-<string name="feature_loan_account_filter_active">نشط</string>
+    <string name="feature_loan_account_filter_active">نشط</string>
     <string name="feature_loan_account_filter_approval_pending">بانتظار الموافقة</string>
     <string name="feature_loan_account_filter_closed">مغلق</string>
     <string name="feature_loan_account_filter_disburse">بانتظار الصرف</string>

--- a/feature/accounts/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/accounts/src/commonMain/composeResources/values-de/strings.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_account_title">Konten</string>
+    <string name="feature_loan_account_title">Kreditkonten</string>
+    <string name="feature_saving_account_title">Sparkonten</string>
+    <string name="feature_share_account_title">Aktienkonten</string>
+
+    <string name="feature_accounts_filter_status">Status</string>
+    <string name="feature_accounts_filter_type">Typ</string>
+
+<string name="feature_loan_account_filter_active">Aktiv</string>
+    <string name="feature_loan_account_filter_approval_pending">Genehmigung ausstehend</string>
+    <string name="feature_loan_account_filter_closed">Geschlossen</string>
+    <string name="feature_loan_account_filter_disburse">Warten auf Auszahlung</string>
+    <string name="feature_loan_account_filter_overpaid">Überzahlt</string>
+    <string name="feature_loan_account_filter_in_arrears">Im Rückstand</string>
+    <string name="feature_loan_account_filter_withdrawn">Zurückgezogen</string>
+    <string name="feature_loan_account_filter_matured">Fällig</string>
+    <string name="feature_loan_account_filter_rejected">Abgelehnt</string>
+
+    <string name="feature_loan_account_filter_personal">Persönlich</string>
+    <string name="feature_loan_account_filter_bronze">Bronze</string>
+
+    <string name="feature_savings_filter_wallet_account">Wallet-Konto</string>
+    <string name="feature_savings_filter_bank_account">Bankkonto</string>
+    <string name="feature_savings_filter_group_account">Gruppenkonto</string>
+    <string name="feature_savings_filter_nb_account">NB-Konto</string>
+
+    <string name="feature_savings_filter_active_account">Aktiv</string>
+    <string name="feature_savings_filter_pending_account">Genehmigung ausstehend</string>
+    <string name="feature_savings_filter_closed_account">Geschlossen</string>
+    <string name="feature_savings_filter_matured_account">Fällig</string>
+    <string name="feature_savings_filter_approved_account">Genehmigt</string>
+
+    <string name="feature_savings_filter">Filter</string>
+    <string name="feature_savings_reset">Zurücksetzen</string>
+    <string name="feature_savings_apply">Anwenden</string>
+    <string name="feature_filters_count">%1$s Ausgewählt</string>
+
+    <string name="feature_transaction_transaction_history">Transaktionsverlauf</string>
+    <string name="feature_transaction_statement">Kontoauszug</string>
+    <string name="feature_transaction_download_icon_description">Download-Symbol</string>
+    <string name="feature_transaction_filter">Filtern</string>
+    <string name="feature_transaction_filter_icon_description">Filter-Symbol</string>
+
+    <string name="feature_transaction_filter_credit">Haben</string>
+    <string name="feature_transaction_filter_debit">Soll</string>
+
+    <string name="feature_transaction_filter_past_month">Letzter Monat</string>
+    <string name="feature_transaction_filter_past_3_months">Letzte 3 Monate</string>
+    <string name="feature_transaction_filter_past_6_months">Letzte 6 Monate</string>
+    <string name="feature_transaction_filter_past_1_year">Letztes Jahr</string>
+    <string name="feature_transaction_filter_past_2_years">Letzte 2 Jahre</string>
+
+    <string name="feature_transaction_type">Transaktionstyp</string>
+    <string name="feature_duration">Dauer</string>
+    <string name="feature_no_transactions_found">Keine Transaktionen gefunden</string>
+    <string name="feature_no__filtered_transactions_found">Keine Transaktionen für ausgewählte Filter gefunden</string>
+
+    <string name="feature_generic_error_server">Serverproblem auf unserer Seite, Vorgang kann nicht fortgesetzt werden. Bitte versuchen Sie es später erneut.</string>
+
+    <string name="feature_transaction_details">Transaktionsdetails</string>
+    <string name="feature_transaction_detail_id">Transaktions-ID</string>
+    <string name="feature_transaction_detail_transfer_description">Überweisungsbeschreibung</string>
+    <string name="feature_transaction_detail_date">Datum</string>
+    <string name="feature_transaction_detail_status">Status</string>
+    <string name="feature_transaction_detail_status_success">Erfolgreich</string>
+    <string name="feature_transaction_detail_account_ref">Konto-Ref</string>
+    <string name="feature_transaction_detail_payment_method">Zahlungsmethode</string>
+    <string name="feature_transaction_detail_type">Typ</string>
+    <string name="feature_transaction_detail_status_reversed">Storniert</string>
+    <string name="feature_transaction_detail_receipt">Beleg #</string>
+    <string name="feature_transaction_detail_external_id">Externe ID</string>
+    <string name="feature_transaction_detail_breakdown">Aufschlüsselung</string>
+    <string name="feature_transaction_detail_principal">Kapital</string>
+    <string name="feature_transaction_detail_interest">Zinsen</string>
+    <string name="feature_transaction_detail_fees">Gebühren</string>
+    <string name="feature_transaction_detail_penalties">Strafen</string>
+    <string name="feature_transaction_detail_balance">Verbleibender Saldo</string>
+    <string name="feature_transaction_detail_default_type">Transaktion</string>
+
+</resources>

--- a/feature/accounts/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/accounts/src/commonMain/composeResources/values-de/strings.xml
@@ -18,7 +18,7 @@
     <string name="feature_accounts_filter_status">Status</string>
     <string name="feature_accounts_filter_type">Typ</string>
 
-<string name="feature_loan_account_filter_active">Aktiv</string>
+    <string name="feature_loan_account_filter_active">Aktiv</string>
     <string name="feature_loan_account_filter_approval_pending">Genehmigung ausstehend</string>
     <string name="feature_loan_account_filter_closed">Geschlossen</string>
     <string name="feature_loan_account_filter_disburse">Warten auf Auszahlung</string>

--- a/feature/accounts/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/accounts/src/commonMain/composeResources/values-fr/strings.xml
@@ -18,7 +18,7 @@
     <string name="feature_accounts_filter_status">Statut</string>
     <string name="feature_accounts_filter_type">Type</string>
 
-<string name="feature_loan_account_filter_active">Actif</string>
+    <string name="feature_loan_account_filter_active">Actif</string>
     <string name="feature_loan_account_filter_approval_pending">En attente d\'approbation</string>
     <string name="feature_loan_account_filter_closed">Fermé</string>
     <string name="feature_loan_account_filter_disburse">En attente de versement</string>

--- a/feature/accounts/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/accounts/src/commonMain/composeResources/values-fr/strings.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_account_title">Comptes</string>
+    <string name="feature_loan_account_title">Comptes de prêt</string>
+    <string name="feature_saving_account_title">Comptes d\'épargne</string>
+    <string name="feature_share_account_title">Comptes de parts</string>
+
+    <string name="feature_accounts_filter_status">Statut</string>
+    <string name="feature_accounts_filter_type">Type</string>
+
+<string name="feature_loan_account_filter_active">Actif</string>
+    <string name="feature_loan_account_filter_approval_pending">En attente d\'approbation</string>
+    <string name="feature_loan_account_filter_closed">Fermé</string>
+    <string name="feature_loan_account_filter_disburse">En attente de versement</string>
+    <string name="feature_loan_account_filter_overpaid">Trop-perçu</string>
+    <string name="feature_loan_account_filter_in_arrears">En retard</string>
+    <string name="feature_loan_account_filter_withdrawn">Retiré</string>
+    <string name="feature_loan_account_filter_matured">Échu</string>
+    <string name="feature_loan_account_filter_rejected">Rejeté</string>
+
+    <string name="feature_loan_account_filter_personal">Personnel</string>
+    <string name="feature_loan_account_filter_bronze">Bronze</string>
+
+    <string name="feature_savings_filter_wallet_account">Compte portefeuille</string>
+    <string name="feature_savings_filter_bank_account">Compte bancaire</string>
+    <string name="feature_savings_filter_group_account">Compte de groupe</string>
+    <string name="feature_savings_filter_nb_account">Compte NB</string>
+
+    <string name="feature_savings_filter_active_account">Actif</string>
+    <string name="feature_savings_filter_pending_account">En attente d\'approbation</string>
+    <string name="feature_savings_filter_closed_account">Fermé</string>
+    <string name="feature_savings_filter_matured_account">Échu</string>
+    <string name="feature_savings_filter_approved_account">Approuvé</string>
+
+    <string name="feature_savings_filter">Filtres</string>
+    <string name="feature_savings_reset">Réinitialiser</string>
+    <string name="feature_savings_apply">Appliquer</string>
+    <string name="feature_filters_count">%1$s Sélectionné(s)</string>
+
+    <string name="feature_transaction_transaction_history">Historique des transactions</string>
+    <string name="feature_transaction_statement">Relevé</string>
+    <string name="feature_transaction_download_icon_description">Icône de téléchargement</string>
+    <string name="feature_transaction_filter">Filtrer</string>
+    <string name="feature_transaction_filter_icon_description">Icône de filtre</string>
+
+    <string name="feature_transaction_filter_credit">Crédit</string>
+    <string name="feature_transaction_filter_debit">Débit</string>
+
+    <string name="feature_transaction_filter_past_month">Mois dernier</string>
+    <string name="feature_transaction_filter_past_3_months">3 derniers mois</string>
+    <string name="feature_transaction_filter_past_6_months">6 derniers mois</string>
+    <string name="feature_transaction_filter_past_1_year">Année dernière</string>
+    <string name="feature_transaction_filter_past_2_years">2 dernières années</string>
+
+    <string name="feature_transaction_type">Type de transaction</string>
+    <string name="feature_duration">Durée</string>
+    <string name="feature_no_transactions_found">Aucune transaction trouvée</string>
+    <string name="feature_no__filtered_transactions_found">Aucune transaction trouvée pour les filtres sélectionnés</string>
+
+    <string name="feature_generic_error_server">Problème de serveur de notre côté, impossible de continuer. Réessayez dans un moment.</string>
+
+    <string name="feature_transaction_details">Détails de la transaction</string>
+    <string name="feature_transaction_detail_id">ID de transaction</string>
+    <string name="feature_transaction_detail_transfer_description">Description du transfert</string>
+    <string name="feature_transaction_detail_date">Date</string>
+    <string name="feature_transaction_detail_status">Statut</string>
+    <string name="feature_transaction_detail_status_success">Succès</string>
+    <string name="feature_transaction_detail_account_ref">Réf compte</string>
+    <string name="feature_transaction_detail_payment_method">Moyen de paiement</string>
+    <string name="feature_transaction_detail_type">Type</string>
+    <string name="feature_transaction_detail_status_reversed">Annulé</string>
+    <string name="feature_transaction_detail_receipt">Reçu n°</string>
+    <string name="feature_transaction_detail_external_id">ID externe</string>
+    <string name="feature_transaction_detail_breakdown">Détail</string>
+    <string name="feature_transaction_detail_principal">Principal</string>
+    <string name="feature_transaction_detail_interest">Intérêts</string>
+    <string name="feature_transaction_detail_fees">Frais</string>
+    <string name="feature_transaction_detail_penalties">Pénalités</string>
+    <string name="feature_transaction_detail_balance">Solde restant</string>
+    <string name="feature_transaction_detail_default_type">Transaction</string>
+
+</resources>

--- a/feature/accounts/src/commonMain/composeResources/values-gu/strings.xml
+++ b/feature/accounts/src/commonMain/composeResources/values-gu/strings.xml
@@ -18,7 +18,7 @@
     <string name="feature_accounts_filter_status">સ્થિતિ</string>
     <string name="feature_accounts_filter_type">પ્રકાર</string>
 
-<string name="feature_loan_account_filter_active">સક્રિય</string>
+    <string name="feature_loan_account_filter_active">સક્રિય</string>
     <string name="feature_loan_account_filter_approval_pending">મંજૂરી બાકી</string>
     <string name="feature_loan_account_filter_closed">બંધ</string>
     <string name="feature_loan_account_filter_disburse">વિતરણ માટે રાહ જોઈ રહ્યું છે</string>

--- a/feature/accounts/src/commonMain/composeResources/values-gu/strings.xml
+++ b/feature/accounts/src/commonMain/composeResources/values-gu/strings.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_account_title">ખાતાઓ</string>
+    <string name="feature_loan_account_title">લોન ખાતાઓ</string>
+    <string name="feature_saving_account_title">બચત ખાતાઓ</string>
+    <string name="feature_share_account_title">શેર ખાતાઓ</string>
+
+    <string name="feature_accounts_filter_status">સ્થિતિ</string>
+    <string name="feature_accounts_filter_type">પ્રકાર</string>
+
+<string name="feature_loan_account_filter_active">સક્રિય</string>
+    <string name="feature_loan_account_filter_approval_pending">મંજૂરી બાકી</string>
+    <string name="feature_loan_account_filter_closed">બંધ</string>
+    <string name="feature_loan_account_filter_disburse">વિતરણ માટે રાહ જોઈ રહ્યું છે</string>
+    <string name="feature_loan_account_filter_overpaid">વધારે ચૂકવેલ</string>
+    <string name="feature_loan_account_filter_in_arrears">બાકી લેણાં</string>
+    <string name="feature_loan_account_filter_withdrawn">પાછું ખેંચ્યું</string>
+    <string name="feature_loan_account_filter_matured">પાકતી મુદત</string>
+    <string name="feature_loan_account_filter_rejected">નકારેલ</string>
+
+    <string name="feature_loan_account_filter_personal">વ્યક્તિગત</string>
+    <string name="feature_loan_account_filter_bronze">બ્રોન્ઝ</string>
+
+    <string name="feature_savings_filter_wallet_account">વોલેટ એકાઉન્ટ</string>
+    <string name="feature_savings_filter_bank_account">બેંક એકાઉન્ટ</string>
+    <string name="feature_savings_filter_group_account">જૂથ એકાઉન્ટ</string>
+    <string name="feature_savings_filter_nb_account">NB એકાઉન્ટ</string>
+
+    <string name="feature_savings_filter_active_account">સક્રિય</string>
+    <string name="feature_savings_filter_pending_account">મંજૂરી બાકી</string>
+    <string name="feature_savings_filter_closed_account">બંધ</string>
+    <string name="feature_savings_filter_matured_account">પાકતી મુદત</string>
+    <string name="feature_savings_filter_approved_account">મંજૂર</string>
+
+    <string name="feature_savings_filter">ફિલ્ટર્સ</string>
+    <string name="feature_savings_reset">રીસેટ</string>
+    <string name="feature_savings_apply">લાગુ કરો</string>
+    <string name="feature_filters_count">%1$s પસંદ કરેલ</string>
+
+    <string name="feature_transaction_transaction_history">વ્યવહાર ઇતિહાસ</string>
+    <string name="feature_transaction_statement">સ્ટેટમેન્ટ</string>
+    <string name="feature_transaction_download_icon_description">ડાઉનલોડ આયકન</string>
+    <string name="feature_transaction_filter">ફિલ્ટર</string>
+    <string name="feature_transaction_filter_icon_description">ફિલ્ટર આયકન</string>
+
+    <string name="feature_transaction_filter_credit">જમા</string>
+    <string name="feature_transaction_filter_debit">ઉધાર</string>
+
+    <string name="feature_transaction_filter_past_month">છેલ્લો મહિનો</string>
+    <string name="feature_transaction_filter_past_3_months">છેલ્લા 3 મહિના</string>
+    <string name="feature_transaction_filter_past_6_months">છેલ્લા 6 મહિના</string>
+    <string name="feature_transaction_filter_past_1_year">છેલ્લા 1 વર્ષ</string>
+    <string name="feature_transaction_filter_past_2_years">છેલ્લા 2 વર્ષ</string>
+
+    <string name="feature_transaction_type">વ્યવહારનો પ્રકાર</string>
+    <string name="feature_duration">સમયગાળો</string>
+    <string name="feature_no_transactions_found">કોઈ વ્યવહાર મળ્યો નથી</string>
+    <string name="feature_no__filtered_transactions_found">પસંદ કરેલ ફિલ્ટર્સ માટે કોઈ વ્યવહાર મળ્યો નથી</string>
+
+    <string name="feature_generic_error_server">અમારી બાજુથી સર્વર સમસ્યા હોવાથી આગળ વધી શકાતું નથી, થોડીવાર પછી ફરી પ્રયાસ કરો</string>
+
+    <string name="feature_transaction_details">વ્યવહાર વિગતો</string>
+    <string name="feature_transaction_detail_id">ટ્રાન્ઝેક્શન આઈડી</string>
+    <string name="feature_transaction_detail_transfer_description">ટ્રાન્સફર વર્ણન</string>
+    <string name="feature_transaction_detail_date">તારીખ</string>
+    <string name="feature_transaction_detail_status">સ્થિતિ</string>
+    <string name="feature_transaction_detail_status_success">સફળ</string>
+    <string name="feature_transaction_detail_account_ref">એકાઉન્ટ રેફરન્સ</string>
+    <string name="feature_transaction_detail_payment_method">ચુકવણી પદ્ધતિ</string>
+    <string name="feature_transaction_detail_type">પ્રકાર</string>
+    <string name="feature_transaction_detail_status_reversed">ઉલટાવી</string>
+    <string name="feature_transaction_detail_receipt">રસીદ #</string>
+    <string name="feature_transaction_detail_external_id">બાહ્ય ID</string>
+    <string name="feature_transaction_detail_breakdown">બ્રેકડાઉન</string>
+    <string name="feature_transaction_detail_principal">મૂળ રકમ</string>
+    <string name="feature_transaction_detail_interest">વ્યાજ</string>
+    <string name="feature_transaction_detail_fees">ફી</string>
+    <string name="feature_transaction_detail_penalties">દંડ</string>
+    <string name="feature_transaction_detail_balance">બાકી સિલક</string>
+    <string name="feature_transaction_detail_default_type">વ્યવહાર</string>
+
+</resources>

--- a/feature/accounts/src/commonMain/composeResources/values-hi/strings.xml
+++ b/feature/accounts/src/commonMain/composeResources/values-hi/strings.xml
@@ -18,7 +18,7 @@
     <string name="feature_accounts_filter_status">स्थिति</string>
     <string name="feature_accounts_filter_type">प्रकार</string>
 
-<string name="feature_loan_account_filter_active">सक्रिय</string>
+    <string name="feature_loan_account_filter_active">सक्रिय</string>
     <string name="feature_loan_account_filter_approval_pending">अनुमोदन लंबित</string>
     <string name="feature_loan_account_filter_closed">बंद</string>
     <string name="feature_loan_account_filter_disburse">संवितरण की प्रतीक्षा में</string>

--- a/feature/accounts/src/commonMain/composeResources/values-hi/strings.xml
+++ b/feature/accounts/src/commonMain/composeResources/values-hi/strings.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_account_title">खाते</string>
+    <string name="feature_loan_account_title">ऋण खाते</string>
+    <string name="feature_saving_account_title">बचत खाते</string>
+    <string name="feature_share_account_title">शेयर खाते</string>
+
+    <string name="feature_accounts_filter_status">स्थिति</string>
+    <string name="feature_accounts_filter_type">प्रकार</string>
+
+<string name="feature_loan_account_filter_active">सक्रिय</string>
+    <string name="feature_loan_account_filter_approval_pending">अनुमोदन लंबित</string>
+    <string name="feature_loan_account_filter_closed">बंद</string>
+    <string name="feature_loan_account_filter_disburse">संवितरण की प्रतीक्षा में</string>
+    <string name="feature_loan_account_filter_overpaid">अधिक भुगतान</string>
+    <string name="feature_loan_account_filter_in_arrears">बकाया</string>
+    <string name="feature_loan_account_filter_withdrawn">निकाला गया</string>
+    <string name="feature_loan_account_filter_matured">परिपक्व</string>
+    <string name="feature_loan_account_filter_rejected">अस्वीकृत</string>
+
+    <string name="feature_loan_account_filter_personal">व्यक्तिगत</string>
+    <string name="feature_loan_account_filter_bronze">कांस्य</string>
+
+    <string name="feature_savings_filter_wallet_account">वॉलेट खाता</string>
+    <string name="feature_savings_filter_bank_account">बैंक खाता</string>
+    <string name="feature_savings_filter_group_account">समूह खाता</string>
+    <string name="feature_savings_filter_nb_account">NB खाता</string>
+
+    <string name="feature_savings_filter_active_account">सक्रिय</string>
+    <string name="feature_savings_filter_pending_account">अनुमोदन लंबित</string>
+    <string name="feature_savings_filter_closed_account">बंद</string>
+    <string name="feature_savings_filter_matured_account">परिपक्व</string>
+    <string name="feature_savings_filter_approved_account">स्वीकृत</string>
+
+    <string name="feature_savings_filter">फ़िल्टर</string>
+    <string name="feature_savings_reset">रीसेट</string>
+    <string name="feature_savings_apply">लागू करें</string>
+    <string name="feature_filters_count">%1$s चयनित</string>
+
+    <string name="feature_transaction_transaction_history">लेन-देन इतिहास</string>
+    <string name="feature_transaction_statement">विवरण (Statement)</string>
+    <string name="feature_transaction_download_icon_description">डाउनलोड आइकन</string>
+    <string name="feature_transaction_filter">फ़िल्टर</string>
+    <string name="feature_transaction_filter_icon_description">फ़िल्टर आइकन</string>
+
+    <string name="feature_transaction_filter_credit">जमा</string>
+    <string name="feature_transaction_filter_debit">नामे</string>
+
+    <string name="feature_transaction_filter_past_month">पिछला महीना</string>
+    <string name="feature_transaction_filter_past_3_months">पिछले 3 महीने</string>
+    <string name="feature_transaction_filter_past_6_months">पिछले 6 महीने</string>
+    <string name="feature_transaction_filter_past_1_year">पिछला 1 वर्ष</string>
+    <string name="feature_transaction_filter_past_2_years">पिछले 2 वर्ष</string>
+
+    <string name="feature_transaction_type">लेन-देन का प्रकार</string>
+    <string name="feature_duration">अवधि</string>
+    <string name="feature_no_transactions_found">कोई लेन-देन नहीं मिला</string>
+    <string name="feature_no__filtered_transactions_found">चयनित फ़िल्टर के लिए कोई लेन-देन नहीं मिला</string>
+
+    <string name="feature_generic_error_server">हमारी ओर से सर्वर की समस्या के कारण आगे नहीं बढ़ सकते, कुछ देर बाद पुन: प्रयास करें</string>
+
+    <string name="feature_transaction_details">लेन-देन विवरण</string>
+    <string name="feature_transaction_detail_id">लेन-देन आईडी</string>
+    <string name="feature_transaction_detail_transfer_description">स्थानांतरण विवरण</string>
+    <string name="feature_transaction_detail_date">तारीख</string>
+    <string name="feature_transaction_detail_status">स्थिति</string>
+    <string name="feature_transaction_detail_status_success">सफल</string>
+    <string name="feature_transaction_detail_account_ref">खाता संदर्भ</string>
+    <string name="feature_transaction_detail_payment_method">भुगतान विधि</string>
+    <string name="feature_transaction_detail_type">प्रकार</string>
+    <string name="feature_transaction_detail_status_reversed">उलट दिया गया (Reversed)</string>
+    <string name="feature_transaction_detail_receipt">रसीद #</string>
+    <string name="feature_transaction_detail_external_id">बाहरी आईडी</string>
+    <string name="feature_transaction_detail_breakdown">ब्रेकडाउन</string>
+    <string name="feature_transaction_detail_principal">मूलधन</string>
+    <string name="feature_transaction_detail_interest">ब्याज</string>
+    <string name="feature_transaction_detail_fees">शुल्क</string>
+    <string name="feature_transaction_detail_penalties">जुर्माना</string>
+    <string name="feature_transaction_detail_balance">शेष राशि</string>
+    <string name="feature_transaction_detail_default_type">लेन-देन</string>
+
+</resources>

--- a/feature/accounts/src/commonMain/composeResources/values-hu/strings.xml
+++ b/feature/accounts/src/commonMain/composeResources/values-hu/strings.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_account_title">Számlák</string>
+    <string name="feature_loan_account_title">Hitel számlák</string>
+    <string name="feature_saving_account_title">Megtakarítási számlák</string>
+    <string name="feature_share_account_title">Részjegy számlák</string>
+
+    <string name="feature_accounts_filter_status">Állapot</string>
+    <string name="feature_accounts_filter_type">Típus</string>
+
+<string name="feature_loan_account_filter_active">Aktív</string>
+    <string name="feature_loan_account_filter_approval_pending">Jóváhagyásra vár</string>
+    <string name="feature_loan_account_filter_closed">Lezárt</string>
+    <string name="feature_loan_account_filter_disburse">Folyósításra vár</string>
+    <string name="feature_loan_account_filter_overpaid">Túlfizetett</string>
+    <string name="feature_loan_account_filter_in_arrears">Hátralékos</string>
+    <string name="feature_loan_account_filter_withdrawn">Visszavont</string>
+    <string name="feature_loan_account_filter_matured">Lejárt</string>
+    <string name="feature_loan_account_filter_rejected">Elutasított</string>
+
+    <string name="feature_loan_account_filter_personal">Személyes</string>
+    <string name="feature_loan_account_filter_bronze">Bronz</string>
+
+    <string name="feature_savings_filter_wallet_account">Tárca számla</string>
+    <string name="feature_savings_filter_bank_account">Bankszámla</string>
+    <string name="feature_savings_filter_group_account">Csoportos számla</string>
+    <string name="feature_savings_filter_nb_account">NB számla</string>
+
+    <string name="feature_savings_filter_active_account">Aktív</string>
+    <string name="feature_savings_filter_pending_account">Jóváhagyásra vár</string>
+    <string name="feature_savings_filter_closed_account">Lezárt</string>
+    <string name="feature_savings_filter_matured_account">Lejárt</string>
+    <string name="feature_savings_filter_approved_account">Jóváhagyott</string>
+
+    <string name="feature_savings_filter">Szűrők</string>
+    <string name="feature_savings_reset">Visszaállítás</string>
+    <string name="feature_savings_apply">Alkalmaz</string>
+    <string name="feature_filters_count">%1$s Kiválasztva</string>
+
+    <string name="feature_transaction_transaction_history">Tranzakciótörténet</string>
+    <string name="feature_transaction_statement">Számlakivonat</string>
+    <string name="feature_transaction_download_icon_description">Letöltés ikon</string>
+    <string name="feature_transaction_filter">Szűrés</string>
+    <string name="feature_transaction_filter_icon_description">Szűrés ikon</string>
+
+    <string name="feature_transaction_filter_credit">Jóváírás</string>
+    <string name="feature_transaction_filter_debit">Terhelés</string>
+
+    <string name="feature_transaction_filter_past_month">Elmúlt hónap</string>
+    <string name="feature_transaction_filter_past_3_months">Elmúlt 3 hónap</string>
+    <string name="feature_transaction_filter_past_6_months">Elmúlt 6 hónap</string>
+    <string name="feature_transaction_filter_past_1_year">Elmúlt 1 év</string>
+    <string name="feature_transaction_filter_past_2_years">Elmúlt 2 év</string>
+
+    <string name="feature_transaction_type">Tranzakció típusa</string>
+    <string name="feature_duration">Időtartam</string>
+    <string name="feature_no_transactions_found">Nincs tranzakció</string>
+    <string name="feature_no__filtered_transactions_found">Nincs tranzakció a kiválasztott szűrőkhöz</string>
+
+    <string name="feature_generic_error_server">Szerverhiba lépett fel, nem lehet folytatni. Kérjük, próbálja újra később.</string>
+
+    <string name="feature_transaction_details">Tranzakció részletei</string>
+    <string name="feature_transaction_detail_id">Tranzakció azonosító</string>
+    <string name="feature_transaction_detail_transfer_description">Átutalás leírása</string>
+    <string name="feature_transaction_detail_date">Dátum</string>
+    <string name="feature_transaction_detail_status">Állapot</string>
+    <string name="feature_transaction_detail_status_success">Sikeres</string>
+    <string name="feature_transaction_detail_account_ref">Számla hiv.</string>
+    <string name="feature_transaction_detail_payment_method">Fizetési mód</string>
+    <string name="feature_transaction_detail_type">Típus</string>
+    <string name="feature_transaction_detail_status_reversed">Visszavonva</string>
+    <string name="feature_transaction_detail_receipt">Nyugta #</string>
+    <string name="feature_transaction_detail_external_id">Külső azonosító</string>
+    <string name="feature_transaction_detail_breakdown">Részletezés</string>
+    <string name="feature_transaction_detail_principal">Tőke</string>
+    <string name="feature_transaction_detail_interest">Kamat</string>
+    <string name="feature_transaction_detail_fees">Díjak</string>
+    <string name="feature_transaction_detail_penalties">Büntetések</string>
+    <string name="feature_transaction_detail_balance">Fennmaradó egyenleg</string>
+    <string name="feature_transaction_detail_default_type">Tranzakció</string>
+
+</resources>

--- a/feature/accounts/src/commonMain/composeResources/values-hu/strings.xml
+++ b/feature/accounts/src/commonMain/composeResources/values-hu/strings.xml
@@ -18,7 +18,7 @@
     <string name="feature_accounts_filter_status">Állapot</string>
     <string name="feature_accounts_filter_type">Típus</string>
 
-<string name="feature_loan_account_filter_active">Aktív</string>
+    <string name="feature_loan_account_filter_active">Aktív</string>
     <string name="feature_loan_account_filter_approval_pending">Jóváhagyásra vár</string>
     <string name="feature_loan_account_filter_closed">Lezárt</string>
     <string name="feature_loan_account_filter_disburse">Folyósításra vár</string>

--- a/feature/accounts/src/commonMain/composeResources/values-in/strings.xml
+++ b/feature/accounts/src/commonMain/composeResources/values-in/strings.xml
@@ -18,7 +18,7 @@
     <string name="feature_accounts_filter_status">Status</string>
     <string name="feature_accounts_filter_type">Jenis</string>
 
-<string name="feature_loan_account_filter_active">Aktif</string>
+    <string name="feature_loan_account_filter_active">Aktif</string>
     <string name="feature_loan_account_filter_approval_pending">Menunggu Persetujuan</string>
     <string name="feature_loan_account_filter_closed">Ditutup</string>
     <string name="feature_loan_account_filter_disburse">Menunggu Pencairan</string>

--- a/feature/accounts/src/commonMain/composeResources/values-in/strings.xml
+++ b/feature/accounts/src/commonMain/composeResources/values-in/strings.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_account_title">Akun</string>
+    <string name="feature_loan_account_title">Akun Pinjaman</string>
+    <string name="feature_saving_account_title">Akun Tabungan</string>
+    <string name="feature_share_account_title">Akun Saham</string>
+
+    <string name="feature_accounts_filter_status">Status</string>
+    <string name="feature_accounts_filter_type">Jenis</string>
+
+<string name="feature_loan_account_filter_active">Aktif</string>
+    <string name="feature_loan_account_filter_approval_pending">Menunggu Persetujuan</string>
+    <string name="feature_loan_account_filter_closed">Ditutup</string>
+    <string name="feature_loan_account_filter_disburse">Menunggu Pencairan</string>
+    <string name="feature_loan_account_filter_overpaid">Kelebihan Bayar</string>
+    <string name="feature_loan_account_filter_in_arrears">Menunggak</string>
+    <string name="feature_loan_account_filter_withdrawn">Ditarik</string>
+    <string name="feature_loan_account_filter_matured">Jatuh Tempo</string>
+    <string name="feature_loan_account_filter_rejected">Ditolak</string>
+
+    <string name="feature_loan_account_filter_personal">Pribadi</string>
+    <string name="feature_loan_account_filter_bronze">Perunggu</string>
+
+    <string name="feature_savings_filter_wallet_account">Akun Dompet</string>
+    <string name="feature_savings_filter_bank_account">Akun Bank</string>
+    <string name="feature_savings_filter_group_account">Akun Grup</string>
+    <string name="feature_savings_filter_nb_account">Akun NB</string>
+
+    <string name="feature_savings_filter_active_account">Aktif</string>
+    <string name="feature_savings_filter_pending_account">Menunggu Persetujuan</string>
+    <string name="feature_savings_filter_closed_account">Ditutup</string>
+    <string name="feature_savings_filter_matured_account">Jatuh Tempo</string>
+    <string name="feature_savings_filter_approved_account">Disetujui</string>
+
+    <string name="feature_savings_filter">Filter</string>
+    <string name="feature_savings_reset">Atur Ulang</string>
+    <string name="feature_savings_apply">Terapkan</string>
+    <string name="feature_filters_count">%1$s Dipilih</string>
+
+    <string name="feature_transaction_transaction_history">Riwayat Transaksi</string>
+    <string name="feature_transaction_statement">Laporan</string>
+    <string name="feature_transaction_download_icon_description">Ikon Unduh</string>
+    <string name="feature_transaction_filter">Filter</string>
+    <string name="feature_transaction_filter_icon_description">Ikon Filter</string>
+
+    <string name="feature_transaction_filter_credit">Kredit</string>
+    <string name="feature_transaction_filter_debit">Debit</string>
+
+    <string name="feature_transaction_filter_past_month">Bulan Lalu</string>
+    <string name="feature_transaction_filter_past_3_months">3 Bulan Terakhir</string>
+    <string name="feature_transaction_filter_past_6_months">6 Bulan Terakhir</string>
+    <string name="feature_transaction_filter_past_1_year">1 Tahun Terakhir</string>
+    <string name="feature_transaction_filter_past_2_years">2 Tahun Terakhir</string>
+
+    <string name="feature_transaction_type">Jenis Transaksi</string>
+    <string name="feature_duration">Durasi</string>
+    <string name="feature_no_transactions_found">Tidak Ada Transaksi Ditemukan</string>
+    <string name="feature_no__filtered_transactions_found">Tidak Ada Transaksi Ditemukan untuk Filter yang dipilih</string>
+
+    <string name="feature_generic_error_server">Masalah server dari sisi kami, tidak dapat melanjutkan. Coba lagi sesaat lagi</string>
+
+    <string name="feature_transaction_details">Detail Transaksi</string>
+    <string name="feature_transaction_detail_id">ID Transaksi</string>
+    <string name="feature_transaction_detail_transfer_description">Deskripsi Transfer</string>
+    <string name="feature_transaction_detail_date">Tanggal</string>
+    <string name="feature_transaction_detail_status">Status</string>
+    <string name="feature_transaction_detail_status_success">Sukses</string>
+    <string name="feature_transaction_detail_account_ref">Ref Akun</string>
+    <string name="feature_transaction_detail_payment_method">Metode Pembayaran</string>
+    <string name="feature_transaction_detail_type">Jenis</string>
+    <string name="feature_transaction_detail_status_reversed">Dibatalkan (Reversed)</string>
+    <string name="feature_transaction_detail_receipt">No. Resi</string>
+    <string name="feature_transaction_detail_external_id">ID Eksternal</string>
+    <string name="feature_transaction_detail_breakdown">Rincian</string>
+    <string name="feature_transaction_detail_principal">Pokok</string>
+    <string name="feature_transaction_detail_interest">Bunga</string>
+    <string name="feature_transaction_detail_fees">Biaya</string>
+    <string name="feature_transaction_detail_penalties">Denda</string>
+    <string name="feature_transaction_detail_balance">Sisa Saldo</string>
+    <string name="feature_transaction_detail_default_type">Transaksi</string>
+
+</resources>

--- a/feature/accounts/src/commonMain/composeResources/values-kn/strings.xml
+++ b/feature/accounts/src/commonMain/composeResources/values-kn/strings.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_account_title">ಖಾತೆಗಳು</string>
+    <string name="feature_loan_account_title">ಸಾಲದ ಖಾತೆಗಳು</string>
+    <string name="feature_saving_account_title">ಉಳಿತಾಯ ಖಾತೆಗಳು</string>
+    <string name="feature_share_account_title">ಷೇರು ಖಾತೆಗಳು</string>
+
+    <string name="feature_accounts_filter_status">ಸ್ಥಿತಿ</string>
+    <string name="feature_accounts_filter_type">ಪ್ರಕಾರ</string>
+
+<string name="feature_loan_account_filter_active">ಸಕ್ರಿಯ</string>
+    <string name="feature_loan_account_filter_approval_pending">ಅನುಮೋದನೆ ಬಾಕಿ ಇದೆ</string>
+    <string name="feature_loan_account_filter_closed">ಮುಚ್ಚಲಾಗಿದೆ</string>
+    <string name="feature_loan_account_filter_disburse">ವಿತರಣೆಗೆ ಕಾಯುತ್ತಿದೆ</string>
+    <string name="feature_loan_account_filter_overpaid">ಹೆಚ್ಚುವರಿ ಪಾವತಿಸಲಾಗಿದೆ</string>
+    <string name="feature_loan_account_filter_in_arrears">ಬಾಕಿ (In Arrears)</string>
+    <string name="feature_loan_account_filter_withdrawn">ಹಿಂತೆಗೆದುಕೊಳ್ಳಲಾಗಿದೆ</string>
+    <string name="feature_loan_account_filter_matured">ಪಕ್ವವಾಗಿದೆ (Matured)</string>
+    <string name="feature_loan_account_filter_rejected">ತಿರಸ್ಕರಿಸಲಾಗಿದೆ</string>
+
+    <string name="feature_loan_account_filter_personal">ವೈಯಕ್ತಿಕ</string>
+    <string name="feature_loan_account_filter_bronze">ಕಂಚು</string>
+
+    <string name="feature_savings_filter_wallet_account">ವ್ಯಾಲೆಟ್ ಖಾತೆ</string>
+    <string name="feature_savings_filter_bank_account">ಬ್ಯಾಂಕ್ ಖಾತೆ</string>
+    <string name="feature_savings_filter_group_account">ಗುಂಪು ಖಾತೆ</string>
+    <string name="feature_savings_filter_nb_account">NB ಖಾತೆ</string>
+
+    <string name="feature_savings_filter_active_account">ಸಕ್ರಿಯ</string>
+    <string name="feature_savings_filter_pending_account">ಅನುಮೋದನೆ ಬಾಕಿ ಇದೆ</string>
+    <string name="feature_savings_filter_closed_account">ಮುಚ್ಚಲಾಗಿದೆ</string>
+    <string name="feature_savings_filter_matured_account">ಪಕ್ವವಾಗಿದೆ</string>
+    <string name="feature_savings_filter_approved_account">ಅನುಮೋದಿಸಲಾಗಿದೆ</string>
+
+    <string name="feature_savings_filter">ಫಿಲ್ಟರ್‌ಗಳು</string>
+    <string name="feature_savings_reset">ಮರುಹೊಂದಿಸಿ</string>
+    <string name="feature_savings_apply">ಅನ್ವಯಿಸಿ</string>
+    <string name="feature_filters_count">%1$s ಆಯ್ಕೆಮಾಡಲಾಗಿದೆ</string>
+
+    <string name="feature_transaction_transaction_history">ವಹಿವಾಟು ಇತಿಹಾಸ</string>
+    <string name="feature_transaction_statement">ಸ್ಟೇಟ್ಮೆಂಟ್ (Statement)</string>
+    <string name="feature_transaction_download_icon_description">ಡೌನ್‌ಲೋಡ್ ಐಕಾನ್</string>
+    <string name="feature_transaction_filter">ಫಿಲ್ಟರ್</string>
+    <string name="feature_transaction_filter_icon_description">ಫಿಲ್ಟರ್ ಐಕಾನ್</string>
+
+    <string name="feature_transaction_filter_credit">ಕ್ರೆಡಿಟ್</string>
+    <string name="feature_transaction_filter_debit">ಡೆಬಿಟ್</string>
+
+    <string name="feature_transaction_filter_past_month">ಕಳೆದ ತಿಂಗಳು</string>
+    <string name="feature_transaction_filter_past_3_months">ಕಳೆದ 3 ತಿಂಗಳುಗಳು</string>
+    <string name="feature_transaction_filter_past_6_months">ಕಳೆದ 6 ತಿಂಗಳುಗಳು</string>
+    <string name="feature_transaction_filter_past_1_year">ಕಳೆದ 1 ವರ್ಷ</string>
+    <string name="feature_transaction_filter_past_2_years">ಕಳೆದ 2 ವರ್ಷಗಳು</string>
+
+    <string name="feature_transaction_type">ವಹಿವಾಟಿನ ಪ್ರಕಾರ</string>
+    <string name="feature_duration">ಅವಧಿ</string>
+    <string name="feature_no_transactions_found">ಯಾವುದೇ ವಹಿವಾಟುಗಳು ಕಂಡುಬಂದಿಲ್ಲ</string>
+    <string name="feature_no__filtered_transactions_found">ಆಯ್ಕೆಮಾಡಿದ ಫಿಲ್ಟರ್‌ಗಳಿಗೆ ಯಾವುದೇ ವಹಿವಾಟುಗಳು ಕಂಡುಬಂದಿಲ್ಲ</string>
+
+    <string name="feature_generic_error_server">ನಮ್ಮ ಕಡೆಯಿಂದ ಸರ್ವರ್ ಸಮಸ್ಯೆ ಇದೆ, ಮುಂದುವರಿಯಲು ಸಾಧ್ಯವಿಲ್ಲ, ಸ್ವಲ್ಪ ಸಮಯದ ನಂತರ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ</string>
+
+    <string name="feature_transaction_details">ವಹಿವಾಟಿನ ವಿವರಗಳು</string>
+    <string name="feature_transaction_detail_id">ವಹಿವಾಟು ID</string>
+    <string name="feature_transaction_detail_transfer_description">ವರ್ಗಾವಣೆ ವಿವರಣೆ</string>
+    <string name="feature_transaction_detail_date">ದಿನಾಂಕ</string>
+    <string name="feature_transaction_detail_status">ಸ್ಥಿತಿ</string>
+    <string name="feature_transaction_detail_status_success">ಯಶಸ್ವಿ</string>
+    <string name="feature_transaction_detail_account_ref">ಖಾತೆ ಉಲ್ಲೇಖ</string>
+    <string name="feature_transaction_detail_payment_method">ಪಾವತಿ ವಿಧಾನ</string>
+    <string name="feature_transaction_detail_type">ಪ್ರಕಾರ</string>
+    <string name="feature_transaction_detail_status_reversed">ಹಿಂತಿರುಗಿಸಲಾಗಿದೆ (Reversed)</string>
+    <string name="feature_transaction_detail_receipt">ರಶೀದಿ #</string>
+    <string name="feature_transaction_detail_external_id">ಬಾಹ್ಯ ID</string>
+    <string name="feature_transaction_detail_breakdown">ವಿಭಜನೆ (Breakdown)</string>
+    <string name="feature_transaction_detail_principal">ಅಸಲು (Principal)</string>
+    <string name="feature_transaction_detail_interest">ಬಡ್ಡಿ</string>
+    <string name="feature_transaction_detail_fees">ಶುಲ್ಕಗಳು</string>
+    <string name="feature_transaction_detail_penalties">ದಂಡಗಳು</string>
+    <string name="feature_transaction_detail_balance">ಉಳಿದ ಬಾಕಿ</string>
+    <string name="feature_transaction_detail_default_type">ವಹಿವಾಟು</string>
+
+</resources>

--- a/feature/accounts/src/commonMain/composeResources/values-kn/strings.xml
+++ b/feature/accounts/src/commonMain/composeResources/values-kn/strings.xml
@@ -18,7 +18,7 @@
     <string name="feature_accounts_filter_status">ಸ್ಥಿತಿ</string>
     <string name="feature_accounts_filter_type">ಪ್ರಕಾರ</string>
 
-<string name="feature_loan_account_filter_active">ಸಕ್ರಿಯ</string>
+    <string name="feature_loan_account_filter_active">ಸಕ್ರಿಯ</string>
     <string name="feature_loan_account_filter_approval_pending">ಅನುಮೋದನೆ ಬಾಕಿ ಇದೆ</string>
     <string name="feature_loan_account_filter_closed">ಮುಚ್ಚಲಾಗಿದೆ</string>
     <string name="feature_loan_account_filter_disburse">ವಿತರಣೆಗೆ ಕಾಯುತ್ತಿದೆ</string>

--- a/feature/accounts/src/commonMain/composeResources/values-mr/strings.xml
+++ b/feature/accounts/src/commonMain/composeResources/values-mr/strings.xml
@@ -18,7 +18,7 @@
     <string name="feature_accounts_filter_status">स्थिती</string>
     <string name="feature_accounts_filter_type">प्रकार</string>
 
-<string name="feature_loan_account_filter_active">सक्रिय</string>
+    <string name="feature_loan_account_filter_active">सक्रिय</string>
     <string name="feature_loan_account_filter_approval_pending">मंजूरी प्रलंबित</string>
     <string name="feature_loan_account_filter_closed">बंद</string>
     <string name="feature_loan_account_filter_disburse">वितरणाच्या प्रतीक्षेत</string>

--- a/feature/accounts/src/commonMain/composeResources/values-mr/strings.xml
+++ b/feature/accounts/src/commonMain/composeResources/values-mr/strings.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_account_title">खाती</string>
+    <string name="feature_loan_account_title">कर्ज खाती</string>
+    <string name="feature_saving_account_title">बचत खाती</string>
+    <string name="feature_share_account_title">शेअर खाती</string>
+
+    <string name="feature_accounts_filter_status">स्थिती</string>
+    <string name="feature_accounts_filter_type">प्रकार</string>
+
+<string name="feature_loan_account_filter_active">सक्रिय</string>
+    <string name="feature_loan_account_filter_approval_pending">मंजूरी प्रलंबित</string>
+    <string name="feature_loan_account_filter_closed">बंद</string>
+    <string name="feature_loan_account_filter_disburse">वितरणाच्या प्रतीक्षेत</string>
+    <string name="feature_loan_account_filter_overpaid">जास्त रक्कम भरली</string>
+    <string name="feature_loan_account_filter_in_arrears">थकीत (In Arrears)</string>
+    <string name="feature_loan_account_filter_withdrawn">काढून घेतले</string>
+    <string name="feature_loan_account_filter_matured">मुदत पूर्ण</string>
+    <string name="feature_loan_account_filter_rejected">नाकारले</string>
+
+    <string name="feature_loan_account_filter_personal">वैयक्तिक</string>
+    <string name="feature_loan_account_filter_bronze">कांस्य</string>
+
+    <string name="feature_savings_filter_wallet_account">वॉलेट खाते</string>
+    <string name="feature_savings_filter_bank_account">बँक खाते</string>
+    <string name="feature_savings_filter_group_account">गट खाते</string>
+    <string name="feature_savings_filter_nb_account">NB खाते</string>
+
+    <string name="feature_savings_filter_active_account">सक्रिय</string>
+    <string name="feature_savings_filter_pending_account">मंजूरी प्रलंबित</string>
+    <string name="feature_savings_filter_closed_account">बंद</string>
+    <string name="feature_savings_filter_matured_account">मुदत पूर्ण</string>
+    <string name="feature_savings_filter_approved_account">मंजूर</string>
+
+    <string name="feature_savings_filter">फिल्टर</string>
+    <string name="feature_savings_reset">रीसेट</string>
+    <string name="feature_savings_apply">लागू करा</string>
+    <string name="feature_filters_count">%1$s निवडले</string>
+
+    <string name="feature_transaction_transaction_history">व्यवहार इतिहास</string>
+    <string name="feature_transaction_statement">विवरणपत्र (Statement)</string>
+    <string name="feature_transaction_download_icon_description">डाउनलोड चिन्ह</string>
+    <string name="feature_transaction_filter">फिल्टर</string>
+    <string name="feature_transaction_filter_icon_description">फिल्टर चिन्ह</string>
+
+    <string name="feature_transaction_filter_credit">जमा</string>
+    <string name="feature_transaction_filter_debit">नावे</string>
+
+    <string name="feature_transaction_filter_past_month">मागील महिना</string>
+    <string name="feature_transaction_filter_past_3_months">मागील 3 महिने</string>
+    <string name="feature_transaction_filter_past_6_months">मागील 6 महिने</string>
+    <string name="feature_transaction_filter_past_1_year">मागील 1 वर्ष</string>
+    <string name="feature_transaction_filter_past_2_years">मागील 2 वर्षे</string>
+
+    <string name="feature_transaction_type">व्यवहाराचा प्रकार</string>
+    <string name="feature_duration">कालावधी</string>
+    <string name="feature_no_transactions_found">कोणतेही व्यवहार आढळले नाहीत</string>
+    <string name="feature_no__filtered_transactions_found">निवडलेल्या फिल्टरसाठी कोणतेही व्यवहार आढळले नाहीत</string>
+
+    <string name="feature_generic_error_server">आमच्या बाजूने सर्व्हर समस्या असल्याने पुढे जाऊ शकत नाही, थोड्या वेळाने पुन्हा प्रयत्न करा</string>
+
+    <string name="feature_transaction_details">व्यवहार तपशील</string>
+    <string name="feature_transaction_detail_id">व्यवहार ID</string>
+    <string name="feature_transaction_detail_transfer_description">हस्तांतरण वर्णन</string>
+    <string name="feature_transaction_detail_date">तारीख</string>
+    <string name="feature_transaction_detail_status">स्थिती</string>
+    <string name="feature_transaction_detail_status_success">यशस्वी</string>
+    <string name="feature_transaction_detail_account_ref">खाते संदर्भ</string>
+    <string name="feature_transaction_detail_payment_method">पेमेंट पद्धत</string>
+    <string name="feature_transaction_detail_type">प्रकार</string>
+    <string name="feature_transaction_detail_status_reversed">उलट (Reversed)</string>
+    <string name="feature_transaction_detail_receipt">पावती #</string>
+    <string name="feature_transaction_detail_external_id">बाह्य ID</string>
+    <string name="feature_transaction_detail_breakdown">तपशील</string>
+    <string name="feature_transaction_detail_principal">मुद्दल</string>
+    <string name="feature_transaction_detail_interest">व्याज</string>
+    <string name="feature_transaction_detail_fees">शुल्क</string>
+    <string name="feature_transaction_detail_penalties">दंड</string>
+    <string name="feature_transaction_detail_balance">शिल्लक रक्कम</string>
+    <string name="feature_transaction_detail_default_type">व्यवहार</string>
+
+</resources>

--- a/feature/accounts/src/commonMain/composeResources/values-ms/strings.xml
+++ b/feature/accounts/src/commonMain/composeResources/values-ms/strings.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_account_title">Akaun</string>
+    <string name="feature_loan_account_title">Akaun Pinjaman</string>
+    <string name="feature_saving_account_title">Akaun Simpanan</string>
+    <string name="feature_share_account_title">Akaun Saham</string>
+
+    <string name="feature_accounts_filter_status">Status</string>
+    <string name="feature_accounts_filter_type">Jenis</string>
+
+<string name="feature_loan_account_filter_active">Aktif</string>
+    <string name="feature_loan_account_filter_approval_pending">Menunggu Kelulusan</string>
+    <string name="feature_loan_account_filter_closed">Ditutup</string>
+    <string name="feature_loan_account_filter_disburse">Menunggu Pengeluaran</string>
+    <string name="feature_loan_account_filter_overpaid">Terlebih Bayar</string>
+    <string name="feature_loan_account_filter_in_arrears">Tunggakan</string>
+    <string name="feature_loan_account_filter_withdrawn">Ditarik Balik</string>
+    <string name="feature_loan_account_filter_matured">Matang</string>
+    <string name="feature_loan_account_filter_rejected">Ditolak</string>
+
+    <string name="feature_loan_account_filter_personal">Peribadi</string>
+    <string name="feature_loan_account_filter_bronze">Gangsa</string>
+
+    <string name="feature_savings_filter_wallet_account">Akaun Dompet</string>
+    <string name="feature_savings_filter_bank_account">Akaun Bank</string>
+    <string name="feature_savings_filter_group_account">Akaun Kumpulan</string>
+    <string name="feature_savings_filter_nb_account">Akaun NB</string>
+
+    <string name="feature_savings_filter_active_account">Aktif</string>
+    <string name="feature_savings_filter_pending_account">Menunggu Kelulusan</string>
+    <string name="feature_savings_filter_closed_account">Ditutup</string>
+    <string name="feature_savings_filter_matured_account">Matang</string>
+    <string name="feature_savings_filter_approved_account">Diluluskan</string>
+
+    <string name="feature_savings_filter">Tapis</string>
+    <string name="feature_savings_reset">Tetapkan Semula</string>
+    <string name="feature_savings_apply">Gunakan</string>
+    <string name="feature_filters_count">%1$s Dipilih</string>
+
+    <string name="feature_transaction_transaction_history">Sejarah Transaksi</string>
+    <string name="feature_transaction_statement">Penyata</string>
+    <string name="feature_transaction_download_icon_description">Ikon Muat Turun</string>
+    <string name="feature_transaction_filter">Tapis</string>
+    <string name="feature_transaction_filter_icon_description">Ikon Penapis</string>
+
+    <string name="feature_transaction_filter_credit">Kredit</string>
+    <string name="feature_transaction_filter_debit">Debit</string>
+
+    <string name="feature_transaction_filter_past_month">Bulan Lepas</string>
+    <string name="feature_transaction_filter_past_3_months">3 Bulan Lepas</string>
+    <string name="feature_transaction_filter_past_6_months">6 Bulan Lepas</string>
+    <string name="feature_transaction_filter_past_1_year">1 Tahun Lepas</string>
+    <string name="feature_transaction_filter_past_2_years">2 Tahun Lepas</string>
+
+    <string name="feature_transaction_type">Jenis Transaksi</string>
+    <string name="feature_duration">Tempoh</string>
+    <string name="feature_no_transactions_found">Tiada Transaksi Dijumpai</string>
+    <string name="feature_no__filtered_transactions_found">Tiada Transaksi Dijumpai untuk Penapis yang dipilih</string>
+
+    <string name="feature_generic_error_server">Masalah pelayan dari pihak kami, tidak dapat meneruskan. Cuba lagi sebentar lagi</string>
+
+    <string name="feature_transaction_details">Butiran Transaksi</string>
+    <string name="feature_transaction_detail_id">ID Transaksi</string>
+    <string name="feature_transaction_detail_transfer_description">Penerangan Pindahan</string>
+    <string name="feature_transaction_detail_date">Tarikh</string>
+    <string name="feature_transaction_detail_status">Status</string>
+    <string name="feature_transaction_detail_status_success">Berjaya</string>
+    <string name="feature_transaction_detail_account_ref">Ruj Akaun</string>
+    <string name="feature_transaction_detail_payment_method">Kaedah Pembayaran</string>
+    <string name="feature_transaction_detail_type">Jenis</string>
+    <string name="feature_transaction_detail_status_reversed">Dibatalkan (Reversed)</string>
+    <string name="feature_transaction_detail_receipt">Resit #</string>
+    <string name="feature_transaction_detail_external_id">ID Luaran</string>
+    <string name="feature_transaction_detail_breakdown">Pecahan</string>
+    <string name="feature_transaction_detail_principal">Pokok</string>
+    <string name="feature_transaction_detail_interest">Faedah</string>
+    <string name="feature_transaction_detail_fees">Yuran</string>
+    <string name="feature_transaction_detail_penalties">Denda</string>
+    <string name="feature_transaction_detail_balance">Baki Tinggal</string>
+    <string name="feature_transaction_detail_default_type">Transaksi</string>
+
+</resources>

--- a/feature/accounts/src/commonMain/composeResources/values-ms/strings.xml
+++ b/feature/accounts/src/commonMain/composeResources/values-ms/strings.xml
@@ -18,7 +18,7 @@
     <string name="feature_accounts_filter_status">Status</string>
     <string name="feature_accounts_filter_type">Jenis</string>
 
-<string name="feature_loan_account_filter_active">Aktif</string>
+    <string name="feature_loan_account_filter_active">Aktif</string>
     <string name="feature_loan_account_filter_approval_pending">Menunggu Kelulusan</string>
     <string name="feature_loan_account_filter_closed">Ditutup</string>
     <string name="feature_loan_account_filter_disburse">Menunggu Pengeluaran</string>

--- a/feature/accounts/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/accounts/src/commonMain/composeResources/values-pt/strings.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_account_title">Contas</string>
+    <string name="feature_loan_account_title">Contas de Empréstimo</string>
+    <string name="feature_saving_account_title">Contas Poupança</string>
+    <string name="feature_share_account_title">Contas de Ações</string>
+
+    <string name="feature_accounts_filter_status">Estado</string>
+    <string name="feature_accounts_filter_type">Tipo</string>
+
+<string name="feature_loan_account_filter_active">Ativo</string>
+    <string name="feature_loan_account_filter_approval_pending">Aprovação Pendente</string>
+    <string name="feature_loan_account_filter_closed">Fechado</string>
+    <string name="feature_loan_account_filter_disburse">A Aguardar Desembolso</string>
+    <string name="feature_loan_account_filter_overpaid">Pago em Excesso</string>
+    <string name="feature_loan_account_filter_in_arrears">Em Atraso</string>
+    <string name="feature_loan_account_filter_withdrawn">Retirado</string>
+    <string name="feature_loan_account_filter_matured">Vencido</string>
+    <string name="feature_loan_account_filter_rejected">Rejeitado</string>
+
+    <string name="feature_loan_account_filter_personal">Pessoal</string>
+    <string name="feature_loan_account_filter_bronze">Bronze</string>
+
+    <string name="feature_savings_filter_wallet_account">Conta Carteira</string>
+    <string name="feature_savings_filter_bank_account">Conta Bancária</string>
+    <string name="feature_savings_filter_group_account">Conta de Grupo</string>
+    <string name="feature_savings_filter_nb_account">Conta NB</string>
+
+    <string name="feature_savings_filter_active_account">Ativo</string>
+    <string name="feature_savings_filter_pending_account">Aprovação Pendente</string>
+    <string name="feature_savings_filter_closed_account">Fechado</string>
+    <string name="feature_savings_filter_matured_account">Vencido</string>
+    <string name="feature_savings_filter_approved_account">Aprovado</string>
+
+    <string name="feature_savings_filter">Filtros</string>
+    <string name="feature_savings_reset">Redefinir</string>
+    <string name="feature_savings_apply">Aplicar</string>
+    <string name="feature_filters_count">%1$s Selecionado(s)</string>
+
+    <string name="feature_transaction_transaction_history">Histórico de Transações</string>
+    <string name="feature_transaction_statement">Extrato</string>
+    <string name="feature_transaction_download_icon_description">Ícone de Download</string>
+    <string name="feature_transaction_filter">Filtrar</string>
+    <string name="feature_transaction_filter_icon_description">Ícone de Filtro</string>
+
+    <string name="feature_transaction_filter_credit">Crédito</string>
+    <string name="feature_transaction_filter_debit">Débito</string>
+
+    <string name="feature_transaction_filter_past_month">Mês Passado</string>
+    <string name="feature_transaction_filter_past_3_months">Últimos 3 Meses</string>
+    <string name="feature_transaction_filter_past_6_months">Últimos 6 Meses</string>
+    <string name="feature_transaction_filter_past_1_year">Último Ano</string>
+    <string name="feature_transaction_filter_past_2_years">Últimos 2 Anos</string>
+
+    <string name="feature_transaction_type">Tipo de Transação</string>
+    <string name="feature_duration">Duração</string>
+    <string name="feature_no_transactions_found">Nenhuma Transação Encontrada</string>
+    <string name="feature_no__filtered_transactions_found">Nenhuma Transação Encontrada para Filtros selecionados</string>
+
+    <string name="feature_generic_error_server">Problema no servidor, não é possível prosseguir. Tente novamente mais tarde.</string>
+
+    <string name="feature_transaction_details">Detalhes da Transação</string>
+    <string name="feature_transaction_detail_id">ID da Transação</string>
+    <string name="feature_transaction_detail_transfer_description">Descrição da Transferência</string>
+    <string name="feature_transaction_detail_date">Data</string>
+    <string name="feature_transaction_detail_status">Estado</string>
+    <string name="feature_transaction_detail_status_success">Sucesso</string>
+    <string name="feature_transaction_detail_account_ref">Ref da Conta</string>
+    <string name="feature_transaction_detail_payment_method">Método de Pagamento</string>
+    <string name="feature_transaction_detail_type">Tipo</string>
+    <string name="feature_transaction_detail_status_reversed">Estornado</string>
+    <string name="feature_transaction_detail_receipt">Recibo #</string>
+    <string name="feature_transaction_detail_external_id">ID Externo</string>
+    <string name="feature_transaction_detail_breakdown">Discriminação</string>
+    <string name="feature_transaction_detail_principal">Principal</string>
+    <string name="feature_transaction_detail_interest">Juros</string>
+    <string name="feature_transaction_detail_fees">Taxas</string>
+    <string name="feature_transaction_detail_penalties">Penalidades</string>
+    <string name="feature_transaction_detail_balance">Saldo Restante</string>
+    <string name="feature_transaction_detail_default_type">Transação</string>
+
+</resources>

--- a/feature/accounts/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/accounts/src/commonMain/composeResources/values-pt/strings.xml
@@ -18,7 +18,7 @@
     <string name="feature_accounts_filter_status">Estado</string>
     <string name="feature_accounts_filter_type">Tipo</string>
 
-<string name="feature_loan_account_filter_active">Ativo</string>
+    <string name="feature_loan_account_filter_active">Ativo</string>
     <string name="feature_loan_account_filter_approval_pending">Aprovação Pendente</string>
     <string name="feature_loan_account_filter_closed">Fechado</string>
     <string name="feature_loan_account_filter_disburse">A Aguardar Desembolso</string>

--- a/feature/accounts/src/commonMain/composeResources/values-si/strings.xml
+++ b/feature/accounts/src/commonMain/composeResources/values-si/strings.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_account_title">ගිණුම්</string>
+    <string name="feature_loan_account_title">ණය ගිණුම්</string>
+    <string name="feature_saving_account_title">ඉතුරුම් ගිණුම්</string>
+    <string name="feature_share_account_title">කොටස් ගිණුම්</string>
+
+    <string name="feature_accounts_filter_status">තත්වය</string>
+    <string name="feature_accounts_filter_type">වර්ගය</string>
+
+    <string name="feature_loan_account_filter_active">සක්‍රීය</string>
+    <string name="feature_loan_account_filter_approval_pending">අනුමැතිය අපේක්ෂිත</string>
+    <string name="feature_loan_account_filter_closed">වසා ඇත</string>
+    <string name="feature_loan_account_filter_disburse">මුදා හැරීමට බලා සිටී</string>
+    <string name="feature_loan_account_filter_overpaid">වැඩිපුර ගෙවා ඇත</string>
+    <string name="feature_loan_account_filter_in_arrears">හිඟ (Arrears)</string>
+    <string name="feature_loan_account_filter_withdrawn">ඉල්ලා අස්කර ගන්නා ලදී</string>
+    <string name="feature_loan_account_filter_matured">කාලය පිරුණු (Matured)</string>
+    <string name="feature_loan_account_filter_rejected">ප්‍රතික්ෂේපිත</string>
+
+    <string name="feature_loan_account_filter_personal">පුද්ගලික</string>
+    <string name="feature_loan_account_filter_bronze">ලෝකඩ</string>
+
+    <string name="feature_savings_filter_wallet_account">පසුම්බි ගිණුම</string>
+    <string name="feature_savings_filter_bank_account">බැංකු ගිණුම</string>
+    <string name="feature_savings_filter_group_account">කණ්ඩායම් ගිණුම</string>
+    <string name="feature_savings_filter_nb_account">NB ගිණුම</string>
+
+    <string name="feature_savings_filter_active_account">සක්‍රීය</string>
+    <string name="feature_savings_filter_pending_account">අනුමැතිය අපේක්ෂිත</string>
+    <string name="feature_savings_filter_closed_account">වසා ඇත</string>
+    <string name="feature_savings_filter_matured_account">කාලය පිරුණු</string>
+    <string name="feature_savings_filter_approved_account">අනුමතයි</string>
+
+    <string name="feature_savings_filter">පෙරහන්</string>
+    <string name="feature_savings_reset">යළි පිහිටුවන්න</string>
+    <string name="feature_savings_apply">යොදන්න</string>
+    <string name="feature_filters_count">%1$s තෝරා ඇත</string>
+
+    <string name="feature_transaction_transaction_history">ගනුදෙනු ඉතිහාසය</string>
+    <string name="feature_transaction_statement">ප්‍රකාශය (Statement)</string>
+    <string name="feature_transaction_download_icon_description">බාගත කිරීමේ නිරූපකය</string>
+    <string name="feature_transaction_filter">පෙරහන්න</string>
+    <string name="feature_transaction_filter_icon_description">පෙරහන් නිරූපකය</string>
+
+    <string name="feature_transaction_filter_credit">බැර</string>
+    <string name="feature_transaction_filter_debit">හර</string>
+
+    <string name="feature_transaction_filter_past_month">පසුගිය මාසය</string>
+    <string name="feature_transaction_filter_past_3_months">පසුගිය මාස 3</string>
+    <string name="feature_transaction_filter_past_6_months">පසුගිය මාස 6</string>
+    <string name="feature_transaction_filter_past_1_year">පසුගිය වසර 1</string>
+    <string name="feature_transaction_filter_past_2_years">පසුගිය වසර 2</string>
+
+    <string name="feature_transaction_type">ගනුදෙනු වර්ගය</string>
+    <string name="feature_duration">කාලසීමාව</string>
+    <string name="feature_no_transactions_found">ගනුදෙනු හමු නොවීය</string>
+    <string name="feature_no__filtered_transactions_found">තෝරාගත් පෙරහන් සඳහා ගනුදෙනු හමු නොවීය</string>
+
+    <string name="feature_generic_error_server">අපගේ පාර්ශවයෙන් සේවාදායක දෝෂයක් ඇත, ඉදිරියට යා නොහැක, මොහොතකින් නැවත උත්සාහ කරන්න</string>
+
+    <string name="feature_transaction_details">ගනුදෙනු විස්තර</string>
+    <string name="feature_transaction_detail_id">ගනුදෙනු ID</string>
+    <string name="feature_transaction_detail_transfer_description">මාරු කිරීමේ විස්තරය</string>
+    <string name="feature_transaction_detail_date">දිනය</string>
+    <string name="feature_transaction_detail_status">තත්වය</string>
+    <string name="feature_transaction_detail_status_success">සාර්ථකයි</string>
+    <string name="feature_transaction_detail_account_ref">ගිණුම් යොමුව</string>
+    <string name="feature_transaction_detail_payment_method">ගෙවීම් ක්‍රමය</string>
+    <string name="feature_transaction_detail_type">වර්ගය</string>
+    <string name="feature_transaction_detail_status_reversed">ආපසු හැරවිණි (Reversed)</string>
+    <string name="feature_transaction_detail_receipt">රිසිට්පත #</string>
+    <string name="feature_transaction_detail_external_id">බාහිර ID</string>
+    <string name="feature_transaction_detail_breakdown">විස්තරය</string>
+    <string name="feature_transaction_detail_principal">මූලික මුදල</string>
+    <string name="feature_transaction_detail_interest">පොලිය</string>
+    <string name="feature_transaction_detail_fees">ගාස්තු</string>
+    <string name="feature_transaction_detail_penalties">දඩ</string>
+    <string name="feature_transaction_detail_balance">ඉතිරි ශේෂය</string>
+    <string name="feature_transaction_detail_default_type">ගනුදෙනුව</string>
+
+</resources>

--- a/feature/accounts/src/commonMain/composeResources/values-sw/strings.xml
+++ b/feature/accounts/src/commonMain/composeResources/values-sw/strings.xml
@@ -18,7 +18,7 @@
     <string name="feature_accounts_filter_status">Hali</string>
     <string name="feature_accounts_filter_type">Aina</string>
 
-<string name="feature_loan_account_filter_active">Inatumika</string>
+    <string name="feature_loan_account_filter_active">Inatumika</string>
     <string name="feature_loan_account_filter_approval_pending">Inasubiri Idhini</string>
     <string name="feature_loan_account_filter_closed">Imefungwa</string>
     <string name="feature_loan_account_filter_disburse">Inasubiri Utoaji</string>

--- a/feature/accounts/src/commonMain/composeResources/values-sw/strings.xml
+++ b/feature/accounts/src/commonMain/composeResources/values-sw/strings.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_account_title">Akaunti</string>
+    <string name="feature_loan_account_title">Akaunti za Mikopo</string>
+    <string name="feature_saving_account_title">Akaunti za Akiba</string>
+    <string name="feature_share_account_title">Akaunti za Hisa</string>
+
+    <string name="feature_accounts_filter_status">Hali</string>
+    <string name="feature_accounts_filter_type">Aina</string>
+
+<string name="feature_loan_account_filter_active">Inatumika</string>
+    <string name="feature_loan_account_filter_approval_pending">Inasubiri Idhini</string>
+    <string name="feature_loan_account_filter_closed">Imefungwa</string>
+    <string name="feature_loan_account_filter_disburse">Inasubiri Utoaji</string>
+    <string name="feature_loan_account_filter_overpaid">Imelipwa Ziada</string>
+    <string name="feature_loan_account_filter_in_arrears">Malimbikizo</string>
+    <string name="feature_loan_account_filter_withdrawn">Imetolewa</string>
+    <string name="feature_loan_account_filter_matured">Imekomaa</string>
+    <string name="feature_loan_account_filter_rejected">Imekataliwa</string>
+
+    <string name="feature_loan_account_filter_personal">Binafsi</string>
+    <string name="feature_loan_account_filter_bronze">Shaba</string>
+
+    <string name="feature_savings_filter_wallet_account">Akaunti ya Wallet</string>
+    <string name="feature_savings_filter_bank_account">Akaunti ya Benki</string>
+    <string name="feature_savings_filter_group_account">Akaunti ya Kikundi</string>
+    <string name="feature_savings_filter_nb_account">Akaunti ya NB</string>
+
+    <string name="feature_savings_filter_active_account">Inatumika</string>
+    <string name="feature_savings_filter_pending_account">Inasubiri Idhini</string>
+    <string name="feature_savings_filter_closed_account">Imefungwa</string>
+    <string name="feature_savings_filter_matured_account">Imekomaa</string>
+    <string name="feature_savings_filter_approved_account">Imeidhinishwa</string>
+
+    <string name="feature_savings_filter">Vichujio</string>
+    <string name="feature_savings_reset">Weka Upya</string>
+    <string name="feature_savings_apply">Weka</string>
+    <string name="feature_filters_count">%1$s Imechaguliwa</string>
+
+    <string name="feature_transaction_transaction_history">Historia ya Miamala</string>
+    <string name="feature_transaction_statement">Taarifa</string>
+    <string name="feature_transaction_download_icon_description">Aikoni ya Kupakua</string>
+    <string name="feature_transaction_filter">Chuja</string>
+    <string name="feature_transaction_filter_icon_description">Aikoni ya Kuchuja</string>
+
+    <string name="feature_transaction_filter_credit">Amana</string>
+    <string name="feature_transaction_filter_debit">Makato</string>
+
+    <string name="feature_transaction_filter_past_month">Mwezi Uliopita</string>
+    <string name="feature_transaction_filter_past_3_months">Miezi 3 Iliyopita</string>
+    <string name="feature_transaction_filter_past_6_months">Miezi 6 Iliyopita</string>
+    <string name="feature_transaction_filter_past_1_year">Mwaka 1 Uliopita</string>
+    <string name="feature_transaction_filter_past_2_years">Miaka 2 Iliyopita</string>
+
+    <string name="feature_transaction_type">Aina ya Muamala</string>
+    <string name="feature_duration">Muda</string>
+    <string name="feature_no_transactions_found">Hakuna Miamala Iliyopatikana</string>
+    <string name="feature_no__filtered_transactions_found">Hakuna Miamala Iliyopatikana kwa Vichujio vilivyochaguliwa</string>
+
+    <string name="feature_generic_error_server">Tatizo la seva kutoka upande wetu, haiwezi kuendelea. Jaribu tena baada ya muda</string>
+
+    <string name="feature_transaction_details">Maelezo ya Muamala</string>
+    <string name="feature_transaction_detail_id">Kitambulisho cha Muamala</string>
+    <string name="feature_transaction_detail_transfer_description">Maelezo ya Uhamisho</string>
+    <string name="feature_transaction_detail_date">Tarehe</string>
+    <string name="feature_transaction_detail_status">Hali</string>
+    <string name="feature_transaction_detail_status_success">Imefanikiwa</string>
+    <string name="feature_transaction_detail_account_ref">Rejeleo la Akaunti</string>
+    <string name="feature_transaction_detail_payment_method">Njia ya Malipo</string>
+    <string name="feature_transaction_detail_type">Aina</string>
+    <string name="feature_transaction_detail_status_reversed">Imebatilishwa (Reversed)</string>
+    <string name="feature_transaction_detail_receipt">Stakabadhi #</string>
+    <string name="feature_transaction_detail_external_id">Kitambulisho cha Nje</string>
+    <string name="feature_transaction_detail_breakdown">Mchanganuo</string>
+    <string name="feature_transaction_detail_principal">Mtaji</string>
+    <string name="feature_transaction_detail_interest">Riba</string>
+    <string name="feature_transaction_detail_fees">Ada</string>
+    <string name="feature_transaction_detail_penalties">Adhabu</string>
+    <string name="feature_transaction_detail_balance">Salio Lililobaki</string>
+    <string name="feature_transaction_detail_default_type">Muamala</string>
+
+</resources>

--- a/feature/home/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/home/src/commonMain/composeResources/values-ar/strings.xml
@@ -12,6 +12,8 @@
     <string name="beneficiaries">المستفيدون</string>
     <string name="survey">الاستبيانات</string>
     <string name="apply_for_loan">التقديم على قرض</string>
+    <string name="apply_for_savings">طلب حساب توفير</string>
+    <string name="apply_for_share">طلب حساب أسهم</string>
     <string name="charges">الرسوم</string>
     <string name="transfer">تحويل</string>
     <string name="accounts">الحسابات</string>

--- a/feature/home/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/home/src/commonMain/composeResources/values-fr/strings.xml
@@ -12,6 +12,8 @@
     <string name="beneficiaries">Bénéficiaires</string>
     <string name="survey">Enquêtes</string>
     <string name="apply_for_loan">Demander un prêt</string>
+    <string name="apply_for_savings">Demander compte épargne</string>
+    <string name="apply_for_share">Demander compte parts</string>
     <string name="charges">Frais</string>
     <string name="transfer">Transfert</string>
     <string name="accounts">Comptes</string>

--- a/feature/home/src/commonMain/composeResources/values-hi/strings.xml
+++ b/feature/home/src/commonMain/composeResources/values-hi/strings.xml
@@ -12,6 +12,8 @@
     <string name="beneficiaries">लाभार्थी</string>
     <string name="survey">सर्वेक्षण</string>
     <string name="apply_for_loan">ऋण के लिए आवेदन करें</string>
+    <string name="apply_for_savings">बचत खाता आवेदन</string>
+    <string name="apply_for_share">शेयर खाता आवेदन</string>
     <string name="charges">शुल्क</string>
     <string name="transfer">स्थानांतरण</string>
     <string name="accounts">खाते</string>

--- a/feature/home/src/commonMain/composeResources/values-kn/strings.xml
+++ b/feature/home/src/commonMain/composeResources/values-kn/strings.xml
@@ -12,6 +12,8 @@
     <string name="beneficiaries">ಲಾಭಾಧಾರಿಗಳು</string>
     <string name="survey">ಸಮೀಕ್ಷೆಗಳು</string>
     <string name="apply_for_loan">ಸಾಲಕ್ಕೆ ಅರ್ಜಿ ಸಲ್ಲಿಸಿ</string>
+    <string name="apply_for_savings">ಉಳಿತಾಯ ಖಾತೆಗೆ ಅರ್ಜಿ</string>
+    <string name="apply_for_share">ಷೇರು ಖಾತೆಗೆ ಅರ್ಜಿ</string>
     <string name="charges">ಶುಲ್ಕಗಳು</string>
     <string name="transfer">ಹಸ್ತಾಂತರ</string>
     <string name="accounts">ಖಾತೆಗಳು</string>

--- a/feature/home/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/home/src/commonMain/composeResources/values-pt/strings.xml
@@ -12,6 +12,8 @@
     <string name="beneficiaries">Beneficiários</string>
     <string name="survey">Pesquisas</string>
     <string name="apply_for_loan">Solicitar Empréstimo</string>
+    <string name="apply_for_savings">Pedir Conta Poupança</string>
+    <string name="apply_for_share">Pedir Conta Ações</string>
     <string name="charges">Taxas</string>
     <string name="transfer">Transferência</string>
     <string name="accounts">Contas</string>

--- a/feature/home/src/commonMain/composeResources/values-sw/strings.xml
+++ b/feature/home/src/commonMain/composeResources/values-sw/strings.xml
@@ -12,6 +12,8 @@
     <string name="beneficiaries">Wafaidika</string>
     <string name="survey">Utafiti</string>
     <string name="apply_for_loan">Omba Mkopo</string>
+    <string name="apply_for_savings">Omba Akaunti ya Akiba</string>
+    <string name="apply_for_share">Omba Akaunti ya Hisa</string>
     <string name="charges">Ada</string>
     <string name="transfer">Hamisho</string>
     <string name="accounts">Akaunti</string>

--- a/feature/recent-transaction/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/recent-transaction/src/commonMain/composeResources/values-ar/strings.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="recent_transactions">أحدث المعاملات</string>
+    <string name="no_transaction">لا توجد معاملات</string>
+    <string name="atm_icon">رمز الصراف الآلي</string>
+    <string name="string_and_string">%1$s %2$s</string>
+
+    <string name="something_went_wrong">حدث خطأ ما</string>
+    <string name="filter">تصفية</string>
+    <string name="filter_transactions">تصفية المعاملات</string>
+    <string name="clear_all">مسح الكل</string>
+    <string name="filter_by_account">تصفية حسب الحساب:</string>
+    <string name="account_number_label">رقم الحساب: %1$s</string>
+    <string name="select_account">اختر الحساب</string>
+    <string name="balance">الرصيد: %1$s %2$s</string>
+    <string name="account">الحساب</string>
+    <string name="transaction_type">نوع المعاملة:</string>
+    <string name="all">الكل</string>
+    <string name="debits">الخصم</string>
+    <string name="credits">الإيداع</string>
+    <string name="apply_filters">تطبيق التصفية</string>
+</resources>

--- a/feature/recent-transaction/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/recent-transaction/src/commonMain/composeResources/values-de/strings.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="recent_transactions">Letzte Transaktionen</string>
+    <string name="no_transaction">Keine Transaktion</string>
+    <string name="atm_icon">Geldautomaten-Symbol</string>
+    <string name="string_and_string">%1$s %2$s</string>
+
+    <string name="something_went_wrong">Etwas ist schiefgelaufen</string>
+    <string name="filter">Filtern</string>
+    <string name="filter_transactions">Transaktionen filtern</string>
+    <string name="clear_all">Alles zurücksetzen</string>
+    <string name="filter_by_account">Nach Konto filtern:</string>
+    <string name="account_number_label">Kto-Nr.: %1$s</string>
+    <string name="select_account">Konto auswählen</string>
+    <string name="balance">Kontostand: %1$s %2$s</string>
+    <string name="account">Konto</string>
+    <string name="transaction_type">Transaktionstyp:</string>
+    <string name="all">Alle</string>
+    <string name="debits">Belastungen</string>
+    <string name="credits">Gutschriften</string>
+    <string name="apply_filters">Filter anwenden</string>
+</resources>

--- a/feature/recent-transaction/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/recent-transaction/src/commonMain/composeResources/values-fr/strings.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="recent_transactions">Transactions récentes</string>
+    <string name="no_transaction">Aucune transaction</string>
+    <string name="atm_icon">Icône DAB</string>
+    <string name="string_and_string">%1$s %2$s</string>
+
+    <string name="something_went_wrong">Une erreur est survenue</string>
+    <string name="filter">Filtrer</string>
+    <string name="filter_transactions">Filtrer les transactions</string>
+    <string name="clear_all">Tout effacer</string>
+    <string name="filter_by_account">Filtrer par compte :</string>
+    <string name="account_number_label">N° de compte : %1$s</string>
+    <string name="select_account">Sélectionner un compte</string>
+    <string name="balance">Solde : %1$s %2$s</string>
+    <string name="account">Compte</string>
+    <string name="transaction_type">Type de transaction :</string>
+    <string name="all">Tout</string>
+    <string name="debits">Débits</string>
+    <string name="credits">Crédits</string>
+    <string name="apply_filters">Appliquer les filtres</string>
+</resources>

--- a/feature/recent-transaction/src/commonMain/composeResources/values-gu/strings.xml
+++ b/feature/recent-transaction/src/commonMain/composeResources/values-gu/strings.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="recent_transactions">તાજેતરના વ્યવહારો</string>
+    <string name="no_transaction">કોઈ વ્યવહાર નથી</string>
+    <string name="atm_icon">ATM આયકન</string>
+    <string name="string_and_string">%1$s %2$s</string>
+
+    <string name="something_went_wrong">કંઈક ખોટું થયું</string>
+    <string name="filter">ફિલ્ટર</string>
+    <string name="filter_transactions">વ્યવહારો ફિલ્ટર કરો</string>
+    <string name="clear_all">બધું સાફ કરો</string>
+    <string name="filter_by_account">એકાઉન્ટ દ્વારા ફિલ્ટર કરો :</string>
+    <string name="account_number_label">ખાતા નંબર: %1$s</string>
+    <string name="select_account">એકાઉન્ટ પસંદ કરો</string>
+    <string name="balance">બેલેન્સ: %1$s %2$s</string>
+    <string name="account">એકાઉન્ટ</string>
+    <string name="transaction_type">વ્યવહારનો પ્રકાર:</string>
+    <string name="all">બધા</string>
+    <string name="debits">ઉધાર</string>
+    <string name="credits">જમા</string>
+    <string name="apply_filters">ફિલ્ટર લાગુ કરો</string>
+</resources>

--- a/feature/recent-transaction/src/commonMain/composeResources/values-hi/strings.xml
+++ b/feature/recent-transaction/src/commonMain/composeResources/values-hi/strings.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="recent_transactions">हाल के लेन-देन</string>
+    <string name="no_transaction">कोई लेन-देन नहीं</string>
+    <string name="atm_icon">एटीएम आइकन</string>
+    <string name="string_and_string">%1$s %2$s</string>
+
+    <string name="something_went_wrong">कुछ गलत हो गया</string>
+    <string name="filter">फ़िल्टर</string>
+    <string name="filter_transactions">लेन-देन फ़िल्टर करें</string>
+    <string name="clear_all">सभी साफ़ करें</string>
+    <string name="filter_by_account">खाते के अनुसार फ़िल्टर करें :</string>
+    <string name="account_number_label">खाता संख्या: %1$s</string>
+    <string name="select_account">खाता चुनें</string>
+    <string name="balance">शेष राशि: %1$s %2$s</string>
+    <string name="account">खाता</string>
+    <string name="transaction_type">लेन-देन का प्रकार:</string>
+    <string name="all">सभी</string>
+    <string name="debits">नामे</string>
+    <string name="credits">जमा</string>
+    <string name="apply_filters">फ़िल्टर लागू करें</string>
+</resources>

--- a/feature/recent-transaction/src/commonMain/composeResources/values-hu/strings.xml
+++ b/feature/recent-transaction/src/commonMain/composeResources/values-hu/strings.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="recent_transactions">Legutóbbi tranzakciók</string>
+    <string name="no_transaction">Nincs tranzakció</string>
+    <string name="atm_icon">ATM ikon</string>
+    <string name="string_and_string">%1$s %2$s</string>
+
+    <string name="something_went_wrong">Hiba történt</string>
+    <string name="filter">Szűrés</string>
+    <string name="filter_transactions">Tranzakciók szűrése</string>
+    <string name="clear_all">Összes törlése</string>
+    <string name="filter_by_account">Szűrés számla szerint:</string>
+    <string name="account_number_label">Számlaszám: %1$s</string>
+    <string name="select_account">Számla kiválasztása</string>
+    <string name="balance">Egyenleg: %1$s %2$s</string>
+    <string name="account">Számla</string>
+    <string name="transaction_type">Tranzakció típusa:</string>
+    <string name="all">Összes</string>
+    <string name="debits">Terhelések</string>
+    <string name="credits">Jóváírások</string>
+    <string name="apply_filters">Szűrők alkalmazása</string>
+</resources>

--- a/feature/recent-transaction/src/commonMain/composeResources/values-in/strings.xml
+++ b/feature/recent-transaction/src/commonMain/composeResources/values-in/strings.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="recent_transactions">Transaksi Terkini</string>
+    <string name="no_transaction">Tidak Ada Transaksi</string>
+    <string name="atm_icon">Ikon ATM</string>
+    <string name="string_and_string">%1$s %2$s</string>
+
+    <string name="something_went_wrong">Ada yang salah</string>
+    <string name="filter">Filter</string>
+    <string name="filter_transactions">Filter Transaksi</string>
+    <string name="clear_all">Hapus Semua</string>
+    <string name="filter_by_account">Filter Berdasarkan Akun :</string>
+    <string name="account_number_label">No. Rek: %1$s</string>
+    <string name="select_account">Pilih Akun</string>
+    <string name="balance">Saldo: %1$s %2$s</string>
+    <string name="account">Akun</string>
+    <string name="transaction_type">Jenis Transaksi:</string>
+    <string name="all">Semua</string>
+    <string name="debits">Debit</string>
+    <string name="credits">Kredit</string>
+    <string name="apply_filters">Terapkan Filter</string>
+</resources>

--- a/feature/recent-transaction/src/commonMain/composeResources/values-kn/strings.xml
+++ b/feature/recent-transaction/src/commonMain/composeResources/values-kn/strings.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="recent_transactions">ಇತ್ತೀಚಿನ ವಹಿವಾಟುಗಳು</string>
+    <string name="no_transaction">ಯಾವುದೇ ವಹಿವಾಟು ಇಲ್ಲ</string>
+    <string name="atm_icon">ATM ಐಕಾನ್</string>
+    <string name="string_and_string">%1$s %2$s</string>
+
+    <string name="something_went_wrong">ಏನೋ ತಪ್ಪಾಗಿದೆ</string>
+    <string name="filter">ಫಿಲ್ಟರ್</string>
+    <string name="filter_transactions">ವಹಿವಾಟುಗಳನ್ನು ಫಿಲ್ಟರ್ ಮಾಡಿ</string>
+    <string name="clear_all">ಎಲ್ಲವನ್ನೂ ತೆರವುಗೊಳಿಸಿ</string>
+    <string name="filter_by_account">ಖಾತೆಯ ಮೂಲಕ ಫಿಲ್ಟರ್ ಮಾಡಿ :</string>
+    <string name="account_number_label">ಖಾತೆ ಸಂಖ್ಯೆ: %1$s</string>
+    <string name="select_account">ಖಾತೆಯನ್ನು ಆಯ್ಕೆಮಾಡಿ</string>
+    <string name="balance">ಬ್ಯಾಲೆನ್ಸ್: %1$s %2$s</string>
+    <string name="account">ಖಾತೆ</string>
+    <string name="transaction_type">ವಹಿವಾಟಿನ ಪ್ರಕಾರ:</string>
+    <string name="all">ಎಲ್ಲಾ</string>
+    <string name="debits">ಡೆಬಿಟ್‌ಗಳು</string>
+    <string name="credits">ಕ್ರೆಡಿಟ್‌ಗಳು</string>
+    <string name="apply_filters">ಫಿಲ್ಟರ್‌ಗಳನ್ನು ಅನ್ವಯಿಸಿ</string>
+</resources>

--- a/feature/recent-transaction/src/commonMain/composeResources/values-ml/strings.xml
+++ b/feature/recent-transaction/src/commonMain/composeResources/values-ml/strings.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="recent_transactions">സമീപകാല ഇടപാടുകൾ</string>
+    <string name="no_transaction">ഇടപാടുകൾ ഒന്നുമില്ല</string>
+    <string name="atm_icon">എടിഎം ഐക്കൺ</string>
+    <string name="string_and_string">%1$s %2$s</string>
+
+    <string name="something_went_wrong">എന്തോ കുഴപ്പം സംഭവിച്ചു</string>
+    <string name="filter">ഫിൽട്ടർ</string>
+    <string name="filter_transactions">ഇടപാടുകൾ ഫിൽട്ടർ ചെയ്യുക</string>
+    <string name="clear_all">എല്ലാം മായ്‌ക്കുക</string>
+    <string name="filter_by_account">അക്കൗണ്ട് പ്രകാരം ഫിൽട്ടർ ചെയ്യുക :</string>
+    <string name="account_number_label">അക്കൗണ്ട് നമ്പർ: %1$s</string>
+    <string name="select_account">അക്കൗണ്ട് തിരഞ്ഞെടുക്കുക</string>
+    <string name="balance">ബാലൻസ്: %1$s %2$s</string>
+    <string name="account">അക്കൗണ്ട്</string>
+    <string name="transaction_type">ഇടപാട് തരം:</string>
+    <string name="all">എല്ലാം</string>
+    <string name="debits">ഡെബിറ്റുകൾ</string>
+    <string name="credits">ക്രെഡിറ്റുകൾ</string>
+    <string name="apply_filters">ഫിൽട്ടറുകൾ പ്രയോഗിക്കുക</string>
+</resources>

--- a/feature/recent-transaction/src/commonMain/composeResources/values-ml/strings.xml
+++ b/feature/recent-transaction/src/commonMain/composeResources/values-ml/strings.xml
@@ -19,10 +19,10 @@
     <string name="filter">ഫിൽട്ടർ</string>
     <string name="filter_transactions">ഇടപാടുകൾ ഫിൽട്ടർ ചെയ്യുക</string>
     <string name="clear_all">എല്ലാം മായ്‌ക്കുക</string>
-    <string name="filter_by_account">അക്കൗണ്ട് പ്രകാരം ഫിൽട്ടർ ചെയ്യുക :</string>
-    <string name="account_number_label">അക്കൗണ്ട് നമ്പർ: %1$s</string>
+    <string name="filter_by_account">അക്കൗണ്ട് പ്രകാരം ഫിൽട്ടർ ചെയ്യുക:</string>
+    <string name="account_number_label">അക്കൗണ്ട് നമ്പർ : %1$s</string>
     <string name="select_account">അക്കൗണ്ട് തിരഞ്ഞെടുക്കുക</string>
-    <string name="balance">ബാലൻസ്: %1$s %2$s</string>
+    <string name="balance">ബാലൻസ് : %1$s %2$s</string>
     <string name="account">അക്കൗണ്ട്</string>
     <string name="transaction_type">ഇടപാട് തരം:</string>
     <string name="all">എല്ലാം</string>

--- a/feature/recent-transaction/src/commonMain/composeResources/values-mr/strings.xml
+++ b/feature/recent-transaction/src/commonMain/composeResources/values-mr/strings.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="recent_transactions">अलीकडील व्यवहार</string>
+    <string name="no_transaction">कोणतेही व्यवहार नाहीत</string>
+    <string name="atm_icon">ATM चिन्ह</string>
+    <string name="string_and_string">%1$s %2$s</string>
+
+    <string name="something_went_wrong">काहीतरी चूक झाली</string>
+    <string name="filter">फिल्टर</string>
+    <string name="filter_transactions">व्यवहार फिल्टर करा</string>
+    <string name="clear_all">सर्व साफ करा</string>
+    <string name="filter_by_account">खात्यानुसार फिल्टर करा:</string>
+    <string name="account_number_label">खाते क्र.: %1$s</string>
+    <string name="select_account">खाता निवडा</string>
+    <string name="balance">शिल्लक: %1$s %2$s</string>
+    <string name="account">खाते</string>
+    <string name="transaction_type">व्यवहाराचा प्रकार:</string>
+    <string name="all">सर्व</string>
+    <string name="debits">नावे</string>
+    <string name="credits">जमा</string>
+    <string name="apply_filters">फिल्टर लागू करा</string>
+</resources>

--- a/feature/recent-transaction/src/commonMain/composeResources/values-ms/strings.xml
+++ b/feature/recent-transaction/src/commonMain/composeResources/values-ms/strings.xml
@@ -19,7 +19,7 @@
     <string name="filter">Tapis</string>
     <string name="filter_transactions">Tapis Transaksi</string>
     <string name="clear_all">Kosongkan Semua</string>
-    <string name="filter_by_account">Tapis Mengikut Akaun :</string>
+    <string name="filter_by_account">Tapis Mengikut Akaun:</string>
     <string name="account_number_label">No Akaun: %1$s</string>
     <string name="select_account">Pilih Akaun</string>
     <string name="balance">Baki: %1$s %2$s</string>

--- a/feature/recent-transaction/src/commonMain/composeResources/values-ms/strings.xml
+++ b/feature/recent-transaction/src/commonMain/composeResources/values-ms/strings.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="recent_transactions">Transaksi Terkini</string>
+    <string name="no_transaction">Tiada Transaksi</string>
+    <string name="atm_icon">Ikon ATM</string>
+    <string name="string_and_string">%1$s %2$s</string>
+
+    <string name="something_went_wrong">Sesuatu telah berlaku</string>
+    <string name="filter">Tapis</string>
+    <string name="filter_transactions">Tapis Transaksi</string>
+    <string name="clear_all">Kosongkan Semua</string>
+    <string name="filter_by_account">Tapis Mengikut Akaun :</string>
+    <string name="account_number_label">No Akaun: %1$s</string>
+    <string name="select_account">Pilih Akaun</string>
+    <string name="balance">Baki: %1$s %2$s</string>
+    <string name="account">Akaun</string>
+    <string name="transaction_type">Jenis Transaksi:</string>
+    <string name="all">Semua</string>
+    <string name="debits">Debit</string>
+    <string name="credits">Kredit</string>
+    <string name="apply_filters">Gunakan Penapis</string>
+</resources>

--- a/feature/recent-transaction/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/recent-transaction/src/commonMain/composeResources/values-pt/strings.xml
@@ -19,7 +19,7 @@
     <string name="filter">Filtrar</string>
     <string name="filter_transactions">Filtrar Transações</string>
     <string name="clear_all">Limpar Tudo</string>
-    <string name="filter_by_account">Filtrar por Conta :</string>
+    <string name="filter_by_account">Filtrar por Conta:</string>
     <string name="account_number_label">Nº da Conta: %1$s</string>
     <string name="select_account">Selecionar Conta</string>
     <string name="balance">Saldo: %1$s %2$s</string>

--- a/feature/recent-transaction/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/recent-transaction/src/commonMain/composeResources/values-pt/strings.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="recent_transactions">Transações Recentes</string>
+    <string name="no_transaction">Nenhuma Transação</string>
+    <string name="atm_icon">Ícone ATM</string>
+    <string name="string_and_string">%1$s %2$s</string>
+
+    <string name="something_went_wrong">Algo correu mal</string>
+    <string name="filter">Filtrar</string>
+    <string name="filter_transactions">Filtrar Transações</string>
+    <string name="clear_all">Limpar Tudo</string>
+    <string name="filter_by_account">Filtrar por Conta :</string>
+    <string name="account_number_label">Nº da Conta: %1$s</string>
+    <string name="select_account">Selecionar Conta</string>
+    <string name="balance">Saldo: %1$s %2$s</string>
+    <string name="account">Conta</string>
+    <string name="transaction_type">Tipo de Transação:</string>
+    <string name="all">Tudo</string>
+    <string name="debits">Débitos</string>
+    <string name="credits">Créditos</string>
+    <string name="apply_filters">Aplicar Filtros</string>
+</resources>

--- a/feature/recent-transaction/src/commonMain/composeResources/values-si/strings.xml
+++ b/feature/recent-transaction/src/commonMain/composeResources/values-si/strings.xml
@@ -10,23 +10,23 @@
 -->
 <resources>
 
-    <string name="recent_transactions">Miamala ya Hivi Karibuni</string>
-    <string name="no_transaction">Hakuna Muamala</string>
-    <string name="atm_icon">Aikoni ya ATM</string>
+    <string name="recent_transactions">මෑත ගනුදෙනු</string>
+    <string name="no_transaction">ගනුදෙනු නැත</string>
+    <string name="atm_icon">ATM අයිකනය</string>
     <string name="string_and_string">%1$s %2$s</string>
 
-    <string name="something_went_wrong">Kuna kitu kimeenda vibaya</string>
-    <string name="filter">Chuja</string>
-    <string name="filter_transactions">Chuja Miamala</string>
-    <string name="clear_all">Futa Vyote</string>
-    <string name="filter_by_account">Chuja kwa Akaunti :</string>
-    <string name="account_number_label">Nambari ya Akaunti: %1$s</string>
-    <string name="select_account">Chagua Akaunti</string>
-    <string name="balance">Salio: %1$s %2$s</string>
-    <string name="account">Akaunti</string>
-    <string name="transaction_type">Aina ya Muamala:</string>
-    <string name="all">Yote</string>
-    <string name="debits">Malipo (Debits)</string>
-    <string name="credits">Mikopo (Credits)</string>
-    <string name="apply_filters">Weka Vichujio</string>
+    <string name="something_went_wrong">යමක් වැරදී ඇත</string>
+    <string name="filter">පෙරහන</string>
+    <string name="filter_transactions">ගනුදෙනු පෙරීම</string>
+    <string name="clear_all">සියල්ල ඉවත් කරන්න</string>
+    <string name="filter_by_account">ගිණුම අනුව පෙරීම:</string>
+    <string name="account_number_label">ගිණුම් අංකය: %1$s</string>
+    <string name="select_account">ගිණුම තෝරන්න</string>
+    <string name="balance">ශේෂය: %1$s %2$s</string>
+    <string name="account">ගිණුම</string>
+    <string name="transaction_type">ගනුදෙනු වර්ගය:</string>
+    <string name="all">සියල්ල</string>
+    <string name="debits">හර</string>
+    <string name="credits">බැර</string>
+    <string name="apply_filters">පෙරහන් යොදන්න</string>
 </resources>

--- a/feature/recent-transaction/src/commonMain/composeResources/values-si/strings.xml
+++ b/feature/recent-transaction/src/commonMain/composeResources/values-si/strings.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="recent_transactions">Miamala ya Hivi Karibuni</string>
+    <string name="no_transaction">Hakuna Muamala</string>
+    <string name="atm_icon">Aikoni ya ATM</string>
+    <string name="string_and_string">%1$s %2$s</string>
+
+    <string name="something_went_wrong">Kuna kitu kimeenda vibaya</string>
+    <string name="filter">Chuja</string>
+    <string name="filter_transactions">Chuja Miamala</string>
+    <string name="clear_all">Futa Vyote</string>
+    <string name="filter_by_account">Chuja kwa Akaunti :</string>
+    <string name="account_number_label">Nambari ya Akaunti: %1$s</string>
+    <string name="select_account">Chagua Akaunti</string>
+    <string name="balance">Salio: %1$s %2$s</string>
+    <string name="account">Akaunti</string>
+    <string name="transaction_type">Aina ya Muamala:</string>
+    <string name="all">Yote</string>
+    <string name="debits">Malipo (Debits)</string>
+    <string name="credits">Mikopo (Credits)</string>
+    <string name="apply_filters">Weka Vichujio</string>
+</resources>

--- a/feature/recent-transaction/src/commonMain/composeResources/values-sw/strings.xml
+++ b/feature/recent-transaction/src/commonMain/composeResources/values-sw/strings.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="recent_transactions">Miamala ya Hivi Karibuni</string>
+    <string name="no_transaction">Hakuna Muamala</string>
+    <string name="atm_icon">Aikoni ya ATM</string>
+    <string name="string_and_string">%1$s %2$s</string>
+
+    <string name="something_went_wrong">Kuna hitilafu</string>
+    <string name="filter">Chuja</string>
+    <string name="filter_transactions">Chuja Miamala</string>
+    <string name="clear_all">Futa Vyote</string>
+    <string name="filter_by_account">Chuja kwa Akaunti :</string>
+    <string name="account_number_label">Nambari ya Akaunti: %1$s</string>
+    <string name="select_account">Chagua Akaunti</string>
+    <string name="balance">Salio: %1$s %2$s</string>
+    <string name="account">Akaunti</string>
+    <string name="transaction_type">Aina ya Muamala:</string>
+    <string name="all">Yote</string>
+    <string name="debits">Makato</string>
+    <string name="credits">Amana</string>
+    <string name="apply_filters">Weka Vichujio</string>
+</resources>

--- a/feature/recent-transaction/src/commonMain/composeResources/values-sw/strings.xml
+++ b/feature/recent-transaction/src/commonMain/composeResources/values-sw/strings.xml
@@ -19,7 +19,7 @@
     <string name="filter">Chuja</string>
     <string name="filter_transactions">Chuja Miamala</string>
     <string name="clear_all">Futa Vyote</string>
-    <string name="filter_by_account">Chuja kwa Akaunti :</string>
+    <string name="filter_by_account">Chuja kwa Akaunti:</string>
     <string name="account_number_label">Nambari ya Akaunti: %1$s</string>
     <string name="select_account">Chagua Akaunti</string>
     <string name="balance">Salio: %1$s %2$s</string>

--- a/feature/savings-application/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/savings-application/src/commonMain/composeResources/values-ar/strings.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_apply_savings_title">تفاصيل طلب التوفير</string>
+
+    <string name="feature_apply_savings_section_fill_details">املأ تفاصيل الطلب</string>
+
+    <string name="feature_apply_savings_label_applicant_name">اسم مقدم الطلب</string>
+    <string name="feature_apply_savings_label_savings_product">اسم المنتج</string>
+    <string name="feature_apply_savings_label_field_officer">المسؤول الميداني</string>
+    <string name="feature_apply_savings_label_submission_date">تاريخ التقديم</string>
+    <string name="feature_apply_savings_label_fill_application_details">املأ تفاصيل الطلب</string>
+    <string name="feature_apply_savings_label_details">التفاصيل</string>
+    <string name="feature_apply_savings_label_currency">العملة</string>
+    <string name="feature_apply_savings_label_minimum_opening_balance">الحد الأدنى للرصيد الافتتاحي</string>
+    <string name="feature_apply_savings_label_lock_in_period">فترة الحظر</string>
+    <string name="feature_apply_savings_label_frequency">التكرار</string>
+    <string name="feature_apply_savings_label_frequency_type">نوع التكرار</string>
+    <string name="feature_apply_savings_label_overdraft">سحب على المكشوف</string>
+    <string name="feature_apply_savings_label_request_to_allow_overdraft">طلب السماح بالسحب على المكشوف</string>
+
+    <string name="feature_apply_savings_button_continue">متابعة</string>
+    <string name="feature_apply_savings_button_ok">موافق</string>
+    <string name="feature_apply_savings_button_cancel">إلغاء</string>
+    <string name="feature_apply_savings_button_apply">طلب توفير</string>
+    <string name="feature_button_next">التالي</string>
+
+    <string name="feature_apply_savings_error_amount_empty">المبلغ الأساسي مطلوب</string>
+    <string name="feature_apply_savings_error_amount_invalid_format">يرجى إدخال تنسيق مبلغ صحيح</string>
+    <string name="feature_apply_savings_error_amount_too_small">المبلغ الأساسي صغير جداً</string>
+    <string name="feature_apply_savings_error_amount_too_large">المبلغ الأساسي يتجاوز الحد الأقصى</string>
+    <string name="feature_apply_savings_error_amount_invalid_decimal">المبلغ يحتوي على منازل عشرية كثيرة جداً للعملة المحددة</string>
+
+
+    <string name="feature_apply_savings_error_product_empty">منتج التوفير مطلوب</string>
+
+    <string name="feature_apply_savings_error_server">مشكلة في الخادم من جانبنا، لا يمكن المتابعة، حاول مرة أخرى بعد قليل</string>
+    <string name="feature_apply_savings_error_too_many_attempts">محاولات فاشلة كثيرة جداً. يرجى المحاولة لاحقاً.</string>
+    <string name="feature_apply_savings_error_submit_failed">فشل تقديم طلب التوفير. يرجى المحاولة مرة أخرى.</string>
+
+    <string name="feature_apply_savings_success_submit">تم تقديم طلب التوفير بنجاح!</string>
+    <string name="feature_apply_savings_success_draft_saved">تم حفظ مسودة الطلب بنجاح</string>
+
+    <string name="feature_apply_savings_unsaved_changes_title">تغييرات غير محفوظة!</string>
+    <string name="feature_apply_savings_unsaved_changes_message">لديك تغييرات غير محفوظة. هل أنت متأكد أنك تريد الرجوع؟</string>
+
+
+    <string name="feature_apply_savings_label_next">التالي</string>
+
+    <string name="feature_apply_savings_error_currency_required">العملة مطلوبة</string>
+    <string name="feature_apply_savings_error_minimum_opening_balance_required">الحد الأدنى للرصيد الافتتاحي مطلوب</string>
+    <string name="feature_apply_savings_error_lock_in_period_required">فترة الحظر مطلوبة</string>
+    <string name="feature_apply_savings_error_frequency_required">التكرار مطلوب</string>
+    <string name="feature_apply_savings_error_frequency_invalid">أدخل تكراراً صحيحاً</string>
+
+    <string name="feature_apply_savings_status_success">تم التقديم بنجاح!</string>
+    <string name="feature_apply_savings_status_success_tip">لقد قمت بالتقديم بنجاح على حساب توفير تحت %1$s.</string>
+    <string name="feature_apply_savings_status_success_action">العودة للرئيسية</string>
+
+    <string name="feature_apply_savings_status_failure">فشل تقديم الطلب</string>
+    <string name="feature_apply_savings_status_failure_tip">فشل التقديم على حساب توفير تحت %1$s.</string>
+    <string name="feature_apply_savings_status_failure_action">حاول مرة أخرى</string>
+
+</resources>

--- a/feature/savings-application/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/savings-application/src/commonMain/composeResources/values-de/strings.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_apply_savings_title">Details zum Sparantrag</string>
+
+    <string name="feature_apply_savings_section_fill_details">Antragsdetails ausfüllen</string>
+
+    <string name="feature_apply_savings_label_applicant_name">Name des Antragstellers</string>
+    <string name="feature_apply_savings_label_savings_product">Produktname</string>
+    <string name="feature_apply_savings_label_field_officer">Außendienstmitarbeiter</string>
+    <string name="feature_apply_savings_label_submission_date">Einreichungsdatum</string>
+    <string name="feature_apply_savings_label_fill_application_details">Antragsdetails ausfüllen</string>
+    <string name="feature_apply_savings_label_details">Details</string>
+    <string name="feature_apply_savings_label_currency">Währung</string>
+    <string name="feature_apply_savings_label_minimum_opening_balance">Mindesteröffnungsbetrag</string>
+    <string name="feature_apply_savings_label_lock_in_period">Sperrfrist</string>
+    <string name="feature_apply_savings_label_frequency">Frequenz</string>
+    <string name="feature_apply_savings_label_frequency_type">Frequenztyp</string>
+    <string name="feature_apply_savings_label_overdraft">Überziehung</string>
+    <string name="feature_apply_savings_label_request_to_allow_overdraft">Überziehung beantragen</string>
+
+    <string name="feature_apply_savings_button_continue">Weiter</string>
+    <string name="feature_apply_savings_button_ok">Ok</string>
+    <string name="feature_apply_savings_button_cancel">Abbrechen</string>
+    <string name="feature_apply_savings_button_apply">Sparen beantragen</string>
+    <string name="feature_button_next">Weiter</string>
+
+    <string name="feature_apply_savings_error_amount_empty">Kapitalbetrag ist erforderlich</string>
+    <string name="feature_apply_savings_error_amount_invalid_format">Bitte geben Sie ein gültiges Betragsformat ein</string>
+    <string name="feature_apply_savings_error_amount_too_small">Kapitalbetrag ist zu gering</string>
+    <string name="feature_apply_savings_error_amount_too_large">Kapitalbetrag überschreitet das Maximum</string>
+    <string name="feature_apply_savings_error_amount_invalid_decimal">Betrag hat zu viele Nachkommastellen für die gewählte Währung</string>
+
+
+    <string name="feature_apply_savings_error_product_empty">Sparprodukt ist erforderlich</string>
+
+    <string name="feature_apply_savings_error_server">Serverproblem auf unserer Seite, Vorgang kann nicht fortgesetzt werden. Bitte versuchen Sie es später erneut.</string>
+    <string name="feature_apply_savings_error_too_many_attempts">Zu viele fehlgeschlagene Versuche. Bitte versuchen Sie es später erneut.</string>
+    <string name="feature_apply_savings_error_submit_failed">Antrag auf Sparkonto fehlgeschlagen. Bitte versuchen Sie es erneut.</string>
+
+    <string name="feature_apply_savings_success_submit">Sparantrag erfolgreich eingereicht!</string>
+    <string name="feature_apply_savings_success_draft_saved">Antragsentwurf erfolgreich gespeichert</string>
+
+    <string name="feature_apply_savings_unsaved_changes_title">Ungespeicherte Änderungen!</string>
+    <string name="feature_apply_savings_unsaved_changes_message">Sie haben ungespeicherte Änderungen. Sind Sie sicher, dass Sie zurückgehen möchten?</string>
+
+
+    <string name="feature_apply_savings_label_next">Weiter</string>
+
+    <string name="feature_apply_savings_error_currency_required">Währung ist erforderlich</string>
+    <string name="feature_apply_savings_error_minimum_opening_balance_required">Mindesteröffnungsbetrag ist erforderlich</string>
+    <string name="feature_apply_savings_error_lock_in_period_required">Sperrfrist ist erforderlich</string>
+    <string name="feature_apply_savings_error_frequency_required">Frequenz ist erforderlich</string>
+    <string name="feature_apply_savings_error_frequency_invalid">Geben Sie eine gültige Frequenz ein</string>
+
+    <string name="feature_apply_savings_status_success">Erfolgreich beantragt!</string>
+    <string name="feature_apply_savings_status_success_tip">Sie haben erfolgreich ein Sparkonto unter %1$s beantragt.</string>
+    <string name="feature_apply_savings_status_success_action">Zurück zur Startseite</string>
+
+    <string name="feature_apply_savings_status_failure">Antrag konnte nicht gesendet werden</string>
+    <string name="feature_apply_savings_status_failure_tip">Antrag auf ein Sparkonto unter %1$s fehlgeschlagen.</string>
+    <string name="feature_apply_savings_status_failure_action">Erneut versuchen</string>
+
+</resources>

--- a/feature/savings-application/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/savings-application/src/commonMain/composeResources/values-fr/strings.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_apply_savings_title">Détails de la demande d\'épargne</string>
+
+    <string name="feature_apply_savings_section_fill_details">Remplir les détails de la demande</string>
+
+    <string name="feature_apply_savings_label_applicant_name">Nom du demandeur</string>
+    <string name="feature_apply_savings_label_savings_product">Nom du produit</string>
+    <string name="feature_apply_savings_label_field_officer">Agent de terrain</string>
+    <string name="feature_apply_savings_label_submission_date">Date de soumission</string>
+    <string name="feature_apply_savings_label_fill_application_details">Remplir les détails de la demande</string>
+    <string name="feature_apply_savings_label_details">Détails</string>
+    <string name="feature_apply_savings_label_currency">Devise</string>
+    <string name="feature_apply_savings_label_minimum_opening_balance">Solde d\'ouverture minimum</string>
+    <string name="feature_apply_savings_label_lock_in_period">Période de blocage</string>
+    <string name="feature_apply_savings_label_frequency">Fréquence</string>
+    <string name="feature_apply_savings_label_frequency_type">Type de fréquence</string>
+    <string name="feature_apply_savings_label_overdraft">Découvert</string>
+    <string name="feature_apply_savings_label_request_to_allow_overdraft">Demande d\'autorisation de découvert</string>
+
+    <string name="feature_apply_savings_button_continue">Continuer</string>
+    <string name="feature_apply_savings_button_ok">Ok</string>
+    <string name="feature_apply_savings_button_cancel">Annuler</string>
+    <string name="feature_apply_savings_button_apply">Demander l\'épargne</string>
+    <string name="feature_button_next">Suivant</string>
+
+    <string name="feature_apply_savings_error_amount_empty">Le montant principal est requis</string>
+    <string name="feature_apply_savings_error_amount_invalid_format">Veuillez entrer un format de montant valide</string>
+    <string name="feature_apply_savings_error_amount_too_small">Le montant principal est trop petit</string>
+    <string name="feature_apply_savings_error_amount_too_large">Le montant principal dépasse la limite maximale</string>
+    <string name="feature_apply_savings_error_amount_invalid_decimal">Le montant a trop de décimales pour la devise sélectionnée</string>
+
+
+    <string name="feature_apply_savings_error_product_empty">Le produit d\'épargne est requis</string>
+
+    <string name="feature_apply_savings_error_server">Problème de serveur de notre côté, impossible de continuer. Réessayez dans un moment.</string>
+    <string name="feature_apply_savings_error_too_many_attempts">Trop de tentatives échouées. Veuillez réessayer plus tard.</string>
+    <string name="feature_apply_savings_error_submit_failed">Échec de la soumission de la demande d\'épargne. Veuillez réessayer.</string>
+
+    <string name="feature_apply_savings_success_submit">Demande d\'épargne soumise avec succès !</string>
+    <string name="feature_apply_savings_success_draft_saved">Brouillon de la demande enregistré avec succès</string>
+
+    <string name="feature_apply_savings_unsaved_changes_title">Modifications non enregistrées !</string>
+    <string name="feature_apply_savings_unsaved_changes_message">Vous avez des modifications non enregistrées. Êtes-vous sûr de vouloir revenir en arrière ?</string>
+
+
+    <string name="feature_apply_savings_label_next">Suivant</string>
+
+    <string name="feature_apply_savings_error_currency_required">La devise est requise</string>
+    <string name="feature_apply_savings_error_minimum_opening_balance_required">Le solde d\'ouverture minimum est requis</string>
+    <string name="feature_apply_savings_error_lock_in_period_required">La période de blocage est requise</string>
+    <string name="feature_apply_savings_error_frequency_required">La fréquence est requise</string>
+    <string name="feature_apply_savings_error_frequency_invalid">Entrez une fréquence valide</string>
+
+    <string name="feature_apply_savings_status_success">Demande réussie !</string>
+    <string name="feature_apply_savings_status_success_tip">Vous avez demandé avec succès un compte d\'épargne sous %1$s.</string>
+    <string name="feature_apply_savings_status_success_action">Retour à l\'accueil</string>
+
+    <string name="feature_apply_savings_status_failure">Échec de la soumission de la demande</string>
+    <string name="feature_apply_savings_status_failure_tip">Échec de la demande de compte d\'épargne sous %1$s.</string>
+    <string name="feature_apply_savings_status_failure_action">Réessayer</string>
+
+</resources>

--- a/feature/savings-application/src/commonMain/composeResources/values-gu/strings.xml
+++ b/feature/savings-application/src/commonMain/composeResources/values-gu/strings.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_apply_savings_title">બચત એપ્લિકેશન વિગતો</string>
+
+    <string name="feature_apply_savings_section_fill_details">એપ્લિકેશન વિગતો ભરો</string>
+
+    <string name="feature_apply_savings_label_applicant_name">અરજદારનું નામ</string>
+    <string name="feature_apply_savings_label_savings_product">પ્રોડક્ટનું નામ</string>
+    <string name="feature_apply_savings_label_field_officer">ફિલ્ડ ઓફિસર</string>
+    <string name="feature_apply_savings_label_submission_date">સબમિશન તારીખ</string>
+    <string name="feature_apply_savings_label_fill_application_details">એપ્લિકેશન વિગતો ભરો</string>
+    <string name="feature_apply_savings_label_details">વિગતો</string>
+    <string name="feature_apply_savings_label_currency">ચલણ</string>
+    <string name="feature_apply_savings_label_minimum_opening_balance">ન્યૂનતમ ઓપનિંગ બેલેન્સ</string>
+    <string name="feature_apply_savings_label_lock_in_period">લોક-ઇન સમયગાળો</string>
+    <string name="feature_apply_savings_label_frequency">આવર્તન (Frequency)</string>
+    <string name="feature_apply_savings_label_frequency_type">આવર્તન પ્રકાર</string>
+    <string name="feature_apply_savings_label_overdraft">ઓવરડ્રાફ્ટ</string>
+    <string name="feature_apply_savings_label_request_to_allow_overdraft">ઓવરડ્રાફ્ટની પરવાનગી માટે વિનંતી</string>
+
+    <string name="feature_apply_savings_button_continue">ચાલુ રાખો</string>
+    <string name="feature_apply_savings_button_ok">ઓકે</string>
+    <string name="feature_apply_savings_button_cancel">રદ કરો</string>
+    <string name="feature_apply_savings_button_apply">બચત માટે અરજી કરો</string>
+    <string name="feature_button_next">આગળ</string>
+
+    <string name="feature_apply_savings_error_amount_empty">મૂળ રકમ જરૂરી છે</string>
+    <string name="feature_apply_savings_error_amount_invalid_format">કૃપા કરીને માન્ય રકમ ફોર્મેટ દાખલ કરો</string>
+    <string name="feature_apply_savings_error_amount_too_small">મૂળ રકમ ખૂબ નાની છે</string>
+    <string name="feature_apply_savings_error_amount_too_large">મૂળ રકમ મહત્તમ મર્યાદા કરતાં વધી ગઈ છે</string>
+    <string name="feature_apply_savings_error_amount_invalid_decimal">પસંદ કરેલ ચલણ માટે રકમમાં ઘણા બધા દશાંશ સ્થાનો છે</string>
+
+
+    <string name="feature_apply_savings_error_product_empty">બચત પ્રોડક્ટ જરૂરી છે</string>
+
+    <string name="feature_apply_savings_error_server">અમારી બાજુથી સર્વર સમસ્યા હોવાથી આગળ વધી શકાતું નથી, થોડીવાર પછી ફરી પ્રયાસ કરો</string>
+    <string name="feature_apply_savings_error_too_many_attempts">ઘણા બધા નિષ્ફળ પ્રયાસો. કૃપા કરીને પછીથી ફરી પ્રયાસ કરો.</string>
+    <string name="feature_apply_savings_error_submit_failed">બચત એપ્લિકેશન સબમિટ કરવામાં નિષ્ફળ. કૃપા કરીને ફરી પ્રયાસ કરો.</string>
+
+    <string name="feature_apply_savings_success_submit">બચત એપ્લિકેશન સફળતાપૂર્વક સબમિટ થઈ!</string>
+    <string name="feature_apply_savings_success_draft_saved">એપ્લિકેશન ડ્રાફ્ટ સફળતાપૂર્વક સાચવ્યો</string>
+
+    <string name="feature_apply_savings_unsaved_changes_title">સાચવ્યા વગરના ફેરફારો!</string>
+    <string name="feature_apply_savings_unsaved_changes_message">તમારી પાસે સાચવ્યા વગરના ફેરફારો છે. શું તમે ખરેખર પાછા જવા માંગો છો?</string>
+
+
+    <string name="feature_apply_savings_label_next">આગળ</string>
+
+    <string name="feature_apply_savings_error_currency_required">ચલણ જરૂરી છે</string>
+    <string name="feature_apply_savings_error_minimum_opening_balance_required">ન્યૂનતમ ઓપનિંગ બેલેન્સ જરૂરી છે</string>
+    <string name="feature_apply_savings_error_lock_in_period_required">લોક-ઇન સમયગાળો જરૂરી છે</string>
+    <string name="feature_apply_savings_error_frequency_required">આવર્તન જરૂરી છે</string>
+    <string name="feature_apply_savings_error_frequency_invalid">માન્ય આવર્તન દાખલ કરો</string>
+
+    <string name="feature_apply_savings_status_success">સફળતાપૂર્વક અરજી કરી!</string>
+    <string name="feature_apply_savings_status_success_tip">તમે %1$s હેઠળ બચત ખાતા માટે સફળતાપૂર્વક અરજી કરી છે.</string>
+    <string name="feature_apply_savings_status_success_action">હોમ પર પાછા જાઓ</string>
+
+    <string name="feature_apply_savings_status_failure">એપ્લિકેશન સબમિટ કરવામાં નિષ્ફળ</string>
+    <string name="feature_apply_savings_status_failure_tip">%1$s હેઠળ બચત ખાતા માટે અરજી કરવામાં નિષ્ફળ.</string>
+    <string name="feature_apply_savings_status_failure_action">ફરી પ્રયાસ કરો</string>
+
+</resources>

--- a/feature/savings-application/src/commonMain/composeResources/values-hi/strings.xml
+++ b/feature/savings-application/src/commonMain/composeResources/values-hi/strings.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_apply_savings_title">बचत आवेदन विवरण</string>
+
+    <string name="feature_apply_savings_section_fill_details">आवेदन विवरण भरें</string>
+
+    <string name="feature_apply_savings_label_applicant_name">आवेदक का नाम</string>
+    <string name="feature_apply_savings_label_savings_product">उत्पाद का नाम</string>
+    <string name="feature_apply_savings_label_field_officer">फील्ड ऑफिसर</string>
+    <string name="feature_apply_savings_label_submission_date">जमा करने की तिथि</string>
+    <string name="feature_apply_savings_label_fill_application_details">आवेदन विवरण भरें</string>
+    <string name="feature_apply_savings_label_details">विवरण</string>
+    <string name="feature_apply_savings_label_currency">मुद्रा</string>
+    <string name="feature_apply_savings_label_minimum_opening_balance">न्यूनतम प्रारंभिक शेष राशि</string>
+    <string name="feature_apply_savings_label_lock_in_period">लॉक-इन अवधि</string>
+    <string name="feature_apply_savings_label_frequency">आवृत्ति (Frequency)</string>
+    <string name="feature_apply_savings_label_frequency_type">आवृत्ति प्रकार</string>
+    <string name="feature_apply_savings_label_overdraft">ओवरड्राफ्ट</string>
+    <string name="feature_apply_savings_label_request_to_allow_overdraft">ओवरड्राफ्ट की अनुमति के लिए अनुरोध</string>
+
+    <string name="feature_apply_savings_button_continue">जारी रखें</string>
+    <string name="feature_apply_savings_button_ok">ठीक है</string>
+    <string name="feature_apply_savings_button_cancel">रद्द करें</string>
+    <string name="feature_apply_savings_button_apply">बचत आवेदन करें</string>
+    <string name="feature_button_next">अगला</string>
+
+    <string name="feature_apply_savings_error_amount_empty">मूल राशि आवश्यक है</string>
+    <string name="feature_apply_savings_error_amount_invalid_format">कृपया एक मान्य राशि प्रारूप दर्ज करें</string>
+    <string name="feature_apply_savings_error_amount_too_small">मूल राशि बहुत कम है</string>
+    <string name="feature_apply_savings_error_amount_too_large">मूल राशि अधिकतम सीमा से अधिक है</string>
+    <string name="feature_apply_savings_error_amount_invalid_decimal">चुनी गई मुद्रा के लिए राशि में बहुत अधिक दशमलव स्थान हैं</string>
+
+
+    <string name="feature_apply_savings_error_product_empty">बचत उत्पाद आवश्यक है</string>
+
+    <string name="feature_apply_savings_error_server">हमारी ओर से सर्वर की समस्या के कारण आगे नहीं बढ़ सकते, कुछ देर बाद पुन: प्रयास करें</string>
+    <string name="feature_apply_savings_error_too_many_attempts">बहुत सारे विफल प्रयास। कृपया बाद में पुन: प्रयास करें।</string>
+    <string name="feature_apply_savings_error_submit_failed">बचत आवेदन जमा करने में विफल। कृपया पुन: प्रयास करें।</string>
+
+    <string name="feature_apply_savings_success_submit">बचत आवेदन सफलतापूर्वक जमा किया गया!</string>
+    <string name="feature_apply_savings_success_draft_saved">आवेदन ड्राफ्ट सफलतापूर्वक सहेजा गया</string>
+
+    <string name="feature_apply_savings_unsaved_changes_title">सहेज नहीं गए बदलाव!</string>
+    <string name="feature_apply_savings_unsaved_changes_message">आपके पास असहेजे गए बदलाव हैं। क्या आप निश्चित रूप से वापस जाना चाहते हैं?</string>
+
+
+    <string name="feature_apply_savings_label_next">अगला</string>
+
+    <string name="feature_apply_savings_error_currency_required">मुद्रा आवश्यक है</string>
+    <string name="feature_apply_savings_error_minimum_opening_balance_required">न्यूनतम प्रारंभिक शेष राशि आवश्यक है</string>
+    <string name="feature_apply_savings_error_lock_in_period_required">लॉक-इन अवधि आवश्यक है</string>
+    <string name="feature_apply_savings_error_frequency_required">आवृत्ति आवश्यक है</string>
+    <string name="feature_apply_savings_error_frequency_invalid">एक मान्य आवृत्ति दर्ज करें</string>
+
+    <string name="feature_apply_savings_status_success">सफलतापूर्वक आवेदन किया गया!</string>
+    <string name="feature_apply_savings_status_success_tip">आपने %1$s के तहत बचत खाते के लिए सफलतापूर्वक आवेदन कर दिया है।</string>
+    <string name="feature_apply_savings_status_success_action">होम पर वापस जाएं</string>
+
+    <string name="feature_apply_savings_status_failure">आवेदन जमा करने में विफल</string>
+    <string name="feature_apply_savings_status_failure_tip">%1$s के तहत बचत खाते के लिए आवेदन करने में विफल।</string>
+    <string name="feature_apply_savings_status_failure_action">पुन: प्रयास करें</string>
+
+</resources>

--- a/feature/savings-application/src/commonMain/composeResources/values-hu/strings.xml
+++ b/feature/savings-application/src/commonMain/composeResources/values-hu/strings.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_apply_savings_title">Megtakarítási kérelem részletei</string>
+
+    <string name="feature_apply_savings_section_fill_details">Töltse ki a kérelem részleteit</string>
+
+    <string name="feature_apply_savings_label_applicant_name">Igénylő neve</string>
+    <string name="feature_apply_savings_label_savings_product">Termék neve</string>
+    <string name="feature_apply_savings_label_field_officer">Területi képviselő</string>
+    <string name="feature_apply_savings_label_submission_date">Benyújtás dátuma</string>
+    <string name="feature_apply_savings_label_fill_application_details">Töltse ki a kérelem részleteit</string>
+    <string name="feature_apply_savings_label_details">Részletek</string>
+    <string name="feature_apply_savings_label_currency">Pénznem</string>
+    <string name="feature_apply_savings_label_minimum_opening_balance">Minimális nyitóegyenleg</string>
+    <string name="feature_apply_savings_label_lock_in_period">Zárolási időszak</string>
+    <string name="feature_apply_savings_label_frequency">Gyakoriság</string>
+    <string name="feature_apply_savings_label_frequency_type">Gyakoriság típusa</string>
+    <string name="feature_apply_savings_label_overdraft">Folyószámlahitel</string>
+    <string name="feature_apply_savings_label_request_to_allow_overdraft">Folyószámlahitel engedélyezésének kérése</string>
+
+    <string name="feature_apply_savings_button_continue">Folytatás</string>
+    <string name="feature_apply_savings_button_ok">Ok</string>
+    <string name="feature_apply_savings_button_cancel">Mégse</string>
+    <string name="feature_apply_savings_button_apply">Megtakarítás igénylése</string>
+    <string name="feature_button_next">Tovább</string>
+
+    <string name="feature_apply_savings_error_amount_empty">A tőkeösszeg megadása kötelező</string>
+    <string name="feature_apply_savings_error_amount_invalid_format">Kérjük, adjon meg érvényes összegformátumot</string>
+    <string name="feature_apply_savings_error_amount_too_small">A tőkeösszeg túl kicsi</string>
+    <string name="feature_apply_savings_error_amount_too_large">A tőkeösszeg meghaladja a maximális határt</string>
+    <string name="feature_apply_savings_error_amount_invalid_decimal">Az összeg túl sok tizedesjegyet tartalmaz a választott pénznemhez</string>
+
+
+    <string name="feature_apply_savings_error_product_empty">Megtakarítási termék megadása kötelező</string>
+
+    <string name="feature_apply_savings_error_server">Szerverhiba lépett fel, nem lehet folytatni. Kérjük, próbálja újra később.</string>
+    <string name="feature_apply_savings_error_too_many_attempts">Túl sok sikertelen kísérlet. Kérjük, próbálja újra később.</string>
+    <string name="feature_apply_savings_error_submit_failed">A megtakarítási kérelem benyújtása sikertelen. Kérjük, próbálja újra.</string>
+
+    <string name="feature_apply_savings_success_submit">Megtakarítási kérelem sikeresen benyújtva!</string>
+    <string name="feature_apply_savings_success_draft_saved">Kérelem piszkozata sikeresen mentve</string>
+
+    <string name="feature_apply_savings_unsaved_changes_title">Mentetlen változások!</string>
+    <string name="feature_apply_savings_unsaved_changes_message">Mentetlen változtatásai vannak. Biztosan vissza akar lépni?</string>
+
+
+    <string name="feature_apply_savings_label_next">Tovább</string>
+
+    <string name="feature_apply_savings_error_currency_required">Pénznem megadása kötelező</string>
+    <string name="feature_apply_savings_error_minimum_opening_balance_required">Minimális nyitóegyenleg megadása kötelező</string>
+    <string name="feature_apply_savings_error_lock_in_period_required">Zárolási időszak megadása kötelező</string>
+    <string name="feature_apply_savings_error_frequency_required">Gyakoriság megadása kötelező</string>
+    <string name="feature_apply_savings_error_frequency_invalid">Adjon meg érvényes gyakoriságot</string>
+
+    <string name="feature_apply_savings_status_success">Sikeres igénylés!</string>
+    <string name="feature_apply_savings_status_success_tip">Sikeresen igényelt megtakarítási számlát a(z) %1$s alatt.</string>
+    <string name="feature_apply_savings_status_success_action">Vissza a főoldalra</string>
+
+    <string name="feature_apply_savings_status_failure">A kérelem benyújtása sikertelen</string>
+    <string name="feature_apply_savings_status_failure_tip">Nem sikerült megtakarítási számlát igényelni a(z) %1$s alatt.</string>
+    <string name="feature_apply_savings_status_failure_action">Próbálja újra</string>
+
+</resources>

--- a/feature/savings-application/src/commonMain/composeResources/values-in/strings.xml
+++ b/feature/savings-application/src/commonMain/composeResources/values-in/strings.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_apply_savings_title">Detail Aplikasi Tabungan</string>
+
+    <string name="feature_apply_savings_section_fill_details">Isi Detail Aplikasi</string>
+
+    <string name="feature_apply_savings_label_applicant_name">Nama Pemohon</string>
+    <string name="feature_apply_savings_label_savings_product">Nama Produk</string>
+    <string name="feature_apply_savings_label_field_officer">Petugas Lapangan</string>
+    <string name="feature_apply_savings_label_submission_date">Tanggal Pengajuan</string>
+    <string name="feature_apply_savings_label_fill_application_details">Isi Detail Aplikasi</string>
+    <string name="feature_apply_savings_label_details">Detail</string>
+    <string name="feature_apply_savings_label_currency">Mata Uang</string>
+    <string name="feature_apply_savings_label_minimum_opening_balance">Saldo Awal Minimum</string>
+    <string name="feature_apply_savings_label_lock_in_period">Periode Penguncian</string>
+    <string name="feature_apply_savings_label_frequency">Frekuensi</string>
+    <string name="feature_apply_savings_label_frequency_type">Jenis Frekuensi</string>
+    <string name="feature_apply_savings_label_overdraft">Overdraft</string>
+    <string name="feature_apply_savings_label_request_to_allow_overdraft">Permintaan untuk mengizinkan overdraft</string>
+
+    <string name="feature_apply_savings_button_continue">Lanjut</string>
+    <string name="feature_apply_savings_button_ok">Ok</string>
+    <string name="feature_apply_savings_button_cancel">Batal</string>
+    <string name="feature_apply_savings_button_apply">Ajukan Tabungan</string>
+    <string name="feature_button_next">Berikutnya</string>
+
+    <string name="feature_apply_savings_error_amount_empty">Jumlah pokok diperlukan</string>
+    <string name="feature_apply_savings_error_amount_invalid_format">Silakan masukkan format jumlah yang valid</string>
+    <string name="feature_apply_savings_error_amount_too_small">Jumlah pokok terlalu kecil</string>
+    <string name="feature_apply_savings_error_amount_too_large">Jumlah pokok melebihi batas maksimum</string>
+    <string name="feature_apply_savings_error_amount_invalid_decimal">Jumlah memiliki terlalu banyak tempat desimal untuk mata uang yang dipilih</string>
+
+
+    <string name="feature_apply_savings_error_product_empty">Produk tabungan diperlukan</string>
+
+    <string name="feature_apply_savings_error_server">Masalah server dari sisi kami, tidak dapat melanjutkan. Coba lagi sesaat lagi</string>
+    <string name="feature_apply_savings_error_too_many_attempts">Terlalu banyak upaya gagal. Silakan coba lagi nanti.</string>
+    <string name="feature_apply_savings_error_submit_failed">Gagal mengirimkan aplikasi tabungan. Silakan coba lagi.</string>
+
+    <string name="feature_apply_savings_success_submit">Aplikasi tabungan berhasil dikirim!</string>
+    <string name="feature_apply_savings_success_draft_saved">Draf aplikasi berhasil disimpan</string>
+
+    <string name="feature_apply_savings_unsaved_changes_title">Perubahan Belum Disimpan!</string>
+    <string name="feature_apply_savings_unsaved_changes_message">Anda memiliki perubahan yang belum disimpan. Apakah Anda yakin ingin kembali?</string>
+
+
+    <string name="feature_apply_savings_label_next">Berikutnya</string>
+
+    <string name="feature_apply_savings_error_currency_required">Mata uang diperlukan</string>
+    <string name="feature_apply_savings_error_minimum_opening_balance_required">Saldo awal minimum diperlukan</string>
+    <string name="feature_apply_savings_error_lock_in_period_required">Periode penguncian diperlukan</string>
+    <string name="feature_apply_savings_error_frequency_required">Frekuensi diperlukan</string>
+    <string name="feature_apply_savings_error_frequency_invalid">Masukkan frekuensi yang valid</string>
+
+    <string name="feature_apply_savings_status_success">Berhasil Diajukan!</string>
+    <string name="feature_apply_savings_status_success_tip">Anda telah berhasil mengajukan akun tabungan di bawah %1$s.</string>
+    <string name="feature_apply_savings_status_success_action">Kembali Ke Beranda</string>
+
+    <string name="feature_apply_savings_status_failure">Aplikasi Gagal Dikirim</string>
+    <string name="feature_apply_savings_status_failure_tip">Gagal mengajukan akun tabungan di bawah %1$s.</string>
+    <string name="feature_apply_savings_status_failure_action">Coba Lagi</string>
+
+</resources>

--- a/feature/savings-application/src/commonMain/composeResources/values-kn/strings.xml
+++ b/feature/savings-application/src/commonMain/composeResources/values-kn/strings.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_apply_savings_title">ಉಳಿತಾಯ ಅಪ್ಲಿಕೇಶನ್ ವಿವರಗಳು</string>
+
+    <string name="feature_apply_savings_section_fill_details">ಅಪ್ಲಿಕೇಶನ್ ವಿವರಗಳನ್ನು ಭರ್ತಿ ಮಾಡಿ</string>
+
+    <string name="feature_apply_savings_label_applicant_name">ಅರ್ಜಿದಾರರ ಹೆಸರು</string>
+    <string name="feature_apply_savings_label_savings_product">ಉತ್ಪನ್ನದ ಹೆಸರು</string>
+    <string name="feature_apply_savings_label_field_officer">ಫೀಲ್ಡ್ ಆಫೀಸರ್</string>
+    <string name="feature_apply_savings_label_submission_date">ಸಲ್ಲಿಸಿದ ದಿನಾಂಕ</string>
+    <string name="feature_apply_savings_label_fill_application_details">ಅಪ್ಲಿಕೇಶನ್ ವಿವರಗಳನ್ನು ಭರ್ತಿ ಮಾಡಿ</string>
+    <string name="feature_apply_savings_label_details">ವಿವರಗಳು</string>
+    <string name="feature_apply_savings_label_currency">ಕರೆನ್ಸಿ</string>
+    <string name="feature_apply_savings_label_minimum_opening_balance">ಕನಿಷ್ಠ ಆರಂಭಿಕ ಬಾಕಿ</string>
+    <string name="feature_apply_savings_label_lock_in_period">ಲಾಕ್-ಇನ್ ಅವಧಿ</string>
+    <string name="feature_apply_savings_label_frequency">ಆವರ್ತನ (Frequency)</string>
+    <string name="feature_apply_savings_label_frequency_type">ಆವರ್ತನ ಪ್ರಕಾರ</string>
+    <string name="feature_apply_savings_label_overdraft">ಓವರ್‌ಡ್ರಾಫ್ಟ್</string>
+    <string name="feature_apply_savings_label_request_to_allow_overdraft">ಓವರ್‌ಡ್ರಾಫ್ಟ್‌ಗೆ ಅನುಮತಿಸಲು ವಿನಂತಿ</string>
+
+    <string name="feature_apply_savings_button_continue">ಮುಂದುವರಿಸಿ</string>
+    <string name="feature_apply_savings_button_ok">ಸರಿ</string>
+    <string name="feature_apply_savings_button_cancel">ರದ್ದುಮಾಡಿ</string>
+    <string name="feature_apply_savings_button_apply">ಉಳಿತಾಯವನ್ನು ಅನ್ವಯಿಸಿ</string>
+    <string name="feature_button_next">ಮುಂದೆ</string>
+
+    <string name="feature_apply_savings_error_amount_empty">ಮೂಲ ಮೊತ್ತ ಅಗತ್ಯವಿದೆ</string>
+    <string name="feature_apply_savings_error_amount_invalid_format">ದಯವಿಟ್ಟು ಮಾನ್ಯವಾದ ಮೊತ್ತದ ಸ್ವರೂಪವನ್ನು ನಮೂದಿಸಿ</string>
+    <string name="feature_apply_savings_error_amount_too_small">ಮೂಲ ಮೊತ್ತವು ತುಂಬಾ ಚಿಕ್ಕದಾಗಿದೆ</string>
+    <string name="feature_apply_savings_error_amount_too_large">ಮೂಲ ಮೊತ್ತವು ಗರಿಷ್ಠ ಮಿತಿಯನ್ನು ಮೀರಿದೆ</string>
+    <string name="feature_apply_savings_error_amount_invalid_decimal">ಆಯ್ಕೆಮಾಡಿದ ಕರೆನ್ಸಿಗೆ ಮೊತ್ತವು ತುಂಬಾ ದಶಮಾಂಶ ಸ್ಥಾನಗಳನ್ನು ಹೊಂದಿದೆ</string>
+
+
+    <string name="feature_apply_savings_error_product_empty">ಉಳಿತಾಯ ಉತ್ಪನ್ನ ಅಗತ್ಯವಿದೆ</string>
+
+    <string name="feature_apply_savings_error_server">ನಮ್ಮ ಕಡೆಯಿಂದ ಸರ್ವರ್ ಸಮಸ್ಯೆ ಇದೆ, ಮುಂದುವರಿಯಲು ಸಾಧ್ಯವಿಲ್ಲ, ಸ್ವಲ್ಪ ಸಮಯದ ನಂತರ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ</string>
+    <string name="feature_apply_savings_error_too_many_attempts">ತುಂಬಾ ವಿಫಲ ಪ್ರಯತ್ನಗಳು. ದಯವಿಟ್ಟು ನಂತರ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.</string>
+    <string name="feature_apply_savings_error_submit_failed">ಉಳಿತಾಯ ಅಪ್ಲಿಕೇಶನ್ ಸಲ್ಲಿಸಲು ವಿಫಲವಾಗಿದೆ. ದಯವಿಟ್ಟು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.</string>
+
+    <string name="feature_apply_savings_success_submit">ಉಳಿತಾಯ ಅಪ್ಲಿಕೇಶನ್ ಯಶಸ್ವಿಯಾಗಿ ಸಲ್ಲಿಸಲಾಗಿದೆ!</string>
+    <string name="feature_apply_savings_success_draft_saved">ಅಪ್ಲಿಕೇಶನ್ ಡ್ರಾಫ್ಟ್ ಯಶಸ್ವಿಯಾಗಿ ಉಳಿಸಲಾಗಿದೆ</string>
+
+    <string name="feature_apply_savings_unsaved_changes_title">ಉಳಿಸದ ಬದಲಾವಣೆಗಳು!</string>
+    <string name="feature_apply_savings_unsaved_changes_message">ನೀವು ಉಳಿಸದ ಬದಲಾವಣೆಗಳನ್ನು ಹೊಂದಿದ್ದೀರಿ. ನೀವು ಖಂಡಿತವಾಗಿಯೂ ಹಿಂದಕ್ಕೆ ಹೋಗಲು ಬಯಸುವಿರಾ?</string>
+
+
+    <string name="feature_apply_savings_label_next">ಮುಂದೆ</string>
+
+    <string name="feature_apply_savings_error_currency_required">ಕರೆನ್ಸಿ ಅಗತ್ಯವಿದೆ</string>
+    <string name="feature_apply_savings_error_minimum_opening_balance_required">ಕನಿಷ್ಠ ಆರಂಭಿಕ ಬಾಕಿ ಅಗತ್ಯವಿದೆ</string>
+    <string name="feature_apply_savings_error_lock_in_period_required">ಲಾಕ್-ಇನ್ ಅವಧಿ ಅಗತ್ಯವಿದೆ</string>
+    <string name="feature_apply_savings_error_frequency_required">ಆವರ್ತನ ಅಗತ್ಯವಿದೆ</string>
+    <string name="feature_apply_savings_error_frequency_invalid">ಮಾನ್ಯವಾದ ಆವರ್ತನವನ್ನು ನಮೂದಿಸಿ</string>
+
+    <string name="feature_apply_savings_status_success">ಅರ್ಜಿ ಸಲ್ಲಿಸುವಿಕೆ ಯಶಸ್ವಿಯಾಗಿದೆ!</string>
+    <string name="feature_apply_savings_status_success_tip">ನೀವು %1$s ಅಡಿಯಲ್ಲಿ ಉಳಿತಾಯ ಖಾತೆಗೆ ಯಶಸ್ವಿಯಾಗಿ ಅರ್ಜಿ ಸಲ್ಲಿಸಿದ್ದೀರಿ.</string>
+    <string name="feature_apply_savings_status_success_action">ಮುಖಪುಟಕ್ಕೆ ಹಿಂತಿರುಗಿ</string>
+
+    <string name="feature_apply_savings_status_failure">ಅಪ್ಲಿಕೇಶನ್ ಸಲ್ಲಿಸಲು ವಿಫಲವಾಗಿದೆ</string>
+    <string name="feature_apply_savings_status_failure_tip">%1$s ಅಡಿಯಲ್ಲಿ ಉಳಿತಾಯ ಖಾತೆಗೆ ಅರ್ಜಿ ಸಲ್ಲಿಸಲು ವಿಫಲವಾಗಿದೆ.</string>
+    <string name="feature_apply_savings_status_failure_action">ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ</string>
+
+</resources>

--- a/feature/savings-application/src/commonMain/composeResources/values-mr/strings.xml
+++ b/feature/savings-application/src/commonMain/composeResources/values-mr/strings.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_apply_savings_title">बचत अर्ज तपशील</string>
+
+    <string name="feature_apply_savings_section_fill_details">अर्ज तपशील भरा</string>
+
+    <string name="feature_apply_savings_label_applicant_name">अर्जदाराचे नाव</string>
+    <string name="feature_apply_savings_label_savings_product">उत्पादनाचे नाव</string>
+    <string name="feature_apply_savings_label_field_officer">फील्ड ऑफिसर</string>
+    <string name="feature_apply_savings_label_submission_date">सादर करण्याची तारीख</string>
+    <string name="feature_apply_savings_label_fill_application_details">अर्ज तपशील भरा</string>
+    <string name="feature_apply_savings_label_details">तपशील</string>
+    <string name="feature_apply_savings_label_currency">चलन</string>
+    <string name="feature_apply_savings_label_minimum_opening_balance">किमान सुरुवातीची शिल्लक</string>
+    <string name="feature_apply_savings_label_lock_in_period">लॉक-इन कालावधी</string>
+    <string name="feature_apply_savings_label_frequency">वारंवारता (Frequency)</string>
+    <string name="feature_apply_savings_label_frequency_type">वारंवारता प्रकार</string>
+    <string name="feature_apply_savings_label_overdraft">ओव्हरड्राफ्ट</string>
+    <string name="feature_apply_savings_label_request_to_allow_overdraft">ओव्हरड्राफ्टला परवानगी देण्यासाठी विनंती</string>
+
+    <string name="feature_apply_savings_button_continue">पुढे चालू ठेवा</string>
+    <string name="feature_apply_savings_button_ok">ठीक आहे</string>
+    <string name="feature_apply_savings_button_cancel">रद्द करा</string>
+    <string name="feature_apply_savings_button_apply">बचत अर्ज करा</string>
+    <string name="feature_button_next">पुढील</string>
+
+    <string name="feature_apply_savings_error_amount_empty">मूळ रक्कम आवश्यक आहे</string>
+    <string name="feature_apply_savings_error_amount_invalid_format">कृपया वैध रक्कम स्वरूप प्रविष्ट करा</string>
+    <string name="feature_apply_savings_error_amount_too_small">मूळ रक्कम खूप लहान आहे</string>
+    <string name="feature_apply_savings_error_amount_too_large">मूळ रक्कम कमाल मर्यादेपेक्षा जास्त आहे</string>
+    <string name="feature_apply_savings_error_amount_invalid_decimal">निवडलेल्या चलनासाठी रक्कमेमध्ये खूप जास्त दशांश स्थाने आहेत</string>
+
+
+    <string name="feature_apply_savings_error_product_empty">बचत उत्पादन आवश्यक आहे</string>
+
+    <string name="feature_apply_savings_error_server">आमच्या बाजूने सर्व्हर समस्या असल्याने पुढे जाऊ शकत नाही, थोड्या वेळाने पुन्हा प्रयत्न करा</string>
+    <string name="feature_apply_savings_error_too_many_attempts">खूप अयशस्वी प्रयत्न. कृपया नंतर पुन्हा प्रयत्न करा.</string>
+    <string name="feature_apply_savings_error_submit_failed">बचत अर्ज सादर करण्यात अयशस्वी. कृपया पुन्हा प्रयत्न करा.</string>
+
+    <string name="feature_apply_savings_success_submit">बचत अर्ज यशस्वीरित्या सादर केला!</string>
+    <string name="feature_apply_savings_success_draft_saved">अर्ज मसुदा यशस्वीरित्या जतन केला</string>
+
+    <string name="feature_apply_savings_unsaved_changes_title">जतन न केलेले बदल!</string>
+    <string name="feature_apply_savings_unsaved_changes_message">तुमच्याकडे जतन न केलेले बदल आहेत. तुम्हाला खात्री आहे की तुम्हाला परत जायचे आहे?</string>
+
+
+    <string name="feature_apply_savings_label_next">पुढील</string>
+
+    <string name="feature_apply_savings_error_currency_required">चलन आवश्यक आहे</string>
+    <string name="feature_apply_savings_error_minimum_opening_balance_required">किमान सुरुवातीची शिल्लक आवश्यक आहे</string>
+    <string name="feature_apply_savings_error_lock_in_period_required">लॉक-इन कालावधी आवश्यक आहे</string>
+    <string name="feature_apply_savings_error_frequency_required">वारंवारता आवश्यक आहे</string>
+    <string name="feature_apply_savings_error_frequency_invalid">एक वैध वारंवारता प्रविष्ट करा</string>
+
+    <string name="feature_apply_savings_status_success">यशस्वीरित्या अर्ज केला!</string>
+    <string name="feature_apply_savings_status_success_tip">तुम्ही %1$s अंतर्गत बचत खात्यासाठी यशस्वीरित्या अर्ज केला आहे.</string>
+    <string name="feature_apply_savings_status_success_action">मुख्य पृष्ठावर परत जा</string>
+
+    <string name="feature_apply_savings_status_failure">अर्ज सादर करण्यात अयशस्वी</string>
+    <string name="feature_apply_savings_status_failure_tip">%1$s अंतर्गत बचत खात्यासाठी अर्ज करण्यात अयशस्वी.</string>
+    <string name="feature_apply_savings_status_failure_action">पुन्हा प्रयत्न करा</string>
+
+</resources>

--- a/feature/savings-application/src/commonMain/composeResources/values-ms/strings.xml
+++ b/feature/savings-application/src/commonMain/composeResources/values-ms/strings.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_apply_savings_title">Butiran Permohonan Simpanan</string>
+
+    <string name="feature_apply_savings_section_fill_details">Isi Butiran Permohonan</string>
+
+    <string name="feature_apply_savings_label_applicant_name">Nama Pemohon</string>
+    <string name="feature_apply_savings_label_savings_product">Nama Produk</string>
+    <string name="feature_apply_savings_label_field_officer">Pegawai Lapangan</string>
+    <string name="feature_apply_savings_label_submission_date">Tarikh Penyerahan</string>
+    <string name="feature_apply_savings_label_fill_application_details">Isi Butiran Permohonan</string>
+    <string name="feature_apply_savings_label_details">Butiran</string>
+    <string name="feature_apply_savings_label_currency">Mata Wang</string>
+    <string name="feature_apply_savings_label_minimum_opening_balance">Baki Permulaan Minimum</string>
+    <string name="feature_apply_savings_label_lock_in_period">Tempoh Terkunci (Lock-in)</string>
+    <string name="feature_apply_savings_label_frequency">Kekerapan</string>
+    <string name="feature_apply_savings_label_frequency_type">Jenis Kekerapan</string>
+    <string name="feature_apply_savings_label_overdraft">Overdraf</string>
+    <string name="feature_apply_savings_label_request_to_allow_overdraft">Permintaan untuk membenarkan overdraf</string>
+
+    <string name="feature_apply_savings_button_continue">Teruskan</string>
+    <string name="feature_apply_savings_button_ok">Ok</string>
+    <string name="feature_apply_savings_button_cancel">Batal</string>
+    <string name="feature_apply_savings_button_apply">Mohon Simpanan</string>
+    <string name="feature_button_next">Seterusnya</string>
+
+    <string name="feature_apply_savings_error_amount_empty">Jumlah pokok diperlukan</string>
+    <string name="feature_apply_savings_error_amount_invalid_format">Sila masukkan format jumlah yang sah</string>
+    <string name="feature_apply_savings_error_amount_too_small">Jumlah pokok terlalu kecil</string>
+    <string name="feature_apply_savings_error_amount_too_large">Jumlah pokok melebihi had maksimum</string>
+    <string name="feature_apply_savings_error_amount_invalid_decimal">Jumlah mempunyai terlalu banyak tempat perpuluhan untuk mata wang yang dipilih</string>
+
+
+    <string name="feature_apply_savings_error_product_empty">Produk simpanan diperlukan</string>
+
+    <string name="feature_apply_savings_error_server">Masalah pelayan dari pihak kami, tidak dapat meneruskan. Cuba lagi sebentar lagi</string>
+    <string name="feature_apply_savings_error_too_many_attempts">Terlalu banyak percubaan gagal. Sila cuba lagi kemudian.</string>
+    <string name="feature_apply_savings_error_submit_failed">Gagal menyerahkan permohonan simpanan. Sila cuba lagi.</string>
+
+    <string name="feature_apply_savings_success_submit">Permohonan simpanan berjaya diserahkan!</string>
+    <string name="feature_apply_savings_success_draft_saved">Draf permohonan berjaya disimpan</string>
+
+    <string name="feature_apply_savings_unsaved_changes_title">Perubahan Tidak Disimpan!</string>
+    <string name="feature_apply_savings_unsaved_changes_message">Anda mempunyai perubahan yang tidak disimpan. Adakah anda pasti mahu kembali?</string>
+
+
+    <string name="feature_apply_savings_label_next">Seterusnya</string>
+
+    <string name="feature_apply_savings_error_currency_required">Mata wang diperlukan</string>
+    <string name="feature_apply_savings_error_minimum_opening_balance_required">Baki permulaan minimum diperlukan</string>
+    <string name="feature_apply_savings_error_lock_in_period_required">Tempoh terkunci diperlukan</string>
+    <string name="feature_apply_savings_error_frequency_required">Kekerapan diperlukan</string>
+    <string name="feature_apply_savings_error_frequency_invalid">Masukkan kekerapan yang sah</string>
+
+    <string name="feature_apply_savings_status_success">Berjaya Memohon!</string>
+    <string name="feature_apply_savings_status_success_tip">Anda telah berjaya memohon akaun simpanan di bawah %1$s.</string>
+    <string name="feature_apply_savings_status_success_action">Kembali Ke Laman Utama</string>
+
+    <string name="feature_apply_savings_status_failure">Permohonan Gagal Diserahkan</string>
+    <string name="feature_apply_savings_status_failure_tip">Gagal memohon akaun simpanan di bawah %1$s.</string>
+    <string name="feature_apply_savings_status_failure_action">Cuba Lagi</string>
+
+</resources>

--- a/feature/savings-application/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/savings-application/src/commonMain/composeResources/values-pt/strings.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_apply_savings_title">Detalhes da Aplicação de Poupança</string>
+
+    <string name="feature_apply_savings_section_fill_details">Preencher Detalhes da Aplicação</string>
+
+    <string name="feature_apply_savings_label_applicant_name">Nome do Requerente</string>
+    <string name="feature_apply_savings_label_savings_product">Nome do Produto</string>
+    <string name="feature_apply_savings_label_field_officer">Agente de Campo</string>
+    <string name="feature_apply_savings_label_submission_date">Data de Submissão</string>
+    <string name="feature_apply_savings_label_fill_application_details">Preencher Detalhes da Aplicação</string>
+    <string name="feature_apply_savings_label_details">Detalhes</string>
+    <string name="feature_apply_savings_label_currency">Moeda</string>
+    <string name="feature_apply_savings_label_minimum_opening_balance">Saldo Mínimo de Abertura</string>
+    <string name="feature_apply_savings_label_lock_in_period">Período de Carência</string>
+    <string name="feature_apply_savings_label_frequency">Frequência</string>
+    <string name="feature_apply_savings_label_frequency_type">Tipo de Frequência</string>
+    <string name="feature_apply_savings_label_overdraft">Descoberto</string>
+    <string name="feature_apply_savings_label_request_to_allow_overdraft">Pedido para permitir descoberto</string>
+
+    <string name="feature_apply_savings_button_continue">Continuar</string>
+    <string name="feature_apply_savings_button_ok">Ok</string>
+    <string name="feature_apply_savings_button_cancel">Cancelar</string>
+    <string name="feature_apply_savings_button_apply">Aplicar Poupança</string>
+    <string name="feature_button_next">Seguinte</string>
+
+    <string name="feature_apply_savings_error_amount_empty">O montante principal é obrigatório</string>
+    <string name="feature_apply_savings_error_amount_invalid_format">Por favor, introduza um formato de montante válido</string>
+    <string name="feature_apply_savings_error_amount_too_small">O montante principal é demasiado pequeno</string>
+    <string name="feature_apply_savings_error_amount_too_large">O montante principal excede o limite máximo</string>
+    <string name="feature_apply_savings_error_amount_invalid_decimal">O montante tem demasiadas casas decimais para a moeda selecionada</string>
+
+
+    <string name="feature_apply_savings_error_product_empty">O produto de poupança é obrigatório</string>
+
+    <string name="feature_apply_savings_error_server">Problema no servidor, não é possível prosseguir. Tente novamente mais tarde.</string>
+    <string name="feature_apply_savings_error_too_many_attempts">Demasiadas tentativas falhadas. Por favor, tente novamente mais tarde.</string>
+    <string name="feature_apply_savings_error_submit_failed">Falha ao submeter o pedido de poupança. Por favor, tente novamente.</string>
+
+    <string name="feature_apply_savings_success_submit">Pedido de poupança submetido com sucesso!</string>
+    <string name="feature_apply_savings_success_draft_saved">Rascunho da aplicação guardado com sucesso</string>
+
+    <string name="feature_apply_savings_unsaved_changes_title">Alterações não guardadas!</string>
+    <string name="feature_apply_savings_unsaved_changes_message">Tem alterações não guardadas. Tem a certeza que pretende voltar?</string>
+
+
+    <string name="feature_apply_savings_label_next">Seguinte</string>
+
+    <string name="feature_apply_savings_error_currency_required">A moeda é obrigatória</string>
+    <string name="feature_apply_savings_error_minimum_opening_balance_required">O saldo mínimo de abertura é obrigatório</string>
+    <string name="feature_apply_savings_error_lock_in_period_required">O período de carência é obrigatório</string>
+    <string name="feature_apply_savings_error_frequency_required">A frequência é obrigatória</string>
+    <string name="feature_apply_savings_error_frequency_invalid">Introduza uma frequência válida</string>
+
+    <string name="feature_apply_savings_status_success">Subscrição Bem-sucedida!</string>
+    <string name="feature_apply_savings_status_success_tip">Subscreveu com sucesso uma conta poupança em %1$s.</string>
+    <string name="feature_apply_savings_status_success_action">Voltar ao Início</string>
+
+    <string name="feature_apply_savings_status_failure">Falha ao Submeter o Pedido</string>
+    <string name="feature_apply_savings_status_failure_tip">Falha ao subscrever a conta poupança em %1$s.</string>
+    <string name="feature_apply_savings_status_failure_action">Tentar Novamente</string>
+
+</resources>

--- a/feature/savings-application/src/commonMain/composeResources/values-si/strings.xml
+++ b/feature/savings-application/src/commonMain/composeResources/values-si/strings.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_apply_savings_title">ඉතුරුම් අයදුම්පත් විස්තර</string>
+
+    <string name="feature_apply_savings_section_fill_details">අයදුම්පත් විස්තර පුරවන්න</string>
+
+    <string name="feature_apply_savings_label_applicant_name">අයදුම්කරුගේ නම</string>
+    <string name="feature_apply_savings_label_savings_product">නිෂ්පාදනයේ නම</string>
+    <string name="feature_apply_savings_label_field_officer">ක්ෂේත්‍ර නිලධාරි</string>
+    <string name="feature_apply_savings_label_submission_date">ඉදිරිපත් කළ දිනය</string>
+    <string name="feature_apply_savings_label_fill_application_details">අයදුම්පත් විස්තර පුරවන්න</string>
+    <string name="feature_apply_savings_label_details">විස්තර</string>
+    <string name="feature_apply_savings_label_currency">මුදල් වර්ගය</string>
+    <string name="feature_apply_savings_label_minimum_opening_balance">අවම ආරම්භක ශේෂය</string>
+    <string name="feature_apply_savings_label_lock_in_period">අගුලු දැමීමේ කාලය (Lock-in Period)</string>
+    <string name="feature_apply_savings_label_frequency">සංඛ්‍යාතය (Frequency)</string>
+    <string name="feature_apply_savings_label_frequency_type">සංඛ්‍යාත වර්ගය</string>
+    <string name="feature_apply_savings_label_overdraft">අයිරා (Overdraft)</string>
+    <string name="feature_apply_savings_label_request_to_allow_overdraft">අයිරා ලබා ගැනීමට ඉල්ලීම</string>
+
+    <string name="feature_apply_savings_button_continue">ඉදිරියට යන්න</string>
+    <string name="feature_apply_savings_button_ok">හරි</string>
+    <string name="feature_apply_savings_button_cancel">අවලංගු කරන්න</string>
+    <string name="feature_apply_savings_button_apply">ඉතුරුම් සඳහා අයදුම් කරන්න</string>
+    <string name="feature_button_next">ඊළඟ</string>
+
+    <string name="feature_apply_savings_error_amount_empty">මූලික මුදල අවශ්‍යයි</string>
+    <string name="feature_apply_savings_error_amount_invalid_format">කරුණාකර වලංගු මුදල් ආකෘතියක් ඇතුළත් කරන්න</string>
+    <string name="feature_apply_savings_error_amount_too_small">මූලික මුදල ඉතා කුඩාය</string>
+    <string name="feature_apply_savings_error_amount_too_large">මූලික මුදල උපරිම සීමාව ඉක්මවයි</string>
+    <string name="feature_apply_savings_error_amount_invalid_decimal">තෝරාගත් මුදල් වර්ගය සඳහා දශම ස්ථාන වැඩිය</string>
+
+
+    <string name="feature_apply_savings_error_product_empty">ඉතුරුම් නිෂ්පාදනය අවශ්‍යයි</string>
+
+    <string name="feature_apply_savings_error_server">අපගේ පාර්ශවයෙන් සේවාදායක දෝෂයක් ඇත, ඉදිරියට යා නොහැක, මොහොතකින් නැවත උත්සාහ කරන්න</string>
+    <string name="feature_apply_savings_error_too_many_attempts">අසාර්ථක උත්සාහයන් වැඩියි. කරුණාකර පසුව නැවත උත්සාහ කරන්න.</string>
+    <string name="feature_apply_savings_error_submit_failed">ඉතුරුම් අයදුම්පත ඉදිරිපත් කිරීමට අපහසු විය. කරුණාකර නැවත උත්සාහ කරන්න.</string>
+
+    <string name="feature_apply_savings_success_submit">ඉතුරුම් අයදුම්පත සාර්ථකව ඉදිරිපත් කරන ලදී!</string>
+    <string name="feature_apply_savings_success_draft_saved">අයදුම්පත් කෙටුම්පත සාර්ථකව සුරැකිණි</string>
+
+    <string name="feature_apply_savings_unsaved_changes_title">සුරැක නොමැති වෙනස්කම්!</string>
+    <string name="feature_apply_savings_unsaved_changes_message">ඔබ සතුව සුරැක නොමැති වෙනස්කම් ඇත. ඔබට ආපසු යාමට අවශ්‍ය බව විශ්වාසද?</string>
+
+
+    <string name="feature_apply_savings_label_next">ඊළඟ</string>
+
+    <string name="feature_apply_savings_error_currency_required">මුදල් වර්ගය අවශ්‍යයි</string>
+    <string name="feature_apply_savings_error_minimum_opening_balance_required">අවම ආරම්භක ශේෂය අවශ්‍යයි</string>
+    <string name="feature_apply_savings_error_lock_in_period_required">අගුලු දැමීමේ කාලය අවශ්‍යයි</string>
+    <string name="feature_apply_savings_error_frequency_required">සංඛ්‍යාතය අවශ්‍යයි</string>
+    <string name="feature_apply_savings_error_frequency_invalid">වලංගු සංඛ්‍යාතයක් ඇතුළත් කරන්න</string>
+
+    <string name="feature_apply_savings_status_success">අයදුම් කිරීම සාර්ථකයි!</string>
+    <string name="feature_apply_savings_status_success_tip">ඔබ %1$s යටතේ ඉතුරුම් ගිණුමක් සඳහා සාර්ථකව අයදුම් කර ඇත.</string>
+    <string name="feature_apply_savings_status_success_action">මුල් පිටුවට</string>
+
+    <string name="feature_apply_savings_status_failure">අයදුම්පත ඉදිරිපත් කිරීම අසාර්ථකයි</string>
+    <string name="feature_apply_savings_status_failure_tip">%1$s යටතේ ඉතුරුම් ගිණුමක් සඳහා අයදුම් කිරීම අසාර්ථකයි.</string>
+    <string name="feature_apply_savings_status_failure_action">නැවත උත්සාහ කරන්න</string>
+
+</resources>

--- a/feature/savings-application/src/commonMain/composeResources/values-sw/strings.xml
+++ b/feature/savings-application/src/commonMain/composeResources/values-sw/strings.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_apply_savings_title">Maelezo ya Maombi ya Akiba</string>
+
+    <string name="feature_apply_savings_section_fill_details">Jaza Maelezo ya Maombi</string>
+
+    <string name="feature_apply_savings_label_applicant_name">Jina la Mwombaji</string>
+    <string name="feature_apply_savings_label_savings_product">Jina la Bidhaa</string>
+    <string name="feature_apply_savings_label_field_officer">Afisa wa Nyanjani</string>
+    <string name="feature_apply_savings_label_submission_date">Tarehe ya Kuwasilisha</string>
+    <string name="feature_apply_savings_label_fill_application_details">Jaza Maelezo ya Maombi</string>
+    <string name="feature_apply_savings_label_details">Maelezo</string>
+    <string name="feature_apply_savings_label_currency">Sarafu</string>
+    <string name="feature_apply_savings_label_minimum_opening_balance">Kiwango cha Chini cha Kufungua</string>
+    <string name="feature_apply_savings_label_lock_in_period">Kipindi cha Kufunga (Lock-in)</string>
+    <string name="feature_apply_savings_label_frequency">Marudio (Frequency)</string>
+    <string name="feature_apply_savings_label_frequency_type">Aina ya Marudio</string>
+    <string name="feature_apply_savings_label_overdraft">Ovadrafti</string>
+    <string name="feature_apply_savings_label_request_to_allow_overdraft">Ombi la kuruhusu ovadrafti</string>
+
+    <string name="feature_apply_savings_button_continue">Endelea</string>
+    <string name="feature_apply_savings_button_ok">Sawa</string>
+    <string name="feature_apply_savings_button_cancel">Ghairi</string>
+    <string name="feature_apply_savings_button_apply">Omba Akiba</string>
+    <string name="feature_button_next">Endelea</string>
+
+    <string name="feature_apply_savings_error_amount_empty">Kiasi kikuu kinahitajika</string>
+    <string name="feature_apply_savings_error_amount_invalid_format">Tafadhali ingiza muundo sahihi wa kiasi</string>
+    <string name="feature_apply_savings_error_amount_too_small">Kiasi kikuu ni kidogo sana</string>
+    <string name="feature_apply_savings_error_amount_too_large">Kiasi kikuu kinazidi kikomo cha juu</string>
+    <string name="feature_apply_savings_error_amount_invalid_decimal">Kiasi kina nafasi nyingi za desimali kwa sarafu iliyochaguliwa</string>
+
+
+    <string name="feature_apply_savings_error_product_empty">Bidhaa ya akiba inahitajika</string>
+
+    <string name="feature_apply_savings_error_server">Tatizo la seva kutoka upande wetu, haiwezi kuendelea. Jaribu tena baada ya muda</string>
+    <string name="feature_apply_savings_error_too_many_attempts">Majaribio mengi yaliyoshindikana. Tafadhali jaribu tena baadaye.</string>
+    <string name="feature_apply_savings_error_submit_failed">Imeshindwa kuwasilisha maombi ya akiba. Tafadhali jaribu tena.</string>
+
+    <string name="feature_apply_savings_success_submit">Maombi ya akiba yamewasilishwa kikamilifu!</string>
+    <string name="feature_apply_savings_success_draft_saved">Rasimu ya maombi imehifadhiwa</string>
+
+    <string name="feature_apply_savings_unsaved_changes_title">Mabadiliko Hayajahifadhiwa!</string>
+    <string name="feature_apply_savings_unsaved_changes_message">Una mabadiliko ambayo hayajahifadhiwa. Una uhakika unataka kurudi?</string>
+
+
+    <string name="feature_apply_savings_label_next">Endelea</string>
+
+    <string name="feature_apply_savings_error_currency_required">Sarafu inahitajika</string>
+    <string name="feature_apply_savings_error_minimum_opening_balance_required">Kiwango cha chini cha kufungua kinahitajika</string>
+    <string name="feature_apply_savings_error_lock_in_period_required">Kipindi cha kufunga kinahitajika</string>
+    <string name="feature_apply_savings_error_frequency_required">Marudio yanahitajika</string>
+    <string name="feature_apply_savings_error_frequency_invalid">Ingiza marudio sahihi</string>
+
+    <string name="feature_apply_savings_status_success">Imefanikiwa Kuomba!</string>
+    <string name="feature_apply_savings_status_success_tip">Umeomba akaunti ya akiba kwa mafanikio chini ya %1$s.</string>
+    <string name="feature_apply_savings_status_success_action">Rudi Nyumbani</string>
+
+    <string name="feature_apply_savings_status_failure">Imeshindwa Kuwasilisha Maombi</string>
+    <string name="feature_apply_savings_status_failure_tip">Imeshindwa kuomba akaunti ya akiba chini ya %1$s.</string>
+    <string name="feature_apply_savings_status_failure_action">Jaribu Tena</string>
+
+</resources>

--- a/feature/share-application/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/share-application/src/commonMain/composeResources/values-ar/strings.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_share_title">تفاصيل طلب الأسهم</string>
+    <string name="feature_share_navigation_back">رجوع</string>
+
+    <string name="feature_share_label_applicant_name">اسم مقدم الطلب</string>
+    <string name="feature_share_label_submission_date">تاريخ التقديم</string>
+    <string name="feature_share_label_product_name">اسم المنتج</string>
+
+    <string name="feature_share_button_next">التالي</string>
+
+    <string name="feature_apply_share_error_server">مشكلة في الخادم من جانبنا، لا يمكن المتابعة، حاول مرة أخرى بعد قليل</string>
+    <string name="feature_apply_share_error_too_many_attempts">محاولات فاشلة كثيرة جداً. يرجى المحاولة لاحقاً.</string>
+    <string name="feature_apply_share_error_submit_failed">فشل تقديم طلب حساب التوفير. يرجى المحاولة مرة أخرى.</string>
+
+    <string name="feature_apply_share_unsaved_changes_title">تغييرات غير محفوظة!</string>
+    <string name="feature_apply_share_unsaved_changes_message">لديك تغييرات غير محفوظة. هل أنت متأكد أنك تريد الرجوع؟</string>
+    <string name="feature_share_no_products_available">لا توجد منتجات أسهم متاحة للتقديم عليها</string>
+
+
+    <string name="feature_apply_share_label_terms">الشروط</string>
+    <string name="feature_apply_share_label_currency">العملة</string>
+    <string name="feature_apply_share_label_current_price">السعر الحالي</string>
+    <string name="feature_apply_share_label_total_number_of_shares">إجمالي عدد الأسهم</string>
+    <string name="feature_apply_share_label_default_savings_account">حساب التوفير الافتراضي</string>
+
+    <string name="feature_apply_share_label_minimum_active_period">الحد الأدنى للفترة النشطة</string>
+    <string name="feature_apply_share_section_minimum_active_period">الحد الأدنى للفترة النشطة</string>
+    <string name="feature_apply_share_label_minimum_frequency">التكرار</string>
+    <string name="feature_apply_share_label_minimum_frequency_type">نوع التكرار</string>
+
+    <string name="feature_apply_share_label_lockin_period">فترة الحظر</string>
+    <string name="feature_apply_share_section_lockin_period">فترة الحظر</string>
+    <string name="feature_apply_share_label_lockin_frequency">التكرار</string>
+    <string name="feature_apply_share_label_lockin_frequency_type">نوع التكرار</string>
+
+    <string name="feature_apply_share_error_frequency_required">التكرار مطلوب</string>
+    <string name="feature_apply_share_frequency_invalid">يرجى إدخال تكرار صحيح</string>
+
+    <string name="feature_apply_share_error_shares_required">الأسهم مطلوبة</string>
+    <string name="feature_apply_share_shares_invalid">يرجى إدخال أسهم صحيحة</string>
+
+    <string name="feature_apply_share_error_price_required">السعر مطلوب</string>
+    <string name="feature_apply_share_price_invalid">يرجى إدخال سعر صحيح</string>
+
+    <string name="feature_apply_share_status_failure">فشل تقديم الطلب</string>
+    <string name="feature_apply_share_status_failure_tip">فشل التقديم على حساب أسهم تحت %1$s</string>
+    <string name="feature_apply_share_status_failure_action">حاول مرة أخرى</string>
+
+    <string name="feature_apply_share_status_success">تم التقديم بنجاح!</string>
+    <string name="feature_apply_share_status_success_tip">لقد قمت بالتقديم بنجاح على حساب أسهم تحت %1$s</string>
+    <string name="feature_apply_share_status_success_action">العودة للرئيسية</string>
+</resources>

--- a/feature/share-application/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/share-application/src/commonMain/composeResources/values-de/strings.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_share_title">Details zum Aktienantrag</string>
+    <string name="feature_share_navigation_back">Zurück</string>
+
+    <string name="feature_share_label_applicant_name">Name des Antragstellers</string>
+    <string name="feature_share_label_submission_date">Einreichungsdatum</string>
+    <string name="feature_share_label_product_name">Produktname</string>
+
+    <string name="feature_share_button_next">Weiter</string>
+
+    <string name="feature_apply_share_error_server">Serverproblem auf unserer Seite, Vorgang kann nicht fortgesetzt werden. Bitte versuchen Sie es später erneut.</string>
+    <string name="feature_apply_share_error_too_many_attempts">Zu viele fehlgeschlagene Versuche. Bitte versuchen Sie es später erneut.</string>
+    <string name="feature_apply_share_error_submit_failed">Antrag auf Sparkonto fehlgeschlagen. Bitte versuchen Sie es erneut.</string>
+
+    <string name="feature_apply_share_unsaved_changes_title">Ungespeicherte Änderungen!</string>
+    <string name="feature_apply_share_unsaved_changes_message">Sie haben ungespeicherte Änderungen. Sind Sie sicher, dass Sie zurückgehen möchten?</string>
+    <string name="feature_share_no_products_available">Keine Aktienprodukte für die Beantragung eines Aktienkontos verfügbar</string>
+
+
+    <string name="feature_apply_share_label_terms">Bedingungen</string>
+    <string name="feature_apply_share_label_currency">Währung</string>
+    <string name="feature_apply_share_label_current_price">Aktueller Preis</string>
+    <string name="feature_apply_share_label_total_number_of_shares">Gesamtanzahl der Aktien</string>
+    <string name="feature_apply_share_label_default_savings_account">Standard-Sparkonto</string>
+
+    <string name="feature_apply_share_label_minimum_active_period">Mindestlaufzeit</string>
+    <string name="feature_apply_share_section_minimum_active_period">Mindestlaufzeit</string>
+    <string name="feature_apply_share_label_minimum_frequency">Frequenz</string>
+    <string name="feature_apply_share_label_minimum_frequency_type">Frequenztyp</string>
+
+    <string name="feature_apply_share_label_lockin_period">Sperrfrist</string>
+    <string name="feature_apply_share_section_lockin_period">Sperrfrist</string>
+    <string name="feature_apply_share_label_lockin_frequency">Frequenz</string>
+    <string name="feature_apply_share_label_lockin_frequency_type">Frequenztyp</string>
+
+    <string name="feature_apply_share_error_frequency_required">Frequenz ist erforderlich</string>
+    <string name="feature_apply_share_frequency_invalid">Bitte geben Sie eine gültige Frequenz ein</string>
+
+    <string name="feature_apply_share_error_shares_required">Aktien sind erforderlich</string>
+    <string name="feature_apply_share_shares_invalid">Bitte geben Sie gültige Aktien ein</string>
+
+    <string name="feature_apply_share_error_price_required">Preis ist erforderlich</string>
+    <string name="feature_apply_share_price_invalid">Bitte geben Sie einen gültigen Preis ein</string>
+
+    <string name="feature_apply_share_status_failure">Antrag konnte nicht gesendet werden</string>
+    <string name="feature_apply_share_status_failure_tip">Antrag auf ein Aktienkonto unter %1$s fehlgeschlagen</string>
+    <string name="feature_apply_share_status_failure_action">Erneut versuchen</string>
+
+    <string name="feature_apply_share_status_success">Erfolgreich beantragt!</string>
+    <string name="feature_apply_share_status_success_tip">Sie haben erfolgreich ein Aktienkonto unter %1$s beantragt</string>
+    <string name="feature_apply_share_status_success_action">Zurück zur Startseite</string>
+</resources>

--- a/feature/share-application/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/share-application/src/commonMain/composeResources/values-fr/strings.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_share_title">Détails de la demande de parts</string>
+    <string name="feature_share_navigation_back">Retour</string>
+
+    <string name="feature_share_label_applicant_name">Nom du demandeur</string>
+    <string name="feature_share_label_submission_date">Date de soumission</string>
+    <string name="feature_share_label_product_name">Nom du produit</string>
+
+    <string name="feature_share_button_next">Suivant</string>
+
+    <string name="feature_apply_share_error_server">Problème de serveur de notre côté, impossible de continuer. Réessayez dans un moment.</string>
+    <string name="feature_apply_share_error_too_many_attempts">Trop de tentatives échouées. Veuillez réessayer plus tard.</string>
+    <string name="feature_apply_share_error_submit_failed">Échec de la soumission de la demande d\'épargne. Veuillez réessayer.</string>
+
+    <string name="feature_apply_share_unsaved_changes_title">Modifications non enregistrées !</string>
+    <string name="feature_apply_share_unsaved_changes_message">Vous avez des modifications non enregistrées. Êtes-vous sûr de vouloir revenir en arrière ?</string>
+    <string name="feature_share_no_products_available">Aucun produit de parts sociales disponible pour la demande</string>
+
+
+    <string name="feature_apply_share_label_terms">Conditions</string>
+    <string name="feature_apply_share_label_currency">Devise</string>
+    <string name="feature_apply_share_label_current_price">Prix actuel</string>
+    <string name="feature_apply_share_label_total_number_of_shares">Nombre total de parts</string>
+    <string name="feature_apply_share_label_default_savings_account">Compte d\'épargne par défaut</string>
+
+    <string name="feature_apply_share_label_minimum_active_period">Période active minimale</string>
+    <string name="feature_apply_share_section_minimum_active_period">Période active minimale</string>
+    <string name="feature_apply_share_label_minimum_frequency">Fréquence</string>
+    <string name="feature_apply_share_label_minimum_frequency_type">Type de fréquence</string>
+
+    <string name="feature_apply_share_label_lockin_period">Période de blocage</string>
+    <string name="feature_apply_share_section_lockin_period">Période de blocage</string>
+    <string name="feature_apply_share_label_lockin_frequency">Fréquence</string>
+    <string name="feature_apply_share_label_lockin_frequency_type">Type de fréquence</string>
+
+    <string name="feature_apply_share_error_frequency_required">La fréquence est requise</string>
+    <string name="feature_apply_share_frequency_invalid">Veuillez entrer une fréquence valide</string>
+
+    <string name="feature_apply_share_error_shares_required">Les parts sont requises</string>
+    <string name="feature_apply_share_shares_invalid">Veuillez entrer des parts valides</string>
+
+    <string name="feature_apply_share_error_price_required">Le prix est requis</string>
+    <string name="feature_apply_share_price_invalid">Veuillez entrer un prix valide</string>
+
+    <string name="feature_apply_share_status_failure">Échec de la soumission de la demande</string>
+    <string name="feature_apply_share_status_failure_tip">Échec de la demande de compte de parts sous %1$s</string>
+    <string name="feature_apply_share_status_failure_action">Réessayer</string>
+
+    <string name="feature_apply_share_status_success">Demande réussie !</string>
+    <string name="feature_apply_share_status_success_tip">Vous avez demandé avec succès un compte de parts sous %1$s</string>
+    <string name="feature_apply_share_status_success_action">Retour à l\'accueil</string>
+</resources>

--- a/feature/share-application/src/commonMain/composeResources/values-gu/strings.xml
+++ b/feature/share-application/src/commonMain/composeResources/values-gu/strings.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_share_title">શેર એપ્લિકેશન વિગતો</string>
+    <string name="feature_share_navigation_back">પાછા</string>
+
+    <string name="feature_share_label_applicant_name">અરજદારનું નામ</string>
+    <string name="feature_share_label_submission_date">સબમિશન તારીખ</string>
+    <string name="feature_share_label_product_name">પ્રોડક્ટનું નામ</string>
+
+    <string name="feature_share_button_next">આગળ</string>
+
+    <string name="feature_apply_share_error_server">અમારી બાજુથી સર્વર સમસ્યા હોવાથી આગળ વધી શકાતું નથી, થોડીવાર પછી ફરી પ્રયાસ કરો</string>
+    <string name="feature_apply_share_error_too_many_attempts">ઘણા બધા નિષ્ફળ પ્રયાસો. કૃપા કરીને પછીથી ફરી પ્રયાસ કરો.</string>
+    <string name="feature_apply_share_error_submit_failed">બચત એપ્લિકેશન સબમિટ કરવામાં નિષ્ફળ. કૃપા કરીને ફરી પ્રયાસ કરો.</string>
+
+    <string name="feature_apply_share_unsaved_changes_title">સાચવ્યા વગરના ફેરફારો!</string>
+    <string name="feature_apply_share_unsaved_changes_message">તમારી પાસે સાચવ્યા વગરના ફેરફારો છે. શું તમે ખરેખર પાછા જવા માંગો છો?</string>
+    <string name="feature_share_no_products_available">શેર ખાતું ખોલવા માટે કોઈ શેર પ્રોડક્ટ્સ ઉપલબ્ધ નથી</string>
+
+
+    <string name="feature_apply_share_label_terms">શરતો</string>
+    <string name="feature_apply_share_label_currency">ચલણ</string>
+    <string name="feature_apply_share_label_current_price">વર્તમાન કિંમત</string>
+    <string name="feature_apply_share_label_total_number_of_shares">શેરની કુલ સંખ્યા</string>
+    <string name="feature_apply_share_label_default_savings_account">ડિફોલ્ટ બચત ખાતું</string>
+
+    <string name="feature_apply_share_label_minimum_active_period">ન્યૂનતમ સક્રિય સમયગાળો</string>
+    <string name="feature_apply_share_section_minimum_active_period">ન્યૂનતમ સક્રિય સમયગાળો</string>
+    <string name="feature_apply_share_label_minimum_frequency">આવર્તન (Frequency)</string>
+    <string name="feature_apply_share_label_minimum_frequency_type">આવર્તન પ્રકાર</string>
+
+    <string name="feature_apply_share_label_lockin_period">લોક-ઇન સમયગાળો</string>
+    <string name="feature_apply_share_section_lockin_period">લોક-ઇન સમયગાળો</string>
+    <string name="feature_apply_share_label_lockin_frequency">આવર્તન (Frequency)</string>
+    <string name="feature_apply_share_label_lockin_frequency_type">આવર્તન પ્રકાર</string>
+
+    <string name="feature_apply_share_error_frequency_required">આવર્તન જરૂરી છે</string>
+    <string name="feature_apply_share_frequency_invalid">કૃપા કરીને માન્ય આવર્તન દાખલ કરો</string>
+
+    <string name="feature_apply_share_error_shares_required">શેર જરૂરી છે</string>
+    <string name="feature_apply_share_shares_invalid">કૃપા કરીને માન્ય શેર દાખલ કરો</string>
+
+    <string name="feature_apply_share_error_price_required">કિંમત જરૂરી છે</string>
+    <string name="feature_apply_share_price_invalid">કૃપા કરીને માન્ય કિંમત દાખલ કરો</string>
+
+    <string name="feature_apply_share_status_failure">એપ્લિકેશન સબમિટ કરવામાં નિષ્ફળ</string>
+    <string name="feature_apply_share_status_failure_tip">%1$s હેઠળ શેર ખાતા માટે અરજી કરવામાં નિષ્ફળ</string>
+    <string name="feature_apply_share_status_failure_action">ફરી પ્રયાસ કરો</string>
+
+    <string name="feature_apply_share_status_success">સફળતાપૂર્વક અરજી કરી!</string>
+    <string name="feature_apply_share_status_success_tip">તમે %1$s હેઠળ શેર ખાતા માટે સફળતાપૂર્વક અરજી કરી છે</string>
+    <string name="feature_apply_share_status_success_action">હોમ પર પાછા જાઓ</string>
+</resources>

--- a/feature/share-application/src/commonMain/composeResources/values-hi/strings.xml
+++ b/feature/share-application/src/commonMain/composeResources/values-hi/strings.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_share_title">शेयर आवेदन विवरण</string>
+    <string name="feature_share_navigation_back">वापस</string>
+
+    <string name="feature_share_label_applicant_name">आवेदक का नाम</string>
+    <string name="feature_share_label_submission_date">जमा करने की तिथि</string>
+    <string name="feature_share_label_product_name">उत्पाद का नाम</string>
+
+    <string name="feature_share_button_next">अगला</string>
+
+    <string name="feature_apply_share_error_server">हमारी ओर से सर्वर की समस्या के कारण आगे नहीं बढ़ सकते, कुछ देर बाद पुन: प्रयास करें</string>
+    <string name="feature_apply_share_error_too_many_attempts">बहुत सारे विफल प्रयास। कृपया बाद में पुन: प्रयास करें।</string>
+    <string name="feature_apply_share_error_submit_failed">बचत आवेदन जमा करने में विफल। कृपया पुन: प्रयास करें।</string>
+
+    <string name="feature_apply_share_unsaved_changes_title">सहेज नहीं गए बदलाव!</string>
+    <string name="feature_apply_share_unsaved_changes_message">आपके पास असहेजे गए बदलाव हैं। क्या आप निश्चित रूप से वापस जाना चाहते हैं?</string>
+    <string name="feature_share_no_products_available">शेयर खाते के आवेदन के लिए कोई शेयर उत्पाद उपलब्ध नहीं है</string>
+
+
+    <string name="feature_apply_share_label_terms">शर्तें</string>
+    <string name="feature_apply_share_label_currency">मुद्रा</string>
+    <string name="feature_apply_share_label_current_price">वर्तमान मूल्य</string>
+    <string name="feature_apply_share_label_total_number_of_shares">शेयरों की कुल संख्या</string>
+    <string name="feature_apply_share_label_default_savings_account">डिफ़ॉल्ट बचत खाता</string>
+
+    <string name="feature_apply_share_label_minimum_active_period">न्यूनतम सक्रिय अवधि</string>
+    <string name="feature_apply_share_section_minimum_active_period">न्यूनतम सक्रिय अवधि</string>
+    <string name="feature_apply_share_label_minimum_frequency">आवृत्ति (Frequency)</string>
+    <string name="feature_apply_share_label_minimum_frequency_type">आवृत्ति प्रकार</string>
+
+    <string name="feature_apply_share_label_lockin_period">लॉक-इन अवधि</string>
+    <string name="feature_apply_share_section_lockin_period">लॉक-इन अवधि</string>
+    <string name="feature_apply_share_label_lockin_frequency">आवृत्ति</string>
+    <string name="feature_apply_share_label_lockin_frequency_type">आवृत्ति प्रकार</string>
+
+    <string name="feature_apply_share_error_frequency_required">आवृत्ति आवश्यक है</string>
+    <string name="feature_apply_share_frequency_invalid">कृपया एक मान्य आवृत्ति दर्ज करें</string>
+
+    <string name="feature_apply_share_error_shares_required">शेयर आवश्यक हैं</string>
+    <string name="feature_apply_share_shares_invalid">कृपया मान्य शेयर दर्ज करें</string>
+
+    <string name="feature_apply_share_error_price_required">मूल्य आवश्यक है</string>
+    <string name="feature_apply_share_price_invalid">कृपया एक मान्य मूल्य दर्ज करें</string>
+
+    <string name="feature_apply_share_status_failure">आवेदन जमा करने में विफल</string>
+    <string name="feature_apply_share_status_failure_tip">%1$s के तहत शेयर खाते के लिए आवेदन करने में विफल</string>
+    <string name="feature_apply_share_status_failure_action">पुन: प्रयास करें</string>
+
+    <string name="feature_apply_share_status_success">सफलतापूर्वक आवेदन किया गया!</string>
+    <string name="feature_apply_share_status_success_tip">आपने %1$s के तहत शेयर खाते के लिए सफलतापूर्वक आवेदन कर दिया है</string>
+    <string name="feature_apply_share_status_success_action">होम पर वापस जाएं</string>
+</resources>

--- a/feature/share-application/src/commonMain/composeResources/values-hu/strings.xml
+++ b/feature/share-application/src/commonMain/composeResources/values-hu/strings.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_share_title">Részjegy igénylés részletei</string>
+    <string name="feature_share_navigation_back">Vissza</string>
+
+    <string name="feature_share_label_applicant_name">Igénylő neve</string>
+    <string name="feature_share_label_submission_date">Benyújtás dátuma</string>
+    <string name="feature_share_label_product_name">Termék neve</string>
+
+    <string name="feature_share_button_next">Tovább</string>
+
+    <string name="feature_apply_share_error_server">Szerverhiba lépett fel, nem lehet folytatni. Kérjük, próbálja újra később.</string>
+    <string name="feature_apply_share_error_too_many_attempts">Túl sok sikertelen kísérlet. Kérjük, próbálja újra később.</string>
+    <string name="feature_apply_share_error_submit_failed">A megtakarítási kérelem benyújtása sikertelen. Kérjük, próbálja újra.</string>
+
+    <string name="feature_apply_share_unsaved_changes_title">Mentetlen változások!</string>
+    <string name="feature_apply_share_unsaved_changes_message">Mentetlen változtatásai vannak. Biztosan vissza akar lépni?</string>
+    <string name="feature_share_no_products_available">Nincs elérhető részjegy termék az igényléshez</string>
+
+
+    <string name="feature_apply_share_label_terms">Feltételek</string>
+    <string name="feature_apply_share_label_currency">Pénznem</string>
+    <string name="feature_apply_share_label_current_price">Aktuális ár</string>
+    <string name="feature_apply_share_label_total_number_of_shares">Részjegyek teljes száma</string>
+    <string name="feature_apply_share_label_default_savings_account">Alapértelmezett megtakarítási számla</string>
+
+    <string name="feature_apply_share_label_minimum_active_period">Minimális aktív időszak</string>
+    <string name="feature_apply_share_section_minimum_active_period">Minimális aktív időszak</string>
+    <string name="feature_apply_share_label_minimum_frequency">Gyakoriság</string>
+    <string name="feature_apply_share_label_minimum_frequency_type">Gyakoriság típusa</string>
+
+    <string name="feature_apply_share_label_lockin_period">Zárolási időszak</string>
+    <string name="feature_apply_share_section_lockin_period">Zárolási időszak</string>
+    <string name="feature_apply_share_label_lockin_frequency">Gyakoriság</string>
+    <string name="feature_apply_share_label_lockin_frequency_type">Gyakoriság típusa</string>
+
+    <string name="feature_apply_share_error_frequency_required">Gyakoriság megadása kötelező</string>
+    <string name="feature_apply_share_frequency_invalid">Kérjük, adjon meg érvényes gyakoriságot</string>
+
+    <string name="feature_apply_share_error_shares_required">Részjegyek megadása kötelező</string>
+    <string name="feature_apply_share_shares_invalid">Kérjük, adjon meg érvényes részjegyeket</string>
+
+    <string name="feature_apply_share_error_price_required">Ár megadása kötelező</string>
+    <string name="feature_apply_share_price_invalid">Kérjük, adjon meg érvényes árat</string>
+
+    <string name="feature_apply_share_status_failure">A kérelem benyújtása sikertelen</string>
+    <string name="feature_apply_share_status_failure_tip">Nem sikerült részjegy számlát igényelni a(z) %1$s alatt</string>
+    <string name="feature_apply_share_status_failure_action">Próbálja újra</string>
+
+    <string name="feature_apply_share_status_success">Sikeres igénylés!</string>
+    <string name="feature_apply_share_status_success_tip">Sikeresen igényelt részjegy számlát a(z) %1$s alatt</string>
+    <string name="feature_apply_share_status_success_action">Vissza a főoldalra</string>
+</resources>

--- a/feature/share-application/src/commonMain/composeResources/values-in/strings.xml
+++ b/feature/share-application/src/commonMain/composeResources/values-in/strings.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_share_title">Detail Aplikasi Saham</string>
+    <string name="feature_share_navigation_back">Kembali</string>
+
+    <string name="feature_share_label_applicant_name">Nama Pemohon</string>
+    <string name="feature_share_label_submission_date">Tanggal Pengajuan</string>
+    <string name="feature_share_label_product_name">Nama Produk</string>
+
+    <string name="feature_share_button_next">Lanjut</string>
+
+    <string name="feature_apply_share_error_server">Masalah server dari sisi kami, tidak dapat melanjutkan. Coba lagi sesaat lagi</string>
+    <string name="feature_apply_share_error_too_many_attempts">Terlalu banyak upaya gagal. Silakan coba lagi nanti.</string>
+    <string name="feature_apply_share_error_submit_failed">Gagal mengirimkan aplikasi tabungan. Silakan coba lagi.</string>
+
+    <string name="feature_apply_share_unsaved_changes_title">Perubahan Belum Disimpan!</string>
+    <string name="feature_apply_share_unsaved_changes_message">Anda memiliki perubahan yang belum disimpan. Apakah Anda yakin ingin kembali?</string>
+    <string name="feature_share_no_products_available">Tidak Ada Produk Saham Tersedia untuk pengajuan akun saham</string>
+
+
+    <string name="feature_apply_share_label_terms">Syarat</string>
+    <string name="feature_apply_share_label_currency">Mata Uang</string>
+    <string name="feature_apply_share_label_current_price">Harga Saat Ini</string>
+    <string name="feature_apply_share_label_total_number_of_shares">Jumlah Total Saham</string>
+    <string name="feature_apply_share_label_default_savings_account">Akun Tabungan Default</string>
+
+    <string name="feature_apply_share_label_minimum_active_period">Periode Aktif Minimum</string>
+    <string name="feature_apply_share_section_minimum_active_period">Periode Aktif Minimum</string>
+    <string name="feature_apply_share_label_minimum_frequency">Frekuensi</string>
+    <string name="feature_apply_share_label_minimum_frequency_type">Jenis Frekuensi</string>
+
+    <string name="feature_apply_share_label_lockin_period">Periode Penguncian</string>
+    <string name="feature_apply_share_section_lockin_period">Periode Penguncian</string>
+    <string name="feature_apply_share_label_lockin_frequency">Frekuensi</string>
+    <string name="feature_apply_share_label_lockin_frequency_type">Jenis Frekuensi</string>
+
+    <string name="feature_apply_share_error_frequency_required">Frekuensi diperlukan</string>
+    <string name="feature_apply_share_frequency_invalid">Silakan masukkan frekuensi yang valid</string>
+
+    <string name="feature_apply_share_error_shares_required">Saham diperlukan</string>
+    <string name="feature_apply_share_shares_invalid">Silakan masukkan saham yang valid</string>
+
+    <string name="feature_apply_share_error_price_required">Harga diperlukan</string>
+    <string name="feature_apply_share_price_invalid">Silakan masukkan harga yang valid</string>
+
+    <string name="feature_apply_share_status_failure">Aplikasi Gagal Dikirim</string>
+    <string name="feature_apply_share_status_failure_tip">Gagal mengajukan akun saham di bawah %1$s</string>
+    <string name="feature_apply_share_status_failure_action">Coba Lagi</string>
+
+    <string name="feature_apply_share_status_success">Berhasil Diajukan!</string>
+    <string name="feature_apply_share_status_success_tip">Anda telah berhasil mengajukan akun saham di bawah %1$s</string>
+    <string name="feature_apply_share_status_success_action">Kembali Ke Beranda</string>
+</resources>

--- a/feature/share-application/src/commonMain/composeResources/values-kn/strings.xml
+++ b/feature/share-application/src/commonMain/composeResources/values-kn/strings.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_share_title">ಷೇರು ಅಪ್ಲಿಕೇಶನ್ ವಿವರಗಳು</string>
+    <string name="feature_share_navigation_back">ಹಿಂದೆ</string>
+
+    <string name="feature_share_label_applicant_name">ಅರ್ಜಿದಾರರ ಹೆಸರು</string>
+    <string name="feature_share_label_submission_date">ಸಲ್ಲಿಸಿದ ದಿನಾಂಕ</string>
+    <string name="feature_share_label_product_name">ಉತ್ಪನ್ನದ ಹೆಸರು</string>
+
+    <string name="feature_share_button_next">ಮುಂದೆ</string>
+
+    <string name="feature_apply_share_error_server">ನಮ್ಮ ಕಡೆಯಿಂದ ಸರ್ವರ್ ಸಮಸ್ಯೆ ಇದೆ, ಮುಂದುವರಿಯಲು ಸಾಧ್ಯವಿಲ್ಲ, ಸ್ವಲ್ಪ ಸಮಯದ ನಂತರ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ</string>
+    <string name="feature_apply_share_error_too_many_attempts">ತುಂಬಾ ವಿಫಲ ಪ್ರಯತ್ನಗಳು. ದಯವಿಟ್ಟು ನಂತರ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.</string>
+    <string name="feature_apply_share_error_submit_failed">ಉಳಿತಾಯ ಅಪ್ಲಿಕೇಶನ್ ಸಲ್ಲಿಸಲು ವಿಫಲವಾಗಿದೆ. ದಯವಿಟ್ಟು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.</string>
+
+    <string name="feature_apply_share_unsaved_changes_title">ಉಳಿಸದ ಬದಲಾವಣೆಗಳು!</string>
+    <string name="feature_apply_share_unsaved_changes_message">ನೀವು ಉಳಿಸದ ಬದಲಾವಣೆಗಳನ್ನು ಹೊಂದಿದ್ದೀರಿ. ನೀವು ಖಂಡಿತವಾಗಿಯೂ ಹಿಂದಕ್ಕೆ ಹೋಗಲು ಬಯಸುವಿರಾ?</string>
+    <string name="feature_share_no_products_available">ಷೇರು ಖಾತೆಗೆ ಅರ್ಜಿ ಸಲ್ಲಿಸಲು ಯಾವುದೇ ಷೇರು ಉತ್ಪನ್ನಗಳು ಲಭ್ಯವಿಲ್ಲ</string>
+
+
+    <string name="feature_apply_share_label_terms">ನಿಯಮಗಳು</string>
+    <string name="feature_apply_share_label_currency">ಕರೆನ್ಸಿ</string>
+    <string name="feature_apply_share_label_current_price">ಪ್ರಸ್ತುತ ಬೆಲೆ</string>
+    <string name="feature_apply_share_label_total_number_of_shares">ಒಟ್ಟು ಷೇರುಗಳ ಸಂಖ್ಯೆ</string>
+    <string name="feature_apply_share_label_default_savings_account">ಡೀಫಾಲ್ಟ್ ಉಳಿತಾಯ ಖಾತೆ</string>
+
+    <string name="feature_apply_share_label_minimum_active_period">ಕನಿಷ್ಠ ಸಕ್ರಿಯ ಅವಧಿ</string>
+    <string name="feature_apply_share_section_minimum_active_period">ಕನಿಷ್ಠ ಸಕ್ರಿಯ ಅವಧಿ</string>
+    <string name="feature_apply_share_label_minimum_frequency">ಆವರ್ತನ (Frequency)</string>
+    <string name="feature_apply_share_label_minimum_frequency_type">ಆವರ್ತನ ಪ್ರಕಾರ</string>
+
+    <string name="feature_apply_share_label_lockin_period">ಲಾಕ್-ಇನ್ ಅವಧಿ</string>
+    <string name="feature_apply_share_section_lockin_period">ಲಾಕ್-ಇನ್ ಅವಧಿ</string>
+    <string name="feature_apply_share_label_lockin_frequency">ಆವರ್ತನ</string>
+    <string name="feature_apply_share_label_lockin_frequency_type">ಆವರ್ತನ ಪ್ರಕಾರ</string>
+
+    <string name="feature_apply_share_error_frequency_required">ಆವರ್ತನ ಅಗತ್ಯವಿದೆ</string>
+    <string name="feature_apply_share_frequency_invalid">ದಯವಿಟ್ಟು ಮಾನ್ಯವಾದ ಆವರ್ತನವನ್ನು ನಮೂದಿಸಿ</string>
+
+    <string name="feature_apply_share_error_shares_required">ಷೇರುಗಳು ಅಗತ್ಯವಿದೆ</string>
+    <string name="feature_apply_share_shares_invalid">ದಯವಿಟ್ಟು ಮಾನ್ಯವಾದ ಷೇರುಗಳನ್ನು ನಮೂದಿಸಿ</string>
+
+    <string name="feature_apply_share_error_price_required">ಬೆಲೆ ಅಗತ್ಯವಿದೆ</string>
+    <string name="feature_apply_share_price_invalid">ದಯವಿಟ್ಟು ಮಾನ್ಯವಾದ ಬೆಲೆಯನ್ನು ನಮೂದಿಸಿ</string>
+
+    <string name="feature_apply_share_status_failure">ಅಪ್ಲಿಕೇಶನ್ ಸಲ್ಲಿಸಲು ವಿಫಲವಾಗಿದೆ</string>
+    <string name="feature_apply_share_status_failure_tip">%1$s ಅಡಿಯಲ್ಲಿ ಷೇರು ಖಾತೆಗೆ ಅರ್ಜಿ ಸಲ್ಲಿಸಲು ವಿಫಲವಾಗಿದೆ</string>
+    <string name="feature_apply_share_status_failure_action">ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ</string>
+
+    <string name="feature_apply_share_status_success">ಅರ್ಜಿ ಸಲ್ಲಿಸುವಿಕೆ ಯಶಸ್ವಿಯಾಗಿದೆ!</string>
+    <string name="feature_apply_share_status_success_tip">ನೀವು %1$s ಅಡಿಯಲ್ಲಿ ಷೇರು ಖಾತೆಗೆ ಯಶಸ್ವಿಯಾಗಿ ಅರ್ಜಿ ಸಲ್ಲಿಸಿದ್ದೀರಿ</string>
+    <string name="feature_apply_share_status_success_action">ಮುಖಪುಟಕ್ಕೆ ಹಿಂತಿರುಗಿ</string>
+</resources>

--- a/feature/share-application/src/commonMain/composeResources/values-kn/strings.xml
+++ b/feature/share-application/src/commonMain/composeResources/values-kn/strings.xml
@@ -21,7 +21,7 @@
 
     <string name="feature_apply_share_error_server">ನಮ್ಮ ಕಡೆಯಿಂದ ಸರ್ವರ್ ಸಮಸ್ಯೆ ಇದೆ, ಮುಂದುವರಿಯಲು ಸಾಧ್ಯವಿಲ್ಲ, ಸ್ವಲ್ಪ ಸಮಯದ ನಂತರ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ</string>
     <string name="feature_apply_share_error_too_many_attempts">ತುಂಬಾ ವಿಫಲ ಪ್ರಯತ್ನಗಳು. ದಯವಿಟ್ಟು ನಂತರ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.</string>
-    <string name="feature_apply_share_error_submit_failed">ಉಳಿತಾಯ ಅಪ್ಲಿಕೇಶನ್ ಸಲ್ಲಿಸಲು ವಿಫಲವಾಗಿದೆ. ದಯವಿಟ್ಟು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.</string>
+    <string name="feature_apply_share_error_submit_failed">ಷೇರು ಅಪ್ಲಿಕೇಶನ್ ಸಲ್ಲಿಸಲು ವಿಫಲವಾಗಿದೆ. ದಯವಿಟ್ಟು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.</string>
 
     <string name="feature_apply_share_unsaved_changes_title">ಉಳಿಸದ ಬದಲಾವಣೆಗಳು!</string>
     <string name="feature_apply_share_unsaved_changes_message">ನೀವು ಉಳಿಸದ ಬದಲಾವಣೆಗಳನ್ನು ಹೊಂದಿದ್ದೀರಿ. ನೀವು ಖಂಡಿತವಾಗಿಯೂ ಹಿಂದಕ್ಕೆ ಹೋಗಲು ಬಯಸುವಿರಾ?</string>

--- a/feature/share-application/src/commonMain/composeResources/values-mr/strings.xml
+++ b/feature/share-application/src/commonMain/composeResources/values-mr/strings.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_share_title">शेअर अर्ज तपशील</string>
+    <string name="feature_share_navigation_back">मागे</string>
+
+    <string name="feature_share_label_applicant_name">अर्जदाराचे नाव</string>
+    <string name="feature_share_label_submission_date">सादर करण्याची तारीख</string>
+    <string name="feature_share_label_product_name">उत्पादनाचे नाव</string>
+
+    <string name="feature_share_button_next">पुढील</string>
+
+    <string name="feature_apply_share_error_server">आमच्या बाजूने सर्व्हर समस्या असल्याने पुढे जाऊ शकत नाही, थोड्या वेळाने पुन्हा प्रयत्न करा</string>
+    <string name="feature_apply_share_error_too_many_attempts">खूप अयशस्वी प्रयत्न. कृपया नंतर पुन्हा प्रयत्न करा.</string>
+    <string name="feature_apply_share_error_submit_failed">बचत अर्ज सादर करण्यात अयशस्वी. कृपया पुन्हा प्रयत्न करा.</string>
+
+    <string name="feature_apply_share_unsaved_changes_title">जतन न केलेले बदल!</string>
+    <string name="feature_apply_share_unsaved_changes_message">तुमच्याकडे जतन न केलेले बदल आहेत. तुम्हाला खात्री आहे की तुम्हाला परत जायचे आहे?</string>
+    <string name="feature_share_no_products_available">शेअर खात्यासाठी अर्ज करण्यासाठी कोणतेही शेअर उत्पादने उपलब्ध नाहीत</string>
+
+
+    <string name="feature_apply_share_label_terms">अटी</string>
+    <string name="feature_apply_share_label_currency">चलन</string>
+    <string name="feature_apply_share_label_current_price">सध्याची किंमत</string>
+    <string name="feature_apply_share_label_total_number_of_shares">एकूण शेअर्सची संख्या</string>
+    <string name="feature_apply_share_label_default_savings_account">डिफॉल्ट बचत खाते</string>
+
+    <string name="feature_apply_share_label_minimum_active_period">किमान सक्रिय कालावधी</string>
+    <string name="feature_apply_share_section_minimum_active_period">किमान सक्रिय कालावधी</string>
+    <string name="feature_apply_share_label_minimum_frequency">वारंवारता (Frequency)</string>
+    <string name="feature_apply_share_label_minimum_frequency_type">वारंवारता प्रकार</string>
+
+    <string name="feature_apply_share_label_lockin_period">लॉक-इन कालावधी</string>
+    <string name="feature_apply_share_section_lockin_period">लॉक-इन कालावधी</string>
+    <string name="feature_apply_share_label_lockin_frequency">वारंवारता</string>
+    <string name="feature_apply_share_label_lockin_frequency_type">वारंवारता प्रकार</string>
+
+    <string name="feature_apply_share_error_frequency_required">वारंवारता आवश्यक आहे</string>
+    <string name="feature_apply_share_frequency_invalid">कृपया वैध वारंवारता प्रविष्ट करा</string>
+
+    <string name="feature_apply_share_error_shares_required">शेअर्स आवश्यक आहेत</string>
+    <string name="feature_apply_share_shares_invalid">कृपया वैध शेअर्स प्रविष्ट करा</string>
+
+    <string name="feature_apply_share_error_price_required">किंमत आवश्यक आहे</string>
+    <string name="feature_apply_share_price_invalid">कृपया वैध किंमत प्रविष्ट करा</string>
+
+    <string name="feature_apply_share_status_failure">अर्ज सादर करण्यात अयशस्वी</string>
+    <string name="feature_apply_share_status_failure_tip">%1$s अंतर्गत शेअर खात्यासाठी अर्ज करण्यात अयशस्वी</string>
+    <string name="feature_apply_share_status_failure_action">पुन्हा प्रयत्न करा</string>
+
+    <string name="feature_apply_share_status_success">यशस्वीरित्या अर्ज केला!</string>
+    <string name="feature_apply_share_status_success_tip">तुम्ही %1$s अंतर्गत शेअर खात्यासाठी यशस्वीरित्या अर्ज केला आहे</string>
+    <string name="feature_apply_share_status_success_action">मुख्य पृष्ठावर परत जा</string>
+</resources>

--- a/feature/share-application/src/commonMain/composeResources/values-ms/strings.xml
+++ b/feature/share-application/src/commonMain/composeResources/values-ms/strings.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_share_title">Butiran Permohonan Saham</string>
+    <string name="feature_share_navigation_back">Kembali</string>
+
+    <string name="feature_share_label_applicant_name">Nama Pemohon</string>
+    <string name="feature_share_label_submission_date">Tarikh Penyerahan</string>
+    <string name="feature_share_label_product_name">Nama Produk</string>
+
+    <string name="feature_share_button_next">Seterusnya</string>
+
+    <string name="feature_apply_share_error_server">Masalah pelayan dari pihak kami, tidak dapat meneruskan. Cuba lagi sebentar lagi</string>
+    <string name="feature_apply_share_error_too_many_attempts">Terlalu banyak percubaan gagal. Sila cuba lagi kemudian.</string>
+    <string name="feature_apply_share_error_submit_failed">Gagal menyerahkan permohonan simpanan. Sila cuba lagi.</string>
+
+    <string name="feature_apply_share_unsaved_changes_title">Perubahan Tidak Disimpan!</string>
+    <string name="feature_apply_share_unsaved_changes_message">Anda mempunyai perubahan yang tidak disimpan. Adakah anda pasti mahu kembali?</string>
+    <string name="feature_share_no_products_available">Tiada Produk Saham Tersedia untuk memohon akaun saham</string>
+
+
+    <string name="feature_apply_share_label_terms">Terma</string>
+    <string name="feature_apply_share_label_currency">Mata Wang</string>
+    <string name="feature_apply_share_label_current_price">Harga Semasa</string>
+    <string name="feature_apply_share_label_total_number_of_shares">Jumlah Bilangan Saham</string>
+    <string name="feature_apply_share_label_default_savings_account">Akaun Simpanan Lalai</string>
+
+    <string name="feature_apply_share_label_minimum_active_period">Tempoh Aktif Minimum</string>
+    <string name="feature_apply_share_section_minimum_active_period">Tempoh Aktif Minimum</string>
+    <string name="feature_apply_share_label_minimum_frequency">Kekerapan</string>
+    <string name="feature_apply_share_label_minimum_frequency_type">Jenis Kekerapan</string>
+
+    <string name="feature_apply_share_label_lockin_period">Tempoh Terkunci (Lock-in)</string>
+    <string name="feature_apply_share_section_lockin_period">Tempoh Terkunci (Lock-in)</string>
+    <string name="feature_apply_share_label_lockin_frequency">Kekerapan</string>
+    <string name="feature_apply_share_label_lockin_frequency_type">Jenis Kekerapan</string>
+
+    <string name="feature_apply_share_error_frequency_required">Kekerapan diperlukan</string>
+    <string name="feature_apply_share_frequency_invalid">Sila masukkan kekerapan yang sah</string>
+
+    <string name="feature_apply_share_error_shares_required">Saham diperlukan</string>
+    <string name="feature_apply_share_shares_invalid">Sila masukkan saham yang sah</string>
+
+    <string name="feature_apply_share_error_price_required">Harga diperlukan</string>
+    <string name="feature_apply_share_price_invalid">Sila masukkan harga yang sah</string>
+
+    <string name="feature_apply_share_status_failure">Permohonan Gagal Diserahkan</string>
+    <string name="feature_apply_share_status_failure_tip">Gagal memohon akaun saham di bawah %1$s</string>
+    <string name="feature_apply_share_status_failure_action">Cuba Lagi</string>
+
+    <string name="feature_apply_share_status_success">Berjaya Memohon!</string>
+    <string name="feature_apply_share_status_success_tip">Anda telah berjaya memohon akaun saham di bawah %1$s</string>
+    <string name="feature_apply_share_status_success_action">Kembali Ke Laman Utama</string>
+</resources>

--- a/feature/share-application/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/share-application/src/commonMain/composeResources/values-pt/strings.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_share_title">Detalhes da Subscrição de Ações</string>
+    <string name="feature_share_navigation_back">Voltar</string>
+
+    <string name="feature_share_label_applicant_name">Nome do Requerente</string>
+    <string name="feature_share_label_submission_date">Data de Submissão</string>
+    <string name="feature_share_label_product_name">Nome do Produto</string>
+
+    <string name="feature_share_button_next">Seguinte</string>
+
+    <string name="feature_apply_share_error_server">Problema no servidor, não é possível prosseguir. Tente novamente mais tarde.</string>
+    <string name="feature_apply_share_error_too_many_attempts">Demasiadas tentativas falhadas. Por favor, tente novamente mais tarde.</string>
+    <string name="feature_apply_share_error_submit_failed">Falha ao submeter o pedido de poupança. Por favor, tente novamente.</string>
+
+    <string name="feature_apply_share_unsaved_changes_title">Alterações não guardadas!</string>
+    <string name="feature_apply_share_unsaved_changes_message">Tem alterações não guardadas. Tem a certeza que pretende voltar?</string>
+    <string name="feature_share_no_products_available">Nenhum produto de ações disponível para subscrição</string>
+
+
+    <string name="feature_apply_share_label_terms">Termos</string>
+    <string name="feature_apply_share_label_currency">Moeda</string>
+    <string name="feature_apply_share_label_current_price">Preço Atual</string>
+    <string name="feature_apply_share_label_total_number_of_shares">Número Total de Ações</string>
+    <string name="feature_apply_share_label_default_savings_account">Conta Poupança Padrão</string>
+
+    <string name="feature_apply_share_label_minimum_active_period">Período Ativo Mínimo</string>
+    <string name="feature_apply_share_section_minimum_active_period">Período Ativo Mínimo</string>
+    <string name="feature_apply_share_label_minimum_frequency">Frequência</string>
+    <string name="feature_apply_share_label_minimum_frequency_type">Tipo de Frequência</string>
+
+    <string name="feature_apply_share_label_lockin_period">Período de Carência</string>
+    <string name="feature_apply_share_section_lockin_period">Período de Carência</string>
+    <string name="feature_apply_share_label_lockin_frequency">Frequência</string>
+    <string name="feature_apply_share_label_lockin_frequency_type">Tipo de Frequência</string>
+
+    <string name="feature_apply_share_error_frequency_required">A frequência é obrigatória</string>
+    <string name="feature_apply_share_frequency_invalid">Por favor, introduza uma frequência válida</string>
+
+    <string name="feature_apply_share_error_shares_required">As ações são obrigatórias</string>
+    <string name="feature_apply_share_shares_invalid">Por favor, introduza ações válidas</string>
+
+    <string name="feature_apply_share_error_price_required">O preço é obrigatório</string>
+    <string name="feature_apply_share_price_invalid">Por favor, introduza um preço válido</string>
+
+    <string name="feature_apply_share_status_failure">Falha ao Submeter o Pedido</string>
+    <string name="feature_apply_share_status_failure_tip">Falha ao subscrever a conta de ações em %1$s</string>
+    <string name="feature_apply_share_status_failure_action">Tentar Novamente</string>
+
+    <string name="feature_apply_share_status_success">Subscrição Bem-sucedida!</string>
+    <string name="feature_apply_share_status_success_tip">Subscreveu com sucesso uma conta de ações em %1$s</string>
+    <string name="feature_apply_share_status_success_action">Voltar ao Início</string>
+</resources>

--- a/feature/share-application/src/commonMain/composeResources/values-si/strings.xml
+++ b/feature/share-application/src/commonMain/composeResources/values-si/strings.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_share_title">කොටස් අයදුම්පත් විස්තර</string>
+    <string name="feature_share_navigation_back">ආපසු</string>
+
+    <string name="feature_share_label_applicant_name">අයදුම්කරුගේ නම</string>
+    <string name="feature_share_label_submission_date">ඉදිරිපත් කළ දිනය</string>
+    <string name="feature_share_label_product_name">නිෂ්පාදනයේ නම</string>
+
+    <string name="feature_share_button_next">ඊළඟ</string>
+
+    <string name="feature_apply_share_error_server">අපගේ පාර්ශවයෙන් සේවාදායක දෝෂයක් ඇත, ඉදිරියට යා නොහැක, මොහොතකින් නැවත උත්සාහ කරන්න</string>
+    <string name="feature_apply_share_error_too_many_attempts">අසාර්ථක උත්සාහයන් වැඩියි. කරුණාකර පසුව නැවත උත්සාහ කරන්න.</string>
+    <string name="feature_apply_share_error_submit_failed">ඉතුරුම් අයදුම්පත ඉදිරිපත් කිරීමට අපහසු විය. කරුණාකර නැවත උත්සාහ කරන්න.</string>
+
+    <string name="feature_apply_share_unsaved_changes_title">සුරැක නොමැති වෙනස්කම්!</string>
+    <string name="feature_apply_share_unsaved_changes_message">ඔබ සතුව සුරැක නොමැති වෙනස්කම් ඇත. ඔබට ආපසු යාමට අවශ්‍ය බව විශ්වාසද?</string>
+    <string name="feature_share_no_products_available">කොටස් ගිණුමක් සඳහා අයදුම් කිරීමට කොටස් නිෂ්පාදන නොමැත</string>
+
+
+    <string name="feature_apply_share_label_terms">කොන්දේසි</string>
+    <string name="feature_apply_share_label_currency">මුදල් වර්ගය</string>
+    <string name="feature_apply_share_label_current_price">වත්මන් මිල</string>
+    <string name="feature_apply_share_label_total_number_of_shares">මුළු කොටස් ගණන</string>
+    <string name="feature_apply_share_label_default_savings_account">පෙරනිමි ඉතුරුම් ගිණුම</string>
+
+    <string name="feature_apply_share_label_minimum_active_period">අවම සක්‍රීය කාල සීමාව</string>
+    <string name="feature_apply_share_section_minimum_active_period">අවම සක්‍රීය කාල සීමාව</string>
+    <string name="feature_apply_share_label_minimum_frequency">සංඛ්‍යාතය (Frequency)</string>
+    <string name="feature_apply_share_label_minimum_frequency_type">සංඛ්‍යාත වර්ගය</string>
+
+    <string name="feature_apply_share_label_lockin_period">අගුලු දැමීමේ කාලය (Lock-in Period)</string>
+    <string name="feature_apply_share_section_lockin_period">අගුලු දැමීමේ කාලය</string>
+    <string name="feature_apply_share_label_lockin_frequency">සංඛ්‍යාතය</string>
+    <string name="feature_apply_share_label_lockin_frequency_type">සංඛ්‍යාත වර්ගය</string>
+
+    <string name="feature_apply_share_error_frequency_required">සංඛ්‍යාතය අවශ්‍යයි</string>
+    <string name="feature_apply_share_frequency_invalid">කරුණාකර වලංගු සංඛ්‍යාතයක් ඇතුළත් කරන්න</string>
+
+    <string name="feature_apply_share_error_shares_required">කොටස් අවශ්‍යයි</string>
+    <string name="feature_apply_share_shares_invalid">කරුණාකර වලංගු කොටස් ගණනක් ඇතුළත් කරන්න</string>
+
+    <string name="feature_apply_share_error_price_required">මිල අවශ්‍යයි</string>
+    <string name="feature_apply_share_price_invalid">කරුණාකර වලංගු මිලක් ඇතුළත් කරන්න</string>
+
+    <string name="feature_apply_share_status_failure">අයදුම්පත ඉදිරිපත් කිරීම අසාර්ථකයි</string>
+    <string name="feature_apply_share_status_failure_tip">%1$s යටතේ කොටස් ගිණුමක් සඳහා අයදුම් කිරීම අසාර්ථකයි</string>
+    <string name="feature_apply_share_status_failure_action">නැවත උත්සාහ කරන්න</string>
+
+    <string name="feature_apply_share_status_success">අයදුම් කිරීම සාර්ථකයි!</string>
+    <string name="feature_apply_share_status_success_tip">ඔබ %1$s යටතේ කොටස් ගිණුමක් සඳහා සාර්ථකව අයදුම් කර ඇත</string>
+    <string name="feature_apply_share_status_success_action">මුල් පිටුවට</string>
+</resources>

--- a/feature/share-application/src/commonMain/composeResources/values-si/strings.xml
+++ b/feature/share-application/src/commonMain/composeResources/values-si/strings.xml
@@ -21,7 +21,7 @@
 
     <string name="feature_apply_share_error_server">අපගේ පාර්ශවයෙන් සේවාදායක දෝෂයක් ඇත, ඉදිරියට යා නොහැක, මොහොතකින් නැවත උත්සාහ කරන්න</string>
     <string name="feature_apply_share_error_too_many_attempts">අසාර්ථක උත්සාහයන් වැඩියි. කරුණාකර පසුව නැවත උත්සාහ කරන්න.</string>
-    <string name="feature_apply_share_error_submit_failed">ඉතුරුම් අයදුම්පත ඉදිරිපත් කිරීමට අපහසු විය. කරුණාකර නැවත උත්සාහ කරන්න.</string>
+    <string name="feature_apply_share_error_submit_failed">කොටස් අයදුම්පත ඉදිරිපත් කිරීමට අපහසු විය. කරුණාකර නැවත උත්සාහ කරන්න.</string>
 
     <string name="feature_apply_share_unsaved_changes_title">සුරැක නොමැති වෙනස්කම්!</string>
     <string name="feature_apply_share_unsaved_changes_message">ඔබ සතුව සුරැක නොමැති වෙනස්කම් ඇත. ඔබට ආපසු යාමට අවශ්‍ය බව විශ්වාසද?</string>

--- a/feature/share-application/src/commonMain/composeResources/values-sw/strings.xml
+++ b/feature/share-application/src/commonMain/composeResources/values-sw/strings.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<resources>
+
+    <string name="feature_share_title">Maelezo ya Maombi ya Hisa</string>
+    <string name="feature_share_navigation_back">Nyuma</string>
+
+    <string name="feature_share_label_applicant_name">Jina la Mwombaji</string>
+    <string name="feature_share_label_submission_date">Tarehe ya Kuwasilisha</string>
+    <string name="feature_share_label_product_name">Jina la Bidhaa</string>
+
+    <string name="feature_share_button_next">Endelea</string>
+
+    <string name="feature_apply_share_error_server">Tatizo la seva kutoka upande wetu, haiwezi kuendelea. Jaribu tena baada ya muda</string>
+    <string name="feature_apply_share_error_too_many_attempts">Majaribio mengi yaliyoshindikana. Tafadhali jaribu tena baadaye.</string>
+    <string name="feature_apply_share_error_submit_failed">Imeshindwa kuwasilisha maombi ya akiba. Tafadhali jaribu tena.</string>
+
+    <string name="feature_apply_share_unsaved_changes_title">Mabadiliko Hayajahifadhiwa!</string>
+    <string name="feature_apply_share_unsaved_changes_message">Una mabadiliko ambayo hayajahifadhiwa. Una uhakika unataka kurudi?</string>
+    <string name="feature_share_no_products_available">Hakuna Bidhaa za Hisa zinazopatikana kwa ajili ya kuomba akaunti ya hisa</string>
+
+
+    <string name="feature_apply_share_label_terms">Masharti</string>
+    <string name="feature_apply_share_label_currency">Sarafu</string>
+    <string name="feature_apply_share_label_current_price">Bei ya Sasa</string>
+    <string name="feature_apply_share_label_total_number_of_shares">Jumla ya Idadi ya Hisa</string>
+    <string name="feature_apply_share_label_default_savings_account">Akaunti ya Akiba ya Msingi</string>
+
+    <string name="feature_apply_share_label_minimum_active_period">Kipindi cha Chini cha Utendaji</string>
+    <string name="feature_apply_share_section_minimum_active_period">Kipindi cha Chini cha Utendaji</string>
+    <string name="feature_apply_share_label_minimum_frequency">Marudio (Frequency)</string>
+    <string name="feature_apply_share_label_minimum_frequency_type">Aina ya Marudio</string>
+
+    <string name="feature_apply_share_label_lockin_period">Kipindi cha Kuzuia (Lock-in)</string>
+    <string name="feature_apply_share_section_lockin_period">Kipindi cha Kuzuia</string>
+    <string name="feature_apply_share_label_lockin_frequency">Marudio</string>
+    <string name="feature_apply_share_label_lockin_frequency_type">Aina ya Marudio</string>
+
+    <string name="feature_apply_share_error_frequency_required">Marudio yanahitajika</string>
+    <string name="feature_apply_share_frequency_invalid">Tafadhali ingiza marudio sahihi</string>
+
+    <string name="feature_apply_share_error_shares_required">Hisa zinahitajika</string>
+    <string name="feature_apply_share_shares_invalid">Tafadhali ingiza hisa sahihi</string>
+
+    <string name="feature_apply_share_error_price_required">Bei inahitajika</string>
+    <string name="feature_apply_share_price_invalid">Tafadhali ingiza bei sahihi</string>
+
+    <string name="feature_apply_share_status_failure">Imeshindwa Kuwasilisha Maombi</string>
+    <string name="feature_apply_share_status_failure_tip">Imeshindwa kuomba akaunti ya hisa chini ya %1$s</string>
+    <string name="feature_apply_share_status_failure_action">Jaribu Tena</string>
+
+    <string name="feature_apply_share_status_success">Imefanikiwa Kuomba!</string>
+    <string name="feature_apply_share_status_success_tip">Umeomba akaunti ya hisa kwa mafanikio chini ya %1$s</string>
+    <string name="feature_apply_share_status_success_action">Rudi Nyumbani</string>
+</resources>


### PR DESCRIPTION
Fixes - [Jira-490](https://mifosforge.jira.com/browse/MM-490)

Uniform language through the app

| After fix |
|-----------|

https://github.com/user-attachments/assets/98fd48fa-9a9b-41ef-b20d-1b4d90d8ae77

| [](url) |


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the static analysis check `./gradlew check` or `ci-prepush.sh` to make sure you didn't break anything

- [ ] If you have multiple commits please combine them into one commit by squashing them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Localization**
  * Added support for 13 new languages: Arabic, German, French, Gujarati, Hindi, Hungarian, Indonesian, Kannada, Marathi, Malay, Portuguese, Sinhala, and Swahili
  * Localization now covers accounts, transactions, recent activity, and savings and share applications
  * Users can access the app in their preferred language across all major features
<!-- end of auto-generated comment: release notes by coderabbit.ai -->