### PR TITLE
[Bug Fix]: Navigation To Contact Us from Home Screen not working

### DIFF
--- a/cmp-navigation/src/commonMain/kotlin/cmp/navigation/authenticated/AuthenticatedNavigation.kt
+++ b/cmp-navigation/src/commonMain/kotlin/cmp/navigation/authenticated/AuthenticatedNavigation.kt
@@ -229,7 +229,7 @@ internal fun NavGraphBuilder.authenticatedGraph(
 
                     StatusNavigationDestination.SAVINGS_UPDATE.name,
                     StatusNavigationDestination.SAVINGS_WITHDRAW.name,
-                        -> {
+                    -> {
                         repeat(2) { navController.popBackStack() }
                     }
 

--- a/cmp-navigation/src/commonMain/kotlin/cmp/navigation/authenticated/AuthenticatedNavigation.kt
+++ b/cmp-navigation/src/commonMain/kotlin/cmp/navigation/authenticated/AuthenticatedNavigation.kt
@@ -62,6 +62,8 @@ import org.mifos.mobile.feature.savingsaccount.navigation.savingsNavGraph
 import org.mifos.mobile.feature.savingsaccount.savingsAccountDetails.navigateToSavingsAccountDetailsScreen
 import org.mifos.mobile.feature.settings.faq.faqDestination
 import org.mifos.mobile.feature.settings.faq.navigateToFaq
+import org.mifos.mobile.feature.settings.help.helpDestination
+import org.mifos.mobile.feature.settings.help.navigateToHelp
 import org.mifos.mobile.feature.share.application.navigation.navigateToShareApplicationGraph
 import org.mifos.mobile.feature.share.application.navigation.shareApplicationNavGraph
 import org.mifos.mobile.feature.shareaccount.navigation.shareNavGraph
@@ -142,6 +144,7 @@ internal fun NavGraphBuilder.authenticatedGraph(
                             StatusNavigationDestination.THIRD_PARTY_TRANSFER.name,
                         )
                     }
+
                     else -> {
                         navController.navigateToManualBeneficiaryAddScreen()
                     }
@@ -226,7 +229,7 @@ internal fun NavGraphBuilder.authenticatedGraph(
 
                     StatusNavigationDestination.SAVINGS_UPDATE.name,
                     StatusNavigationDestination.SAVINGS_WITHDRAW.name,
-                    -> {
+                        -> {
                         repeat(2) { navController.popBackStack() }
                     }
 
@@ -267,7 +270,10 @@ internal fun NavGraphBuilder.authenticatedGraph(
             navController = navController,
             navigateToClientChargeScreen = navController::navigateToClientChargeScreen,
             navigateToShareAccountTransactionScreen = { accountId ->
-                navController.navigateToAccountTransactionsScreen(Constants.SHARE_ACCOUNTS, accountId)
+                navController.navigateToAccountTransactionsScreen(
+                    Constants.SHARE_ACCOUNTS,
+                    accountId,
+                )
             },
             navigateToQrCodeScreen = navController::navigateToQrDisplayScreen,
         )
@@ -345,7 +351,15 @@ internal fun NavGraphBuilder.authenticatedGraph(
             navigateToStatusScreen = navController::navigateToStatusScreenWithoutPopUpTo,
         )
 
-        faqDestination(onBackClick = navController::popBackStack, contact = {})
+        faqDestination(
+            onBackClick = navController::popBackStack,
+            contact = navController::navigateToHelp,
+        )
+
+        helpDestination(
+            onBackClick = navController::popBackStack,
+            navigateToFAQ = navController::navigateToFaq,
+        )
     }
 }
 

--- a/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/help/HelpNavigation.kt
+++ b/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/help/HelpNavigation.kt
@@ -21,7 +21,7 @@ import org.mifos.mobile.feature.settings.componenets.SettingsItems
  *
  * @param navOptions Optional [NavOptions] to apply to this navigation operation.
  */
-internal fun NavController.navigateToHelp(navOptions: NavOptions? = null) =
+fun NavController.navigateToHelp(navOptions: NavOptions? = null) =
     navigate(SettingsItems.Help, navOptions)
 
 /**
@@ -31,7 +31,7 @@ internal fun NavController.navigateToHelp(navOptions: NavOptions? = null) =
  * @param onBackClick A lambda function to be invoked when the user initiates a back action.
  * @param navigateToFAQ A lambda function to navigate to the "FAQ" screen.
  */
-internal fun NavGraphBuilder.helpDestination(
+fun NavGraphBuilder.helpDestination(
     onBackClick: () -> Unit,
     navigateToFAQ: () -> Unit,
 ) {


### PR DESCRIPTION
Before:
faqDestination(onBackClick = navController::popBackStack, contact = {})

Now:
faqDestination(
            onBackClick = navController::popBackStack,
            contact = navController::navigateToHelp,
        )
        
issue is contact lamba passed empty


Before:

https://github.com/user-attachments/assets/b2283bd9-6516-458a-a7e2-b04f4cdfb7de

After

https://github.com/user-attachments/assets/b79d0836-c47b-40bf-bfb5-c42c23733da5



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Help and FAQ sections now link bidirectionally for smoother access between related topics.
  * Help screen is directly accessible from settings.

* **Refactor**
  * Navigation flow tightened: explicit fallback now opens manual beneficiary addition when appropriate, and routing for transaction/share screens improved for more consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->