### PR TITLE
[Bug fix]: shape paramter not specified in outlined dropdown

### DIFF
--- a/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosDropDownTextField.kt
+++ b/core/ui/src/commonMain/kotlin/org/mifos/mobile/core/ui/component/MifosDropDownTextField.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Shape
 import mifos_mobile.core.ui.generated.resources.Res
 import mifos_mobile.core.ui.generated.resources.retry
 import org.jetbrains.compose.resources.StringResource
@@ -46,6 +47,7 @@ fun MifosDropDownTextField(
     isEnabled: Boolean = true,
     supportingText: String? = null,
     error: Boolean = false,
+    shape: Shape = OutlinedTextFieldDefaults.shape,
     optionsList: List<String> = listOf(),
     selectedOption: String? = null,
 ) {
@@ -62,6 +64,7 @@ fun MifosDropDownTextField(
     ) {
         OutlinedTextField(
             value = selectedOption ?: "",
+            shape = shape,
             onValueChange = { },
             label = { Text(stringResource(labelResId)) },
             modifier = Modifier
@@ -121,6 +124,7 @@ fun MifosDropDownDoubleTextField(
     isEnabled: Boolean = true,
     supportingText: String? = null,
     error: Boolean = false,
+    shape: Shape = OutlinedTextFieldDefaults.shape,
     optionsList: List<Pair<String, String>> = listOf(),
     selectedOption: String? = null,
 ) {
@@ -143,6 +147,7 @@ fun MifosDropDownDoubleTextField(
                 .fillMaxWidth()
                 .menuAnchor(MenuAnchorType.PrimaryNotEditable, true),
             readOnly = true,
+            shape = shape,
             enabled = isEnabled,
             textStyle = KptTheme.typography.labelSmall,
             supportingText = { if (error) Text(text = supportingText ?: "") },

--- a/feature/third-party-transfer/src/commonMain/kotlin/org/mifos/mobile/feature/third/party/transfer/thirdPartyTransfer/TptScreen.kt
+++ b/feature/third-party-transfer/src/commonMain/kotlin/org/mifos/mobile/feature/third/party/transfer/thirdPartyTransfer/TptScreen.kt
@@ -218,7 +218,7 @@ internal fun TptForm(
     ) {
         MifosPayFromDropdownUI(
             accounts = state.fromAccountOptions.map
-            { Pair(it.accountNo ?: "", it.clientName ?: "") },
+                { Pair(it.accountNo ?: "", it.clientName ?: "") },
             onAccountSelected = { accountNo, _ ->
 
                 val selectedAccount = state.fromAccountOptions
@@ -253,7 +253,7 @@ internal fun TptForm(
 
         MifosDropDownDoubleTextField(
             optionsList = state.toAccountOptions.map
-            { Pair(it.accountNo ?: "", it.clientName ?: "") },
+                { Pair(it.accountNo ?: "", it.clientName ?: "") },
             selectedOption = state.toAccount?.accountNo ?: "",
             isEnabled = true,
             labelResId = Res.string.feature_tpt_label_destination,

--- a/feature/third-party-transfer/src/commonMain/kotlin/org/mifos/mobile/feature/third/party/transfer/thirdPartyTransfer/TptScreen.kt
+++ b/feature/third-party-transfer/src/commonMain/kotlin/org/mifos/mobile/feature/third/party/transfer/thirdPartyTransfer/TptScreen.kt
@@ -106,11 +106,11 @@ internal fun TptScreen(
 }
 
 /**
-* Composable function for the Third Party Transfer dialog.
-*
-* @param dialogState The dialog state for the Third Party Transfer screen.
-* @param onAction A [TptAction] function to handle actions from this dialog.
-* */
+ * Composable function for the Third Party Transfer dialog.
+ *
+ * @param dialogState The dialog state for the Third Party Transfer screen.
+ * @param onAction A [TptAction] function to handle actions from this dialog.
+ * */
 @Composable
 internal fun TptDialog(
     dialogState: TptState.DialogState?,
@@ -192,18 +192,18 @@ internal fun TprContent(
                 TptForm(state, onAction)
             }
 
-            else -> { }
+            else -> {}
         }
     }
 }
 
 /**
-* Composable function for the Third Party Transfer form.
-*
-* @param state The state for the Third Party Transfer screen.
-* @param onAction A [TptAction] function to handle actions from this form.
-* @param modifier The modifier to apply to this composable.
-* */
+ * Composable function for the Third Party Transfer form.
+ *
+ * @param state The state for the Third Party Transfer screen.
+ * @param onAction A [TptAction] function to handle actions from this form.
+ * @param modifier The modifier to apply to this composable.
+ * */
 @Composable
 internal fun TptForm(
     state: TptState,
@@ -218,7 +218,7 @@ internal fun TptForm(
     ) {
         MifosPayFromDropdownUI(
             accounts = state.fromAccountOptions.map
-                { Pair(it.accountNo ?: "", it.clientName ?: "") },
+            { Pair(it.accountNo ?: "", it.clientName ?: "") },
             onAccountSelected = { accountNo, _ ->
 
                 val selectedAccount = state.fromAccountOptions
@@ -253,7 +253,7 @@ internal fun TptForm(
 
         MifosDropDownDoubleTextField(
             optionsList = state.toAccountOptions.map
-                { Pair(it.accountNo ?: "", it.clientName ?: "") },
+            { Pair(it.accountNo ?: "", it.clientName ?: "") },
             selectedOption = state.toAccount?.accountNo ?: "",
             isEnabled = true,
             labelResId = Res.string.feature_tpt_label_destination,
@@ -264,6 +264,7 @@ internal fun TptForm(
                     ),
                 )
             },
+            shape = KptTheme.shapes.medium,
         )
 
         Row(

--- a/feature/transfer-process/src/commonMain/kotlin/org/mifos/mobile/feature/transfer/process/makeTransfer/MakeTransferScreen.kt
+++ b/feature/transfer-process/src/commonMain/kotlin/org/mifos/mobile/feature/transfer/process/makeTransfer/MakeTransferScreen.kt
@@ -158,7 +158,7 @@ internal fun MakeTransferScreenContent(
                 ) {
                     MifosDropDownDoubleTextField(
                         optionsList = state.toAccountOptions.map
-                        { Pair(it.accountNo ?: "", it.clientName ?: "") },
+                            { Pair(it.accountNo ?: "", it.clientName ?: "") },
                         selectedOption = state.toAccount?.accountNo ?: "",
                         isEnabled = state.outstandingBalance == null,
                         labelResId = Res.string.pay_to,
@@ -174,7 +174,7 @@ internal fun MakeTransferScreenContent(
 
                     MifosPayFromDropdownUI(
                         accounts = state.fromAccountOptions.map
-                        { Pair(it.accountNo ?: "", it.clientName ?: "") },
+                            { Pair(it.accountNo ?: "", it.clientName ?: "") },
                         onAccountSelected = { account, balance ->
                             onAction(MakeTransferAction.OnFromAccountSelected(account))
                         },

--- a/feature/transfer-process/src/commonMain/kotlin/org/mifos/mobile/feature/transfer/process/makeTransfer/MakeTransferScreen.kt
+++ b/feature/transfer-process/src/commonMain/kotlin/org/mifos/mobile/feature/transfer/process/makeTransfer/MakeTransferScreen.kt
@@ -70,8 +70,13 @@ internal fun MakeTransferScreen(
             MakeTransferEvent.NavigateBack -> {
                 navigateBack.invoke()
             }
+
             is MakeTransferEvent.NavigateToTransferScreen -> {
-                navigateToTransferScreen(event.reviewTransferPayload, event.transferType, event.destination)
+                navigateToTransferScreen(
+                    event.reviewTransferPayload,
+                    event.transferType,
+                    event.destination,
+                )
             }
         }
     }
@@ -153,7 +158,7 @@ internal fun MakeTransferScreenContent(
                 ) {
                     MifosDropDownDoubleTextField(
                         optionsList = state.toAccountOptions.map
-                            { Pair(it.accountNo ?: "", it.clientName ?: "") },
+                        { Pair(it.accountNo ?: "", it.clientName ?: "") },
                         selectedOption = state.toAccount?.accountNo ?: "",
                         isEnabled = state.outstandingBalance == null,
                         labelResId = Res.string.pay_to,
@@ -164,11 +169,12 @@ internal fun MakeTransferScreenContent(
                                 ),
                             )
                         },
+                        shape = KptTheme.shapes.medium,
                     )
 
                     MifosPayFromDropdownUI(
                         accounts = state.fromAccountOptions.map
-                            { Pair(it.accountNo ?: "", it.clientName ?: "") },
+                        { Pair(it.accountNo ?: "", it.clientName ?: "") },
                         onAccountSelected = { account, balance ->
                             onAction(MakeTransferAction.OnFromAccountSelected(account))
                         },
@@ -267,6 +273,7 @@ internal fun MakeTransferDialog(
                 modifier = modifier,
             )
         }
+
         null -> {}
     }
 }


### PR DESCRIPTION
Before:
<img width="300"  alt="Screenshot_20260225-212744_Mifos Mobile" src="https://github.com/user-attachments/assets/f591f32c-24c9-4c98-b279-a908930873b6" />

After:
<img width="300"  alt="Screenshot_20260225-212908_Mifos Mobile" src="https://github.com/user-attachments/assets/6bf082ed-90ab-49ea-ad93-5fafdb24d491" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Dropdown text fields now expose a configurable shape option for consistent, customizable UI styling.
  * Transfer-related screens updated to apply the new dropdown appearance option for improved visual consistency.

* **Style**
  * Minor formatting and documentation comment tidy-ups across UI components for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->