### PR TITLE
fix(security): disable Android backup to protect sensitive data

### DIFF
--- a/cmp-android/src/main/AndroidManifest.xml
+++ b/cmp-android/src/main/AndroidManifest.xml
@@ -34,12 +34,15 @@
 
     <application
         android:name=".AndroidApp"
-        android:allowBackup="true"
+        android:allowBackup="false"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.MifosSplash">
+        android:theme="@style/Theme.MifosSplash"
+        tools:targetApi="31">
 
         <activity
             android:name=".MainActivity"

--- a/cmp-android/src/main/res/xml/backup_rules.xml
+++ b/cmp-android/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<!--
+    Backup rules for Android 6.0–11 (API 23–30).
+    All backup is disabled to prevent sensitive financial data from being
+    included in Android Auto Backup or adb backup.
+-->
+<full-backup-content>
+    <exclude domain="root" path="." />
+    <exclude domain="file" path="." />
+    <exclude domain="database" path="." />
+    <exclude domain="sharedpref" path="." />
+    <exclude domain="external" path="." />
+</full-backup-content>

--- a/cmp-android/src/main/res/xml/data_extraction_rules.xml
+++ b/cmp-android/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<!--
+    Data extraction rules for Android 12+ (API 31+).
+    Both cloud backup and device transfer are disabled to prevent sensitive
+    financial data from leaving the device via backup mechanisms.
+-->
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="root" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="external" path="." />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="root" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="external" path="." />
+    </device-transfer>
+</data-extraction-rules>


### PR DESCRIPTION
Summary :
  - Set `android:allowBackup="false"` to prevent sensitive financial data from being backed up via adb or Google Drive
  - Add `backup_rules.xml` for Android 6–11 (API 23–30) to exclude all backup domains
  - Add `data_extraction_rules.xml` for Android 12+ (API 31+) to disable cloud backup and device transfer

Changes :
  - `cmp-android/src/main/AndroidManifest.xml` — disabled backup attributes
  - `cmp-android/src/main/res/xml/backup_rules.xml` — new file
  - `cmp-android/src/main/res/xml/data_extraction_rules.xml` — new file

 