### PR TITLE
refactor(core): introduce domain exceptions for ui error handling

### DIFF
--- a/core/common/src/commonMain/kotlin/org/mifos/mobile/core/common/DataState.kt
+++ b/core/common/src/commonMain/kotlin/org/mifos/mobile/core/common/DataState.kt
@@ -9,10 +9,13 @@
  */
 package org.mifos.mobile.core.common
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.cancellation.CancellationException
 
 sealed class DataState<out T> {
     abstract val data: T?
@@ -29,23 +32,40 @@ sealed class DataState<out T> {
         val exception: Throwable,
         override val data: T? = null,
     ) : DataState<T>() {
-        val message = exception.message.toString()
+        val message: String get() = exception.message ?: "Unknown error"
     }
 }
 
-fun <T> Flow<T>.asDataStateFlow(): Flow<DataState<T>> =
-    map<T, DataState<T>> { DataState.Success(it) }
-        .onStart { emit(DataState.Loading) }
-        .catch {
-            val mapped = if (it is MifosException) {
-                it
-            } else {
-                MifosException.GenericError(it.message ?: "Unknown error", it)
-            }
-            emit(DataState.Error(mapped, null))
-        }
-
-fun <T> Flow<T>.asDataStateFlow(exceptionMapper: (Throwable) -> MifosException): Flow<DataState<T>> =
+fun <T> Flow<T>.asDataStateFlow(
+    exceptionMapper: suspend (Throwable) -> MifosException = ::defaultExceptionMapper,
+): Flow<DataState<T>> =
     map<T, DataState<T>> { DataState.Success(it) }
         .onStart { emit(DataState.Loading) }
         .catch { emit(DataState.Error(exceptionMapper(it), null)) }
+
+suspend fun <T> safeDataStateCall(
+    dispatcher: CoroutineDispatcher,
+    exceptionMapper: suspend (Throwable) -> MifosException = ::defaultExceptionMapper,
+    block: suspend () -> T,
+): DataState<T> {
+    return withContext(dispatcher) {
+        try {
+            DataState.Success(block())
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            DataState.Error(exceptionMapper(e), null)
+        }
+    }
+}
+
+private fun defaultExceptionMapper(throwable: Throwable): MifosException {
+    return if (throwable is MifosException) {
+        throwable
+    } else {
+        MifosException.GenericError(
+            throwable.message ?: "Unknown error",
+            throwable,
+        )
+    }
+}

--- a/core/common/src/commonMain/kotlin/org/mifos/mobile/core/common/DataState.kt
+++ b/core/common/src/commonMain/kotlin/org/mifos/mobile/core/common/DataState.kt
@@ -36,4 +36,16 @@ sealed class DataState<out T> {
 fun <T> Flow<T>.asDataStateFlow(): Flow<DataState<T>> =
     map<T, DataState<T>> { DataState.Success(it) }
         .onStart { emit(DataState.Loading) }
-        .catch { emit(DataState.Error(it, null)) }
+        .catch {
+            val mapped = if (it is MifosException) {
+                it
+            } else {
+                MifosException.GenericError(it.message ?: "Unknown error", it)
+            }
+            emit(DataState.Error(mapped, null))
+        }
+
+fun <T> Flow<T>.asDataStateFlow(exceptionMapper: (Throwable) -> MifosException): Flow<DataState<T>> =
+    map<T, DataState<T>> { DataState.Success(it) }
+        .onStart { emit(DataState.Loading) }
+        .catch { emit(DataState.Error(exceptionMapper(it), null)) }

--- a/core/common/src/commonMain/kotlin/org/mifos/mobile/core/common/MifosException.kt
+++ b/core/common/src/commonMain/kotlin/org/mifos/mobile/core/common/MifosException.kt
@@ -14,6 +14,31 @@ sealed class MifosException(
     cause: Throwable? = null,
 ) : Exception(message, cause) {
 
+    class BadRequest(
+        message: String = "Bad request",
+        cause: Throwable? = null,
+    ) : MifosException(message, cause)
+
+    class Unauthorized(
+        message: String = "Unauthorized",
+        cause: Throwable? = null,
+    ) : MifosException(message, cause)
+
+    class NotFound(
+        message: String = "Not found",
+        cause: Throwable? = null,
+    ) : MifosException(message, cause)
+
+    class RequestTimeout(
+        message: String = "Request timeout",
+        cause: Throwable? = null,
+    ) : MifosException(message, cause)
+
+    class TooManyRequests(
+        message: String = "Too many requests",
+        cause: Throwable? = null,
+    ) : MifosException(message, cause)
+
     class ServerError(
         message: String = "Server error",
         cause: Throwable? = null,
@@ -21,6 +46,11 @@ sealed class MifosException(
 
     class ClientError(
         message: String,
+        cause: Throwable? = null,
+    ) : MifosException(message, cause)
+
+    class SerializationError(
+        message: String = "Serialization error",
         cause: Throwable? = null,
     ) : MifosException(message, cause)
 

--- a/core/common/src/commonMain/kotlin/org/mifos/mobile/core/common/MifosException.kt
+++ b/core/common/src/commonMain/kotlin/org/mifos/mobile/core/common/MifosException.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+ */
+package org.mifos.mobile.core.common
+
+sealed class MifosException(
+    message: String,
+    cause: Throwable? = null,
+) : Exception(message, cause) {
+
+    class ServerError(
+        message: String = "Server error",
+        cause: Throwable? = null,
+    ) : MifosException(message, cause)
+
+    class ClientError(
+        message: String,
+        cause: Throwable? = null,
+    ) : MifosException(message, cause)
+
+    class NetworkError(
+        message: String = "Network error",
+        cause: Throwable? = null,
+    ) : MifosException(message, cause)
+
+    class GenericError(
+        message: String,
+        cause: Throwable? = null,
+    ) : MifosException(message, cause)
+}

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/AccountsRepositoryImp.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/AccountsRepositoryImp.kt
@@ -11,24 +11,21 @@ package org.mifos.mobile.core.data.repositoryImpl
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import org.mifos.mobile.core.common.DataState
-import org.mifos.mobile.core.common.asDataStateFlow
 import org.mifos.mobile.core.data.mapper.accounts.toModel
 import org.mifos.mobile.core.data.repository.AccountsRepository
-import org.mifos.mobile.core.data.util.toMifosException
 import org.mifos.mobile.core.model.entity.client.ClientAccounts
 import org.mifos.mobile.core.network.DataManager
 
 class AccountsRepositoryImp(
     private val dataManager: DataManager,
-    private val ioDispatcher: CoroutineDispatcher,
-) : AccountsRepository {
+    ioDispatcher: CoroutineDispatcher,
+) : BaseRepository(ioDispatcher), AccountsRepository {
 
     override fun loadAccounts(clientId: Long?, accountType: String?): Flow<DataState<ClientAccounts>> {
         return dataManager.clientsApi.getAccounts(clientId!!, accountType)
             .map { it.toModel() }
-            .asDataStateFlow(Throwable::toMifosException).flowOn(ioDispatcher)
+            .asDataState()
     }
 }

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/AccountsRepositoryImp.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/AccountsRepositoryImp.kt
@@ -17,6 +17,7 @@ import org.mifos.mobile.core.common.DataState
 import org.mifos.mobile.core.common.asDataStateFlow
 import org.mifos.mobile.core.data.mapper.accounts.toModel
 import org.mifos.mobile.core.data.repository.AccountsRepository
+import org.mifos.mobile.core.data.util.toMifosException
 import org.mifos.mobile.core.model.entity.client.ClientAccounts
 import org.mifos.mobile.core.network.DataManager
 
@@ -28,6 +29,6 @@ class AccountsRepositoryImp(
     override fun loadAccounts(clientId: Long?, accountType: String?): Flow<DataState<ClientAccounts>> {
         return dataManager.clientsApi.getAccounts(clientId!!, accountType)
             .map { it.toModel() }
-            .asDataStateFlow().flowOn(ioDispatcher)
+            .asDataStateFlow(Throwable::toMifosException).flowOn(ioDispatcher)
     }
 }

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/AuthenticationUserRepository.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/AuthenticationUserRepository.kt
@@ -15,15 +15,12 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.zip
-import kotlinx.coroutines.withContext
 import org.mifos.mobile.core.common.DataState
 import org.mifos.mobile.core.common.Dispatcher
 import org.mifos.mobile.core.common.MifosDispatchers
-import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.UserDataRepository
 import org.mifos.mobile.core.datastore.UserPreferencesRepository
 import org.mifos.mobile.core.datastore.model.AppSettings
@@ -32,10 +29,10 @@ import org.mifos.mobile.core.model.UserData
 
 class AuthenticationUserRepository(
     private val preferencesHelper: UserPreferencesRepository,
-    private val ioDispatcher: CoroutineDispatcher,
+    ioDispatcher: CoroutineDispatcher,
     @Dispatcher(MifosDispatchers.Unconfined)
     private val unconfinedDispatcher: CoroutineDispatcher,
-) : UserDataRepository {
+) : BaseRepository(ioDispatcher), UserDataRepository {
 
     private val unconfinedScope = CoroutineScope(unconfinedDispatcher)
 
@@ -43,28 +40,19 @@ class AuthenticationUserRepository(
         get() = preferencesHelper.userInfo.value.userId
 
     override val userData: Flow<DataState<UserData>> = flow {
-        try {
-            val userData = UserData(
+        emit(
+            UserData(
                 isAuthenticated = !preferencesHelper.token.value.isNullOrEmpty(),
                 userName = preferencesHelper.userInfo.firstOrNull()?.userName ?: "",
                 clientId = preferencesHelper.clientId.value ?: 0,
                 password = preferencesHelper.userInfo.firstOrNull()?.password ?: "",
-            )
-            emit(DataState.Success(userData))
-        } catch (e: Exception) {
-            emit(DataState.Error(MifosException.GenericError(e.message ?: "Unknown error", e), null))
-        }
-    }.flowOn(ioDispatcher)
+            ),
+        )
+    }.asDataState()
 
-    override suspend fun logOut(): DataState<String> {
-        return try {
-            withContext(ioDispatcher) {
-                preferencesHelper.logOut()
-            }
-            DataState.Success("User logged out Successfully")
-        } catch (e: Exception) {
-            DataState.Error(MifosException.GenericError(e.message ?: "Unknown error", e), null)
-        }
+    override suspend fun logOut(): DataState<String> = safeCall {
+        preferencesHelper.logOut()
+        "User logged out Successfully"
     }
 
     override val authState: StateFlow<AuthState>

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/AuthenticationUserRepository.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/AuthenticationUserRepository.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.withContext
 import org.mifos.mobile.core.common.DataState
 import org.mifos.mobile.core.common.Dispatcher
 import org.mifos.mobile.core.common.MifosDispatchers
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.UserDataRepository
 import org.mifos.mobile.core.datastore.UserPreferencesRepository
 import org.mifos.mobile.core.datastore.model.AppSettings
@@ -51,7 +52,7 @@ class AuthenticationUserRepository(
             )
             emit(DataState.Success(userData))
         } catch (e: Exception) {
-            emit(DataState.Error(e, null))
+            emit(DataState.Error(MifosException.GenericError(e.message ?: "Unknown error", e), null))
         }
     }.flowOn(ioDispatcher)
 
@@ -62,7 +63,7 @@ class AuthenticationUserRepository(
             }
             DataState.Success("User logged out Successfully")
         } catch (e: Exception) {
-            DataState.Error(e, null)
+            DataState.Error(MifosException.GenericError(e.message ?: "Unknown error", e), null)
         }
     }
 

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/BaseRepository.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/BaseRepository.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+ */
+package org.mifos.mobile.core.data.repositoryImpl
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
+import org.mifos.mobile.core.common.DataState
+import org.mifos.mobile.core.common.MifosException
+import org.mifos.mobile.core.common.asDataStateFlow
+import org.mifos.mobile.core.common.safeDataStateCall
+import org.mifos.mobile.core.data.util.toMifosExceptionSuspend
+
+abstract class BaseRepository(
+    protected val ioDispatcher: CoroutineDispatcher,
+) {
+    protected val exceptionMapper: suspend (Throwable) -> MifosException = {
+        it.toMifosExceptionSuspend()
+    }
+
+    protected suspend fun <T> safeCall(
+        block: suspend () -> T,
+    ): DataState<T> = safeDataStateCall(
+        dispatcher = ioDispatcher,
+        exceptionMapper = exceptionMapper,
+        block = block,
+    )
+
+    protected fun <T> Flow<T>.asDataState(): Flow<DataState<T>> =
+        asDataStateFlow(exceptionMapper).flowOn(ioDispatcher)
+}

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/BeneficiaryRepositoryImp.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/BeneficiaryRepositoryImp.kt
@@ -9,8 +9,6 @@
  */
 package org.mifos.mobile.core.data.repositoryImpl
 
-import io.ktor.client.plugins.ClientRequestException
-import io.ktor.client.plugins.ServerResponseException
 import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
@@ -18,13 +16,13 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
-import kotlinx.io.IOException
 import org.mifos.mobile.core.common.DataState
 import org.mifos.mobile.core.data.mapper.beneficiary.toModel
 import org.mifos.mobile.core.data.mapper.payloads.toDto
 import org.mifos.mobile.core.data.mapper.templates.toModel
 import org.mifos.mobile.core.data.repository.BeneficiaryRepository
-import org.mifos.mobile.core.data.util.extractErrorMessage
+import org.mifos.mobile.core.data.util.toMifosException
+import org.mifos.mobile.core.data.util.toMifosExceptionSuspend
 import org.mifos.mobile.core.model.entity.beneficiary.Beneficiary
 import org.mifos.mobile.core.model.entity.beneficiary.BeneficiaryPayload
 import org.mifos.mobile.core.model.entity.beneficiary.BeneficiaryUpdatePayload
@@ -43,7 +41,7 @@ class BeneficiaryRepositoryImp(
                     emit(DataState.Success(response))
                 }
         } catch (exception: Exception) {
-            emit(DataState.Error(exception))
+            emit(DataState.Error(exception.toMifosException()))
         }
     }.flowOn(ioDispatcher)
 
@@ -53,13 +51,8 @@ class BeneficiaryRepositoryImp(
                 val response =
                     dataManager.beneficiaryApi.createBeneficiary(beneficiaryPayload?.toDto())
                 DataState.Success(response.bodyAsText())
-            } catch (e: ClientRequestException) {
-                val errorMessage = extractErrorMessage(e.response)
-                DataState.Error(Exception(errorMessage), null)
-            } catch (e: IOException) {
-                DataState.Error(Exception("Network error", e), null)
-            } catch (e: ServerResponseException) {
-                DataState.Error(Exception("Server error", e), null)
+            } catch (e: Exception) {
+                DataState.Error(e.toMifosExceptionSuspend(), null)
             }
         }
     }
@@ -73,13 +66,8 @@ class BeneficiaryRepositoryImp(
                 val response =
                     dataManager.beneficiaryApi.updateBeneficiary(beneficiaryId!!, payload?.toDto())
                 DataState.Success(response.bodyAsText())
-            } catch (e: ClientRequestException) {
-                val errorMessage = extractErrorMessage(e.response)
-                DataState.Error(Exception(errorMessage), null)
-            } catch (e: IOException) {
-                DataState.Error(Exception("Network error", e), null)
-            } catch (e: ServerResponseException) {
-                DataState.Error(Exception("Server error", e), null)
+            } catch (e: Exception) {
+                DataState.Error(e.toMifosExceptionSuspend(), null)
             }
         }
     }
@@ -90,13 +78,8 @@ class BeneficiaryRepositoryImp(
                 val response = dataManager.beneficiaryApi.deleteBeneficiary(beneficiaryId!!)
 
                 DataState.Success(response.bodyAsText())
-            } catch (e: ClientRequestException) {
-                val errorMessage = extractErrorMessage(e.response)
-                DataState.Error(Exception(errorMessage), null)
-            } catch (e: IOException) {
-                DataState.Error(Exception("Network error", e), null)
-            } catch (e: ServerResponseException) {
-                DataState.Error(Exception("Server error", e), null)
+            } catch (e: Exception) {
+                DataState.Error(e.toMifosExceptionSuspend(), null)
             }
         }
     }
@@ -108,7 +91,7 @@ class BeneficiaryRepositoryImp(
                     emit(DataState.Success(response.map { it.toModel() }))
                 }
         } catch (e: Exception) {
-            emit(DataState.Error(e, null))
+            emit(DataState.Error(e.toMifosException(), null))
         }
     }.flowOn(ioDispatcher)
 }

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/BeneficiaryRepositoryImp.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/BeneficiaryRepositoryImp.kt
@@ -12,17 +12,12 @@ package org.mifos.mobile.core.data.repositoryImpl
 import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.withContext
 import org.mifos.mobile.core.common.DataState
 import org.mifos.mobile.core.data.mapper.beneficiary.toModel
 import org.mifos.mobile.core.data.mapper.payloads.toDto
 import org.mifos.mobile.core.data.mapper.templates.toModel
 import org.mifos.mobile.core.data.repository.BeneficiaryRepository
-import org.mifos.mobile.core.data.util.toMifosException
-import org.mifos.mobile.core.data.util.toMifosExceptionSuspend
 import org.mifos.mobile.core.model.entity.beneficiary.Beneficiary
 import org.mifos.mobile.core.model.entity.beneficiary.BeneficiaryPayload
 import org.mifos.mobile.core.model.entity.beneficiary.BeneficiaryUpdatePayload
@@ -31,67 +26,35 @@ import org.mifos.mobile.core.network.DataManager
 
 class BeneficiaryRepositoryImp(
     private val dataManager: DataManager,
-    private val ioDispatcher: CoroutineDispatcher,
-) : BeneficiaryRepository {
-    override fun beneficiaryTemplate(): Flow<DataState<BeneficiaryTemplate>> = flow {
-        try {
-            dataManager.beneficiaryApi.beneficiaryTemplate()
-                .map { it.toModel() }
-                .collect { response ->
-                    emit(DataState.Success(response))
-                }
-        } catch (exception: Exception) {
-            emit(DataState.Error(exception.toMifosException()))
-        }
-    }.flowOn(ioDispatcher)
+    ioDispatcher: CoroutineDispatcher,
+) : BaseRepository(ioDispatcher), BeneficiaryRepository {
+    override fun beneficiaryTemplate(): Flow<DataState<BeneficiaryTemplate>> =
+        dataManager.beneficiaryApi.beneficiaryTemplate()
+            .map { it.toModel() }
+            .asDataState()
 
-    override suspend fun createBeneficiary(beneficiaryPayload: BeneficiaryPayload?): DataState<String> {
-        return withContext(ioDispatcher) {
-            try {
-                val response =
-                    dataManager.beneficiaryApi.createBeneficiary(beneficiaryPayload?.toDto())
-                DataState.Success(response.bodyAsText())
-            } catch (e: Exception) {
-                DataState.Error(e.toMifosExceptionSuspend(), null)
-            }
-        }
+    override suspend fun createBeneficiary(beneficiaryPayload: BeneficiaryPayload?): DataState<String> = safeCall {
+        dataManager.beneficiaryApi
+            .createBeneficiary(beneficiaryPayload?.toDto())
+            .bodyAsText()
     }
-
     override suspend fun updateBeneficiary(
         beneficiaryId: Long?,
         payload: BeneficiaryUpdatePayload?,
-    ): DataState<String> {
-        return withContext(ioDispatcher) {
-            try {
-                val response =
-                    dataManager.beneficiaryApi.updateBeneficiary(beneficiaryId!!, payload?.toDto())
-                DataState.Success(response.bodyAsText())
-            } catch (e: Exception) {
-                DataState.Error(e.toMifosExceptionSuspend(), null)
-            }
-        }
+    ): DataState<String> = safeCall {
+        dataManager.beneficiaryApi
+            .updateBeneficiary(beneficiaryId!!, payload?.toDto())
+            .bodyAsText()
     }
 
-    override suspend fun deleteBeneficiary(beneficiaryId: Long?): DataState<String> {
-        return withContext(ioDispatcher) {
-            try {
-                val response = dataManager.beneficiaryApi.deleteBeneficiary(beneficiaryId!!)
-
-                DataState.Success(response.bodyAsText())
-            } catch (e: Exception) {
-                DataState.Error(e.toMifosExceptionSuspend(), null)
-            }
-        }
+    override suspend fun deleteBeneficiary(beneficiaryId: Long?): DataState<String> = safeCall {
+        dataManager.beneficiaryApi
+            .deleteBeneficiary(beneficiaryId!!)
+            .bodyAsText()
     }
 
-    override fun beneficiaryList(): Flow<DataState<List<Beneficiary>>> = flow {
-        try {
-            dataManager.beneficiaryApi.beneficiaryList()
-                .collect { response ->
-                    emit(DataState.Success(response.map { it.toModel() }))
-                }
-        } catch (e: Exception) {
-            emit(DataState.Error(e.toMifosException(), null))
-        }
-    }.flowOn(ioDispatcher)
+    override fun beneficiaryList(): Flow<DataState<List<Beneficiary>>> =
+        dataManager.beneficiaryApi.beneficiaryList()
+            .map { response -> response.map { it.toModel() } }
+            .asDataState()
 }

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/ClientChargeRepositoryImp.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/ClientChargeRepositoryImp.kt
@@ -21,6 +21,7 @@ import org.mifos.mobile.core.data.mapper.charge.toModel
 import org.mifos.mobile.core.data.mapper.share.toShareChargeModel
 import org.mifos.mobile.core.data.mapper.toPageModel
 import org.mifos.mobile.core.data.repository.ClientChargeRepository
+import org.mifos.mobile.core.data.util.toMifosException
 import org.mifos.mobile.core.model.entity.Charge
 import org.mifos.mobile.core.model.entity.Page
 import org.mifos.mobile.core.model.enums.ChargeType
@@ -42,7 +43,7 @@ class ClientChargeRepositoryImp(
                     },
                 )
             }
-            .catch { exception -> DataState.Error(exception, exception.message) }
+            .catch { exception -> DataState.Error(exception.toMifosException(), null) }
             .flowOn(ioDispatcher)
     }
 
@@ -53,7 +54,7 @@ class ClientChargeRepositoryImp(
                     response.map { it.toModel() },
                 )
             }
-            .catch { exception -> DataState.Error(exception, exception.message) }
+            .catch { exception -> DataState.Error(exception.toMifosException(), null) }
             .flowOn(ioDispatcher)
     }
 
@@ -85,7 +86,7 @@ class ClientChargeRepositoryImp(
                 )
             }
             .catch { exception ->
-                DataState.Error(exception, exception.message)
+                DataState.Error(exception.toMifosException(), null)
             }
             .flowOn(ioDispatcher)
     }

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/ClientChargeRepositoryImp.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/ClientChargeRepositoryImp.kt
@@ -11,17 +11,14 @@ package org.mifos.mobile.core.data.repositoryImpl
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.withContext
 import org.mifos.mobile.core.common.DataState
 import org.mifos.mobile.core.data.mapper.charge.toModel
 import org.mifos.mobile.core.data.mapper.share.toShareChargeModel
 import org.mifos.mobile.core.data.mapper.toPageModel
 import org.mifos.mobile.core.data.repository.ClientChargeRepository
-import org.mifos.mobile.core.data.util.toMifosException
 import org.mifos.mobile.core.model.entity.Charge
 import org.mifos.mobile.core.model.entity.Page
 import org.mifos.mobile.core.model.enums.ChargeType
@@ -31,31 +28,25 @@ import kotlin.collections.map
 class ClientChargeRepositoryImp(
     private val dataManager: DataManager,
 //    private val chargeDao: ChargeDao,
-    private val ioDispatcher: CoroutineDispatcher,
-) : ClientChargeRepository {
+    ioDispatcher: CoroutineDispatcher,
+) : BaseRepository(ioDispatcher), ClientChargeRepository {
 
     override fun getCharges(clientId: Long): Flow<DataState<Page<Charge>>> {
         return dataManager.clientChargeApi.getClientChargeList(clientId)
             .map { response ->
-                DataState.Success(
-                    response.toPageModel { dto ->
-                        dto.toModel()
-                    },
-                )
+                response.toPageModel { dto ->
+                    dto.toModel()
+                }
             }
-            .catch { exception -> DataState.Error(exception.toMifosException(), null) }
-            .flowOn(ioDispatcher)
+            .asDataState()
     }
 
     override fun getLoanOrSavingsCharges(chargeType: ChargeType, chargeTypeId: Long): Flow<DataState<List<Charge>>> {
         return dataManager.clientChargeApi.getChargeList(chargeType.type, chargeTypeId)
             .map { response ->
-                DataState.Success(
-                    response.map { it.toModel() },
-                )
+                response.map { it.toModel() }
             }
-            .catch { exception -> DataState.Error(exception.toMifosException(), null) }
-            .flowOn(ioDispatcher)
+            .asDataState()
     }
 
     override fun clientLocalCharges(): Flow<DataState<Page<Charge>>> {
@@ -66,28 +57,16 @@ class ClientChargeRepositoryImp(
             .flowOn(ioDispatcher)
     }
 
-    override suspend fun syncCharges(charges: Page<Charge>?): DataState<Page<Charge>?> {
-        return withContext(ioDispatcher) {
-//            charges?.pageItems?.let {
-//                chargeDao.syncCharges(it.map { it.toChargeEntity() })
-//            }
-//
-//            charges?.copy(pageItems = charges.pageItems)
-            val result = charges?.copy(pageItems = charges.pageItems) ?: Page(0, emptyList())
-            DataState.Success(result)
-        }
+    override suspend fun syncCharges(charges: Page<Charge>?): DataState<Page<Charge>?> = safeCall {
+        val page = charges ?: Page(totalFilteredRecords = 0, pageItems = emptyList())
+        page
     }
 
     override fun getShareAccountCharges(shareAccountId: Long): Flow<DataState<List<Charge>>> {
         return dataManager.shareAccountApi.getShareAccountDetails(shareAccountId)
             .map { response ->
-                DataState.Success(
-                    response.charges.map { it.toShareChargeModel() },
-                )
+                response.charges.map { it.toShareChargeModel() }
             }
-            .catch { exception ->
-                DataState.Error(exception.toMifosException(), null)
-            }
-            .flowOn(ioDispatcher)
+            .asDataState()
     }
 }

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/ClientRepositoryImp.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/ClientRepositoryImp.kt
@@ -18,6 +18,7 @@ import org.mifos.mobile.core.common.asDataStateFlow
 import org.mifos.mobile.core.data.mapper.client.toModel
 import org.mifos.mobile.core.data.mapper.toPageModel
 import org.mifos.mobile.core.data.repository.ClientRepository
+import org.mifos.mobile.core.data.util.toMifosException
 import org.mifos.mobile.core.model.entity.Page
 import org.mifos.mobile.core.model.entity.client.Client
 import org.mifos.mobile.core.network.DataManager
@@ -34,6 +35,6 @@ class ClientRepositoryImp(
                     dto.toModel()
                 }
             }
-            .asDataStateFlow().flowOn(ioDispatcher)
+            .asDataStateFlow(Throwable::toMifosException).flowOn(ioDispatcher)
     }
 }

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/ClientRepositoryImp.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/ClientRepositoryImp.kt
@@ -11,22 +11,19 @@ package org.mifos.mobile.core.data.repositoryImpl
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import org.mifos.mobile.core.common.DataState
-import org.mifos.mobile.core.common.asDataStateFlow
 import org.mifos.mobile.core.data.mapper.client.toModel
 import org.mifos.mobile.core.data.mapper.toPageModel
 import org.mifos.mobile.core.data.repository.ClientRepository
-import org.mifos.mobile.core.data.util.toMifosException
 import org.mifos.mobile.core.model.entity.Page
 import org.mifos.mobile.core.model.entity.client.Client
 import org.mifos.mobile.core.network.DataManager
 
 class ClientRepositoryImp(
     private val dataManager: DataManager,
-    private val ioDispatcher: CoroutineDispatcher,
-) : ClientRepository {
+    ioDispatcher: CoroutineDispatcher,
+) : BaseRepository(ioDispatcher), ClientRepository {
 
     override fun loadClient(): Flow<DataState<Page<Client>>> {
         return dataManager.clientsApi.clients()
@@ -35,6 +32,6 @@ class ClientRepositoryImp(
                     dto.toModel()
                 }
             }
-            .asDataStateFlow(Throwable::toMifosException).flowOn(ioDispatcher)
+            .asDataState()
     }
 }

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/GuarantorRepositoryImp.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/GuarantorRepositoryImp.kt
@@ -13,16 +13,11 @@ import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.withContext
 import org.mifos.mobile.core.common.DataState
-import org.mifos.mobile.core.common.asDataStateFlow
 import org.mifos.mobile.core.data.mapper.guarantor.toModel
 import org.mifos.mobile.core.data.mapper.payloads.toDto
 import org.mifos.mobile.core.data.repository.GuarantorRepository
-import org.mifos.mobile.core.data.util.toMifosException
-import org.mifos.mobile.core.data.util.toMifosExceptionSuspend
 import org.mifos.mobile.core.model.entity.guarantor.GuarantorApplicationPayload
 import org.mifos.mobile.core.model.entity.guarantor.GuarantorPayload
 import org.mifos.mobile.core.model.entity.guarantor.GuarantorTemplatePayload
@@ -30,65 +25,45 @@ import org.mifos.mobile.core.network.DataManager
 
 class GuarantorRepositoryImp(
     private val dataManager: DataManager,
-    private val ioDispatcher: CoroutineDispatcher,
-) : GuarantorRepository {
+    ioDispatcher: CoroutineDispatcher,
+) : BaseRepository(ioDispatcher), GuarantorRepository {
 
     override fun getGuarantorTemplate(loanId: Long?): Flow<DataState<GuarantorTemplatePayload?>> {
         return dataManager.guarantorApi.getGuarantorTemplate(loanId!!)
             .map { it.toModel() }
-            .asDataStateFlow(Throwable::toMifosException).flowOn(ioDispatcher)
+            .asDataState()
     }
 
     override suspend fun createGuarantor(
         loanId: Long?,
         payload: GuarantorApplicationPayload?,
-    ): DataState<String> {
-        return withContext(ioDispatcher) {
-            try {
-                val response = dataManager.guarantorApi.createGuarantor(loanId!!, payload?.toDto())
-                DataState.Success(response.bodyAsText())
-            } catch (e: Exception) {
-                DataState.Error(e.toMifosExceptionSuspend(), null)
-            }
-        }
+    ): DataState<String> = safeCall {
+        dataManager.guarantorApi
+            .createGuarantor(loanId!!, payload?.toDto())
+            .bodyAsText()
     }
 
     override suspend fun updateGuarantor(
         payload: GuarantorApplicationPayload?,
         loanId: Long?,
         guarantorId: Long?,
-    ): DataState<String> {
-        return withContext(ioDispatcher) {
-            try {
-                val response = dataManager.guarantorApi.updateGuarantor(
-                    payload?.toDto(),
-                    loanId!!,
-                    guarantorId!!,
-                )
-                DataState.Success(response.bodyAsText())
-            } catch (e: Exception) {
-                DataState.Error(e.toMifosExceptionSuspend(), null)
-            }
-        }
+    ): DataState<String> = safeCall {
+        dataManager.guarantorApi
+            .updateGuarantor(payload?.toDto(), loanId!!, guarantorId!!)
+            .bodyAsText()
     }
 
-    override suspend fun deleteGuarantor(loanId: Long?, guarantorId: Long?): DataState<String> {
-        return withContext(ioDispatcher) {
-            try {
-                val response = dataManager.guarantorApi.deleteGuarantor(loanId!!, guarantorId!!)
-                DataState.Success(response.bodyAsText())
-            } catch (e: Exception) {
-                DataState.Error(e.toMifosExceptionSuspend(), null)
-            }
-        }
+    override suspend fun deleteGuarantor(loanId: Long?, guarantorId: Long?): DataState<String> = safeCall {
+        dataManager.guarantorApi
+            .deleteGuarantor(loanId!!, guarantorId!!)
+            .bodyAsText()
     }
 
     override fun getGuarantorList(loanId: Long): Flow<DataState<List<GuarantorPayload?>?>> {
         return flow { emit(getDemoGuarantorPayloads()) }
-            .asDataStateFlow(Throwable::toMifosException)
-            .flowOn(ioDispatcher)
+            .asDataState()
 //        return dataManager.guarantorApi.getGuarantorList(loanId)
-//            .asDataStateFlow().flowOn(ioDispatcher)
+//            .asDataState()
     }
 }
 

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/GuarantorRepositoryImp.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/GuarantorRepositoryImp.kt
@@ -9,7 +9,6 @@
  */
 package org.mifos.mobile.core.data.repositoryImpl
 
-import io.ktor.client.plugins.ClientRequestException
 import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
@@ -22,7 +21,8 @@ import org.mifos.mobile.core.common.asDataStateFlow
 import org.mifos.mobile.core.data.mapper.guarantor.toModel
 import org.mifos.mobile.core.data.mapper.payloads.toDto
 import org.mifos.mobile.core.data.repository.GuarantorRepository
-import org.mifos.mobile.core.data.util.extractErrorMessage
+import org.mifos.mobile.core.data.util.toMifosException
+import org.mifos.mobile.core.data.util.toMifosExceptionSuspend
 import org.mifos.mobile.core.model.entity.guarantor.GuarantorApplicationPayload
 import org.mifos.mobile.core.model.entity.guarantor.GuarantorPayload
 import org.mifos.mobile.core.model.entity.guarantor.GuarantorTemplatePayload
@@ -36,7 +36,7 @@ class GuarantorRepositoryImp(
     override fun getGuarantorTemplate(loanId: Long?): Flow<DataState<GuarantorTemplatePayload?>> {
         return dataManager.guarantorApi.getGuarantorTemplate(loanId!!)
             .map { it.toModel() }
-            .asDataStateFlow().flowOn(ioDispatcher)
+            .asDataStateFlow(Throwable::toMifosException).flowOn(ioDispatcher)
     }
 
     override suspend fun createGuarantor(
@@ -47,9 +47,8 @@ class GuarantorRepositoryImp(
             try {
                 val response = dataManager.guarantorApi.createGuarantor(loanId!!, payload?.toDto())
                 DataState.Success(response.bodyAsText())
-            } catch (e: ClientRequestException) {
-                val errorMessage = extractErrorMessage(e.response)
-                DataState.Error(Exception(errorMessage), null)
+            } catch (e: Exception) {
+                DataState.Error(e.toMifosExceptionSuspend(), null)
             }
         }
     }
@@ -67,9 +66,8 @@ class GuarantorRepositoryImp(
                     guarantorId!!,
                 )
                 DataState.Success(response.bodyAsText())
-            } catch (e: ClientRequestException) {
-                val errorMessage = extractErrorMessage(e.response)
-                DataState.Error(Exception(errorMessage), null)
+            } catch (e: Exception) {
+                DataState.Error(e.toMifosExceptionSuspend(), null)
             }
         }
     }
@@ -79,15 +77,16 @@ class GuarantorRepositoryImp(
             try {
                 val response = dataManager.guarantorApi.deleteGuarantor(loanId!!, guarantorId!!)
                 DataState.Success(response.bodyAsText())
-            } catch (e: ClientRequestException) {
-                val errorMessage = extractErrorMessage(e.response)
-                DataState.Error(Exception(errorMessage), null)
+            } catch (e: Exception) {
+                DataState.Error(e.toMifosExceptionSuspend(), null)
             }
         }
     }
 
     override fun getGuarantorList(loanId: Long): Flow<DataState<List<GuarantorPayload?>?>> {
-        return flow { emit(getDemoGuarantorPayloads()) }.asDataStateFlow().flowOn(ioDispatcher)
+        return flow { emit(getDemoGuarantorPayloads()) }
+            .asDataStateFlow(Throwable::toMifosException)
+            .flowOn(ioDispatcher)
 //        return dataManager.guarantorApi.getGuarantorList(loanId)
 //            .asDataStateFlow().flowOn(ioDispatcher)
     }

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/HomeRepositoryImp.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/HomeRepositoryImp.kt
@@ -15,12 +15,10 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import org.mifos.mobile.core.common.DataState
-import org.mifos.mobile.core.common.asDataStateFlow
 import org.mifos.mobile.core.data.mapper.accounts.toModel
 import org.mifos.mobile.core.data.mapper.client.toModel
 import org.mifos.mobile.core.data.repository.HomeRepository
 import org.mifos.mobile.core.data.repository.NotificationRepository
-import org.mifos.mobile.core.data.util.toMifosException
 import org.mifos.mobile.core.model.entity.client.Client
 import org.mifos.mobile.core.model.entity.client.ClientAccounts
 import org.mifos.mobile.core.network.DataManager
@@ -28,23 +26,23 @@ import org.mifos.mobile.core.network.DataManager
 class HomeRepositoryImp(
     private val dataManager: DataManager,
     private val notificationRepository: NotificationRepository,
-    private val ioDispatcher: CoroutineDispatcher,
-) : HomeRepository {
+    ioDispatcher: CoroutineDispatcher,
+) : BaseRepository(ioDispatcher), HomeRepository {
 
     override fun clientAccounts(clientId: Long): Flow<DataState<ClientAccounts>> =
         dataManager.clientsApi.getClientAccounts(clientId)
             .map { it.toModel() }
-            .asDataStateFlow(Throwable::toMifosException).flowOn(ioDispatcher)
+            .asDataState()
 
     override fun currentClient(clientId: Long): Flow<DataState<Client>> {
         return dataManager.clientsApi.getClientForId(clientId)
             .map { it.toModel() }
-            .asDataStateFlow(Throwable::toMifosException).flowOn(ioDispatcher)
+            .asDataState()
     }
 
     override fun clientImage(clientId: Long): Flow<DataState<String>> {
         return dataManager.clientsApi.getClientImage(clientId)
-            .asDataStateFlow(Throwable::toMifosException)
+            .asDataState()
             .map { response ->
                 when (response) {
                     is DataState.Success -> {

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/HomeRepositoryImp.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/HomeRepositoryImp.kt
@@ -20,6 +20,7 @@ import org.mifos.mobile.core.data.mapper.accounts.toModel
 import org.mifos.mobile.core.data.mapper.client.toModel
 import org.mifos.mobile.core.data.repository.HomeRepository
 import org.mifos.mobile.core.data.repository.NotificationRepository
+import org.mifos.mobile.core.data.util.toMifosException
 import org.mifos.mobile.core.model.entity.client.Client
 import org.mifos.mobile.core.model.entity.client.ClientAccounts
 import org.mifos.mobile.core.network.DataManager
@@ -33,17 +34,17 @@ class HomeRepositoryImp(
     override fun clientAccounts(clientId: Long): Flow<DataState<ClientAccounts>> =
         dataManager.clientsApi.getClientAccounts(clientId)
             .map { it.toModel() }
-            .asDataStateFlow().flowOn(ioDispatcher)
+            .asDataStateFlow(Throwable::toMifosException).flowOn(ioDispatcher)
 
     override fun currentClient(clientId: Long): Flow<DataState<Client>> {
         return dataManager.clientsApi.getClientForId(clientId)
             .map { it.toModel() }
-            .asDataStateFlow().flowOn(ioDispatcher)
+            .asDataStateFlow(Throwable::toMifosException).flowOn(ioDispatcher)
     }
 
     override fun clientImage(clientId: Long): Flow<DataState<String>> {
         return dataManager.clientsApi.getClientImage(clientId)
-            .asDataStateFlow()
+            .asDataStateFlow(Throwable::toMifosException)
             .map { response ->
                 when (response) {
                     is DataState.Success -> {

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/LoanRepositoryImp.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/LoanRepositoryImp.kt
@@ -12,19 +12,13 @@ package org.mifos.mobile.core.data.repositoryImpl
 import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.withContext
 import org.mifos.mobile.core.common.DataState
-import org.mifos.mobile.core.common.asDataStateFlow
 import org.mifos.mobile.core.data.mapper.loan.toModel
 import org.mifos.mobile.core.data.mapper.payloads.toDto
 import org.mifos.mobile.core.data.mapper.templates.toModel
 import org.mifos.mobile.core.data.mapper.transactions.toModel
 import org.mifos.mobile.core.data.repository.LoanRepository
-import org.mifos.mobile.core.data.util.toMifosException
-import org.mifos.mobile.core.data.util.toMifosExceptionSuspend
 import org.mifos.mobile.core.model.entity.TransactionDetails
 import org.mifos.mobile.core.model.entity.accounts.loan.LoanWithAssociations
 import org.mifos.mobile.core.model.entity.accounts.loan.LoanWithdraw
@@ -33,22 +27,16 @@ import org.mifos.mobile.core.network.DataManager
 
 class LoanRepositoryImp(
     private val dataManager: DataManager,
-    private val ioDispatcher: CoroutineDispatcher,
-) : LoanRepository {
+    ioDispatcher: CoroutineDispatcher,
+) : BaseRepository(ioDispatcher), LoanRepository {
 
     override fun getLoanWithAssociations(
         associationType: String?,
         loanId: Long?,
-    ): Flow<DataState<LoanWithAssociations?>> = flow {
-        try {
-            dataManager.loanAccountsListApi.getLoanWithAssociations(loanId!!, associationType)
-                .collect { response ->
-                    emit(DataState.Success(response.toModel()))
-                }
-        } catch (exception: Exception) {
-            emit(DataState.Error(exception.toMifosException()))
-        }
-    }.flowOn(ioDispatcher)
+    ): Flow<DataState<LoanWithAssociations?>> =
+        dataManager.loanAccountsListApi.getLoanWithAssociations(loanId!!, associationType)
+            .map { response -> response.toModel() }
+            .asDataState()
 
     override fun getLoanTransactionDetails(
         loanId: Long,
@@ -57,34 +45,27 @@ class LoanRepositoryImp(
         return dataManager.loanAccountsListApi
             .getLoanTransactionDetails(loanId, transactionId)
             .map { it.toModel() }
-            .asDataStateFlow(Throwable::toMifosException)
-            .flowOn(ioDispatcher)
+            .asDataState()
     }
 
     override suspend fun withdrawLoanAccount(
         loanId: Long?,
         loanWithdraw: LoanWithdraw?,
-    ): DataState<String> {
-        return withContext(ioDispatcher) {
-            try {
-                val response =
-                    dataManager.loanAccountsListApi.withdrawLoanAccount(loanId!!, loanWithdraw?.toDto())
-                DataState.Success(response.bodyAsText())
-            } catch (e: Exception) {
-                DataState.Error(e.toMifosExceptionSuspend(), null)
-            }
-        }
+    ): DataState<String> = safeCall {
+        dataManager.loanAccountsListApi
+            .withdrawLoanAccount(loanId!!, loanWithdraw?.toDto())
+            .bodyAsText()
     }
 
     override fun template(clientId: Long?): Flow<DataState<LoanTemplate?>> {
         return dataManager.loanAccountsListApi.getLoanTemplate(clientId = clientId)
             .map { it.toModel() }
-            .asDataStateFlow(Throwable::toMifosException).flowOn(ioDispatcher)
+            .asDataState()
     }
 
     override fun getLoanTemplateByProduct(clientId: Long?, productId: Int?): Flow<DataState<LoanTemplate?>> {
         return dataManager.loanAccountsListApi.getLoanTemplateByProduct(clientId, productId)
             .map { it.toModel() }
-            .asDataStateFlow(Throwable::toMifosException).flowOn(ioDispatcher)
+            .asDataState()
     }
 }

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/LoanRepositoryImp.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/LoanRepositoryImp.kt
@@ -9,8 +9,6 @@
  */
 package org.mifos.mobile.core.data.repositoryImpl
 
-import io.ktor.client.plugins.ClientRequestException
-import io.ktor.client.plugins.ServerResponseException
 import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
@@ -18,7 +16,6 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
-import kotlinx.io.IOException
 import org.mifos.mobile.core.common.DataState
 import org.mifos.mobile.core.common.asDataStateFlow
 import org.mifos.mobile.core.data.mapper.loan.toModel
@@ -26,7 +23,8 @@ import org.mifos.mobile.core.data.mapper.payloads.toDto
 import org.mifos.mobile.core.data.mapper.templates.toModel
 import org.mifos.mobile.core.data.mapper.transactions.toModel
 import org.mifos.mobile.core.data.repository.LoanRepository
-import org.mifos.mobile.core.data.util.extractErrorMessage
+import org.mifos.mobile.core.data.util.toMifosException
+import org.mifos.mobile.core.data.util.toMifosExceptionSuspend
 import org.mifos.mobile.core.model.entity.TransactionDetails
 import org.mifos.mobile.core.model.entity.accounts.loan.LoanWithAssociations
 import org.mifos.mobile.core.model.entity.accounts.loan.LoanWithdraw
@@ -48,7 +46,7 @@ class LoanRepositoryImp(
                     emit(DataState.Success(response.toModel()))
                 }
         } catch (exception: Exception) {
-            emit(DataState.Error(exception))
+            emit(DataState.Error(exception.toMifosException()))
         }
     }.flowOn(ioDispatcher)
 
@@ -59,7 +57,7 @@ class LoanRepositoryImp(
         return dataManager.loanAccountsListApi
             .getLoanTransactionDetails(loanId, transactionId)
             .map { it.toModel() }
-            .asDataStateFlow()
+            .asDataStateFlow(Throwable::toMifosException)
             .flowOn(ioDispatcher)
     }
 
@@ -72,13 +70,8 @@ class LoanRepositoryImp(
                 val response =
                     dataManager.loanAccountsListApi.withdrawLoanAccount(loanId!!, loanWithdraw?.toDto())
                 DataState.Success(response.bodyAsText())
-            } catch (e: ClientRequestException) {
-                val errorMessage = extractErrorMessage(e.response)
-                DataState.Error(Exception(errorMessage), null)
-            } catch (e: IOException) {
-                DataState.Error(Exception("Network error", e), null)
-            } catch (e: ServerResponseException) {
-                DataState.Error(Exception("Server error", e), null)
+            } catch (e: Exception) {
+                DataState.Error(e.toMifosExceptionSuspend(), null)
             }
         }
     }
@@ -86,12 +79,12 @@ class LoanRepositoryImp(
     override fun template(clientId: Long?): Flow<DataState<LoanTemplate?>> {
         return dataManager.loanAccountsListApi.getLoanTemplate(clientId = clientId)
             .map { it.toModel() }
-            .asDataStateFlow().flowOn(ioDispatcher)
+            .asDataStateFlow(Throwable::toMifosException).flowOn(ioDispatcher)
     }
 
     override fun getLoanTemplateByProduct(clientId: Long?, productId: Int?): Flow<DataState<LoanTemplate?>> {
         return dataManager.loanAccountsListApi.getLoanTemplateByProduct(clientId, productId)
             .map { it.toModel() }
-            .asDataStateFlow().flowOn(ioDispatcher)
+            .asDataStateFlow(Throwable::toMifosException).flowOn(ioDispatcher)
     }
 }

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/NotificationRepositoryImp.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/NotificationRepositoryImp.kt
@@ -19,8 +19,8 @@ import org.mifos.mobile.core.model.entity.MifosNotification
 
 class NotificationRepositoryImp(
 //    private val notificationDao: MifosNotificationDao,
-    private val ioDispatcher: CoroutineDispatcher,
-) : NotificationRepository {
+    ioDispatcher: CoroutineDispatcher,
+) : BaseRepository(ioDispatcher), NotificationRepository {
 
     override fun loadNotifications(): Flow<DataState<List<MifosNotification>>> {
 //        return notificationDao.getNotifications()

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/RecentTransactionRepositoryImp.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/RecentTransactionRepositoryImp.kt
@@ -18,6 +18,7 @@ import org.mifos.mobile.core.common.asDataStateFlow
 import org.mifos.mobile.core.data.mapper.toPageModel
 import org.mifos.mobile.core.data.mapper.transactions.toRecentTransactionModel
 import org.mifos.mobile.core.data.repository.RecentTransactionRepository
+import org.mifos.mobile.core.data.util.toMifosException
 import org.mifos.mobile.core.model.entity.Page
 import org.mifos.mobile.core.model.entity.Transaction
 import org.mifos.mobile.core.network.DataManager
@@ -41,6 +42,6 @@ class RecentTransactionRepositoryImp(
                     dto.toRecentTransactionModel()
                 }
             }
-            .asDataStateFlow().flowOn(ioDispatcher)
+            .asDataStateFlow(Throwable::toMifosException).flowOn(ioDispatcher)
     }
 }

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/RecentTransactionRepositoryImp.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/RecentTransactionRepositoryImp.kt
@@ -11,22 +11,19 @@ package org.mifos.mobile.core.data.repositoryImpl
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import org.mifos.mobile.core.common.DataState
-import org.mifos.mobile.core.common.asDataStateFlow
 import org.mifos.mobile.core.data.mapper.toPageModel
 import org.mifos.mobile.core.data.mapper.transactions.toRecentTransactionModel
 import org.mifos.mobile.core.data.repository.RecentTransactionRepository
-import org.mifos.mobile.core.data.util.toMifosException
 import org.mifos.mobile.core.model.entity.Page
 import org.mifos.mobile.core.model.entity.Transaction
 import org.mifos.mobile.core.network.DataManager
 
 class RecentTransactionRepositoryImp(
     private val dataManager: DataManager,
-    private val ioDispatcher: CoroutineDispatcher,
-) : RecentTransactionRepository {
+    ioDispatcher: CoroutineDispatcher,
+) : BaseRepository(ioDispatcher), RecentTransactionRepository {
     override fun recentTransactions(
         clientId: Long?,
         offset: Int?,
@@ -42,6 +39,6 @@ class RecentTransactionRepositoryImp(
                     dto.toRecentTransactionModel()
                 }
             }
-            .asDataStateFlow(Throwable::toMifosException).flowOn(ioDispatcher)
+            .asDataState()
     }
 }

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/ReviewLoanApplicationRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/ReviewLoanApplicationRepositoryImpl.kt
@@ -9,15 +9,12 @@
  */
 package org.mifos.mobile.core.data.repositoryImpl
 
-import io.ktor.client.plugins.ClientRequestException
-import io.ktor.client.plugins.ServerResponseException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
-import kotlinx.io.IOException
 import org.mifos.mobile.core.common.DataState
 import org.mifos.mobile.core.data.mapper.payloads.toDto
 import org.mifos.mobile.core.data.repository.ReviewLoanApplicationRepository
-import org.mifos.mobile.core.data.util.extractErrorMessage
+import org.mifos.mobile.core.data.util.toMifosExceptionSuspend
 import org.mifos.mobile.core.model.entity.payload.LoansPayload
 import org.mifos.mobile.core.model.enums.LoanState
 import org.mifos.mobile.core.network.DataManager
@@ -48,13 +45,8 @@ class ReviewLoanApplicationRepositoryImpl(
                         return@withContext DataState.Success("Loan Updated Successfully")
                     }
                 }
-            } catch (e: ClientRequestException) {
-                val errorMessage = extractErrorMessage(e.response)
-                DataState.Error(Exception(errorMessage), null)
-            } catch (e: IOException) {
-                DataState.Error(Exception("Network error", e), null)
-            } catch (e: ServerResponseException) {
-                DataState.Error(Exception("Server error", e), null)
+            } catch (e: Exception) {
+                DataState.Error(e.toMifosExceptionSuspend(), null)
             }
         }
     }

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/ReviewLoanApplicationRepositoryImpl.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/ReviewLoanApplicationRepositoryImpl.kt
@@ -10,43 +10,33 @@
 package org.mifos.mobile.core.data.repositoryImpl
 
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.withContext
 import org.mifos.mobile.core.common.DataState
 import org.mifos.mobile.core.data.mapper.payloads.toDto
 import org.mifos.mobile.core.data.repository.ReviewLoanApplicationRepository
-import org.mifos.mobile.core.data.util.toMifosExceptionSuspend
 import org.mifos.mobile.core.model.entity.payload.LoansPayload
 import org.mifos.mobile.core.model.enums.LoanState
 import org.mifos.mobile.core.network.DataManager
 
 class ReviewLoanApplicationRepositoryImpl(
     private val dataManager: DataManager,
-    private val ioDispatcher: CoroutineDispatcher,
-) : ReviewLoanApplicationRepository {
+    ioDispatcher: CoroutineDispatcher,
+) : BaseRepository(ioDispatcher), ReviewLoanApplicationRepository {
 
     override suspend fun submitLoan(
         loanState: LoanState,
         loansPayload: LoansPayload,
         loanId: Long,
-    ): DataState<String> {
-        return withContext(ioDispatcher) {
-            try {
-                when (loanState) {
-                    LoanState.CREATE -> {
-                        val response =
-                            dataManager.loanAccountsListApi.createLoansAccount(loansPayload.toDto())
-                        println("response $response")
-                        return@withContext DataState.Success("Loan Created Successfully")
-                    }
-                    LoanState.UPDATE -> {
-                        val response =
-                            dataManager.loanAccountsListApi.updateLoanAccount(loanId, loansPayload.toDto())
-                        println("response $response")
-                        return@withContext DataState.Success("Loan Updated Successfully")
-                    }
-                }
-            } catch (e: Exception) {
-                DataState.Error(e.toMifosExceptionSuspend(), null)
+    ): DataState<String> = safeCall {
+        when (loanState) {
+            LoanState.CREATE -> {
+                val response = dataManager.loanAccountsListApi.createLoansAccount(loansPayload.toDto())
+                println("response $response")
+                "Loan Created Successfully"
+            }
+            LoanState.UPDATE -> {
+                val response = dataManager.loanAccountsListApi.updateLoanAccount(loanId, loansPayload.toDto())
+                println("response $response")
+                "Loan Updated Successfully"
             }
         }
     }

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/SavingsAccountRepositoryImp.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/SavingsAccountRepositoryImp.kt
@@ -9,15 +9,12 @@
  */
 package org.mifos.mobile.core.data.repositoryImpl
 
-import io.ktor.client.plugins.ClientRequestException
-import io.ktor.client.plugins.ServerResponseException
 import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
-import kotlinx.io.IOException
 import org.mifos.mobile.core.common.DataState
 import org.mifos.mobile.core.common.asDataStateFlow
 import org.mifos.mobile.core.data.mapper.payloads.toDto
@@ -25,7 +22,8 @@ import org.mifos.mobile.core.data.mapper.savings.toModel
 import org.mifos.mobile.core.data.mapper.templates.toModel
 import org.mifos.mobile.core.data.mapper.transactions.toModel
 import org.mifos.mobile.core.data.repository.SavingsAccountRepository
-import org.mifos.mobile.core.data.util.extractErrorMessage
+import org.mifos.mobile.core.data.util.toMifosException
+import org.mifos.mobile.core.data.util.toMifosExceptionSuspend
 import org.mifos.mobile.core.model.entity.TransactionDetails
 import org.mifos.mobile.core.model.entity.accounts.savings.SavingsAccountApplicationPayload
 import org.mifos.mobile.core.model.entity.accounts.savings.SavingsAccountUpdatePayload
@@ -49,7 +47,7 @@ class SavingsAccountRepositoryImp(
             associationType,
         )
             .map { it.toModel() }
-            .asDataStateFlow().flowOn(ioDispatcher)
+            .asDataStateFlow(Throwable::toMifosException).flowOn(ioDispatcher)
     }
 
     override fun getSavingsAccountTransactionDetails(
@@ -59,7 +57,7 @@ class SavingsAccountRepositoryImp(
         return dataManager.savingAccountsListApi
             .getSavingsAccountTransactionDetails(accountId, transactionId)
             .map { it.toModel() }
-            .asDataStateFlow()
+            .asDataStateFlow(Throwable::toMifosException)
             .flowOn(ioDispatcher)
     }
 
@@ -68,7 +66,7 @@ class SavingsAccountRepositoryImp(
     ): Flow<DataState<SavingsAccountTemplate>> {
         return dataManager.savingAccountsListApi.getSavingsAccountApplicationTemplate(clientId)
             .map { it.toModel() }
-            .asDataStateFlow().flowOn(ioDispatcher)
+            .asDataStateFlow(Throwable::toMifosException).flowOn(ioDispatcher)
     }
 
     override fun getSavingAccountApplicationTemplateByProduct(
@@ -80,7 +78,7 @@ class SavingsAccountRepositoryImp(
             productId,
         )
             .map { it.toModel() }
-            .asDataStateFlow().flowOn(ioDispatcher)
+            .asDataStateFlow(Throwable::toMifosException).flowOn(ioDispatcher)
     }
 
     override suspend fun submitSavingAccountApplication(
@@ -91,13 +89,8 @@ class SavingsAccountRepositoryImp(
                 val response =
                     dataManager.savingAccountsListApi.submitSavingAccountApplication(payload?.toDto())
                 DataState.Success(response.bodyAsText())
-            } catch (e: ClientRequestException) {
-                val errorMessage = extractErrorMessage(e.response)
-                DataState.Error(Exception(errorMessage), null)
-            } catch (e: IOException) {
-                DataState.Error(Exception("Network error", e), null)
-            } catch (e: ServerResponseException) {
-                DataState.Error(Exception("Server error", e), null)
+            } catch (e: Exception) {
+                DataState.Error(e.toMifosExceptionSuspend(), null)
             }
         }
     }
@@ -114,13 +107,8 @@ class SavingsAccountRepositoryImp(
                         payload?.toDto(),
                     )
                 DataState.Success(response.bodyAsText())
-            } catch (e: ClientRequestException) {
-                val errorMessage = extractErrorMessage(e.response)
-                DataState.Error(Exception(errorMessage), null)
-            } catch (e: IOException) {
-                DataState.Error(Exception("Network error", e), null)
-            } catch (e: ServerResponseException) {
-                DataState.Error(Exception("Server error", e), null)
+            } catch (e: Exception) {
+                DataState.Error(e.toMifosExceptionSuspend(), null)
             }
         }
     }
@@ -137,13 +125,8 @@ class SavingsAccountRepositoryImp(
                         payload?.toDto(),
                     )
                 DataState.Success(response.bodyAsText())
-            } catch (e: ClientRequestException) {
-                val errorMessage = extractErrorMessage(e.response)
-                DataState.Error(Exception(errorMessage), null)
-            } catch (e: IOException) {
-                DataState.Error(Exception("Network error", e), null)
-            } catch (e: ServerResponseException) {
-                DataState.Error(Exception("Server error", e), null)
+            } catch (e: Exception) {
+                DataState.Error(e.toMifosExceptionSuspend(), null)
             }
         }
     }
@@ -154,6 +137,6 @@ class SavingsAccountRepositoryImp(
     ): Flow<DataState<AccountOptionsTemplate>> {
         return dataManager.savingAccountsListApi.accountTransferTemplate(accountId!!, accountType)
             .map { it.toModel() }
-            .asDataStateFlow().flowOn(ioDispatcher)
+            .asDataStateFlow(Throwable::toMifosException).flowOn(ioDispatcher)
     }
 }

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/SavingsAccountRepositoryImp.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/SavingsAccountRepositoryImp.kt
@@ -12,18 +12,13 @@ package org.mifos.mobile.core.data.repositoryImpl
 import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.withContext
 import org.mifos.mobile.core.common.DataState
-import org.mifos.mobile.core.common.asDataStateFlow
 import org.mifos.mobile.core.data.mapper.payloads.toDto
 import org.mifos.mobile.core.data.mapper.savings.toModel
 import org.mifos.mobile.core.data.mapper.templates.toModel
 import org.mifos.mobile.core.data.mapper.transactions.toModel
 import org.mifos.mobile.core.data.repository.SavingsAccountRepository
-import org.mifos.mobile.core.data.util.toMifosException
-import org.mifos.mobile.core.data.util.toMifosExceptionSuspend
 import org.mifos.mobile.core.model.entity.TransactionDetails
 import org.mifos.mobile.core.model.entity.accounts.savings.SavingsAccountApplicationPayload
 import org.mifos.mobile.core.model.entity.accounts.savings.SavingsAccountUpdatePayload
@@ -35,8 +30,8 @@ import org.mifos.mobile.core.network.DataManager
 
 class SavingsAccountRepositoryImp(
     private val dataManager: DataManager,
-    private val ioDispatcher: CoroutineDispatcher,
-) : SavingsAccountRepository {
+    ioDispatcher: CoroutineDispatcher,
+) : BaseRepository(ioDispatcher), SavingsAccountRepository {
 
     override fun getSavingsWithAssociations(
         accountId: Long?,
@@ -47,7 +42,7 @@ class SavingsAccountRepositoryImp(
             associationType,
         )
             .map { it.toModel() }
-            .asDataStateFlow(Throwable::toMifosException).flowOn(ioDispatcher)
+            .asDataState()
     }
 
     override fun getSavingsAccountTransactionDetails(
@@ -57,8 +52,7 @@ class SavingsAccountRepositoryImp(
         return dataManager.savingAccountsListApi
             .getSavingsAccountTransactionDetails(accountId, transactionId)
             .map { it.toModel() }
-            .asDataStateFlow(Throwable::toMifosException)
-            .flowOn(ioDispatcher)
+            .asDataState()
     }
 
     override fun getSavingAccountApplicationTemplate(
@@ -66,7 +60,7 @@ class SavingsAccountRepositoryImp(
     ): Flow<DataState<SavingsAccountTemplate>> {
         return dataManager.savingAccountsListApi.getSavingsAccountApplicationTemplate(clientId)
             .map { it.toModel() }
-            .asDataStateFlow(Throwable::toMifosException).flowOn(ioDispatcher)
+            .asDataState()
     }
 
     override fun getSavingAccountApplicationTemplateByProduct(
@@ -78,57 +72,33 @@ class SavingsAccountRepositoryImp(
             productId,
         )
             .map { it.toModel() }
-            .asDataStateFlow(Throwable::toMifosException).flowOn(ioDispatcher)
+            .asDataState()
     }
 
     override suspend fun submitSavingAccountApplication(
         payload: SavingsAccountApplicationPayload?,
-    ): DataState<String> {
-        return withContext(ioDispatcher) {
-            try {
-                val response =
-                    dataManager.savingAccountsListApi.submitSavingAccountApplication(payload?.toDto())
-                DataState.Success(response.bodyAsText())
-            } catch (e: Exception) {
-                DataState.Error(e.toMifosExceptionSuspend(), null)
-            }
-        }
+    ): DataState<String> = safeCall {
+        dataManager.savingAccountsListApi
+            .submitSavingAccountApplication(payload?.toDto())
+            .bodyAsText()
     }
 
     override suspend fun updateSavingsAccount(
         accountId: Long?,
         payload: SavingsAccountUpdatePayload?,
-    ): DataState<String> {
-        return withContext(ioDispatcher) {
-            try {
-                val response =
-                    dataManager.savingAccountsListApi.updateSavingsAccountUpdate(
-                        accountId!!,
-                        payload?.toDto(),
-                    )
-                DataState.Success(response.bodyAsText())
-            } catch (e: Exception) {
-                DataState.Error(e.toMifosExceptionSuspend(), null)
-            }
-        }
+    ): DataState<String> = safeCall {
+        dataManager.savingAccountsListApi
+            .updateSavingsAccountUpdate(accountId!!, payload?.toDto())
+            .bodyAsText()
     }
 
     override suspend fun submitWithdrawSavingsAccount(
         accountId: Long?,
         payload: SavingsAccountWithdrawPayload?,
-    ): DataState<String> {
-        return withContext(ioDispatcher) {
-            try {
-                val response =
-                    dataManager.savingAccountsListApi.submitWithdrawSavingsAccount(
-                        accountId!!,
-                        payload?.toDto(),
-                    )
-                DataState.Success(response.bodyAsText())
-            } catch (e: Exception) {
-                DataState.Error(e.toMifosExceptionSuspend(), null)
-            }
-        }
+    ): DataState<String> = safeCall {
+        dataManager.savingAccountsListApi
+            .submitWithdrawSavingsAccount(accountId!!, payload?.toDto())
+            .bodyAsText()
     }
 
     override fun accountTransferTemplate(
@@ -137,6 +107,6 @@ class SavingsAccountRepositoryImp(
     ): Flow<DataState<AccountOptionsTemplate>> {
         return dataManager.savingAccountsListApi.accountTransferTemplate(accountId!!, accountType)
             .map { it.toModel() }
-            .asDataStateFlow(Throwable::toMifosException).flowOn(ioDispatcher)
+            .asDataState()
     }
 }

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/ShareAccountRepositoryImp.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/ShareAccountRepositoryImp.kt
@@ -12,18 +12,12 @@ package org.mifos.mobile.core.data.repositoryImpl
 import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.withContext
 import org.mifos.mobile.core.common.DataState
-import org.mifos.mobile.core.common.asDataStateFlow
 import org.mifos.mobile.core.data.mapper.payloads.toDto
 import org.mifos.mobile.core.data.mapper.share.toModel
 import org.mifos.mobile.core.data.mapper.toPageModel
 import org.mifos.mobile.core.data.repository.ShareAccountRepository
-import org.mifos.mobile.core.data.util.toMifosException
-import org.mifos.mobile.core.data.util.toMifosExceptionSuspend
 import org.mifos.mobile.core.model.entity.Page
 import org.mifos.mobile.core.model.entity.accounts.share.ShareAccountWithAssociations
 import org.mifos.mobile.core.model.entity.payload.ShareApplicationPayload
@@ -33,20 +27,17 @@ import org.mifos.mobile.core.network.DataManager
 
 class ShareAccountRepositoryImp(
     private val dataManager: DataManager,
-    private val ioDispatcher: CoroutineDispatcher,
-) : ShareAccountRepository {
+    ioDispatcher: CoroutineDispatcher,
+) : BaseRepository(ioDispatcher), ShareAccountRepository {
 
     override fun getShareProducts(clientId: Long?): Flow<DataState<Page<ShareProduct>>> {
         return dataManager.shareAccountApi.getShareProducts(clientId)
             .map { response ->
-                DataState.Success(
-                    response.toPageModel { dto ->
-                        dto.toModel()
-                    },
-                )
+                response.toPageModel { dto ->
+                    dto.toModel()
+                }
             }
-            .catch { exception -> DataState.Error(exception.toMifosException(), null) }
-            .flowOn(ioDispatcher)
+            .asDataState()
     }
 
     override fun getShareProductById(
@@ -55,25 +46,20 @@ class ShareAccountRepositoryImp(
     ): Flow<DataState<ShareProductDetails>> {
         return dataManager.shareAccountApi.getShareProductById(productId, clientId)
             .map { it.toModel() }
-            .asDataStateFlow(Throwable::toMifosException).flowOn(ioDispatcher)
+            .asDataState()
     }
 
-    override suspend fun submitShareApplication(payload: ShareApplicationPayload?): DataState<String> {
-        return withContext(ioDispatcher) {
-            try {
-                val response =
-                    dataManager.shareAccountApi.submitShareApplication(payload?.toDto())
-                DataState.Success(response.bodyAsText())
-            } catch (e: Exception) {
-                DataState.Error(e.toMifosExceptionSuspend(), null)
-            }
-        }
+    override suspend fun submitShareApplication(
+        payload: ShareApplicationPayload?,
+    ): DataState<String> = safeCall {
+        dataManager.shareAccountApi
+            .submitShareApplication(payload?.toDto())
+            .bodyAsText()
     }
 
     override fun getShareAccountDetails(accountId: Long): Flow<DataState<ShareAccountWithAssociations>> {
         return dataManager.shareAccountApi.getShareAccountDetails(accountId)
             .map { it.toModel() }
-            .asDataStateFlow(Throwable::toMifosException)
-            .flowOn(ioDispatcher)
+            .asDataState()
     }
 }

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/ShareAccountRepositoryImp.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/ShareAccountRepositoryImp.kt
@@ -9,8 +9,6 @@
  */
 package org.mifos.mobile.core.data.repositoryImpl
 
-import io.ktor.client.plugins.ClientRequestException
-import io.ktor.client.plugins.ServerResponseException
 import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
@@ -18,14 +16,14 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
-import kotlinx.io.IOException
 import org.mifos.mobile.core.common.DataState
 import org.mifos.mobile.core.common.asDataStateFlow
 import org.mifos.mobile.core.data.mapper.payloads.toDto
 import org.mifos.mobile.core.data.mapper.share.toModel
 import org.mifos.mobile.core.data.mapper.toPageModel
 import org.mifos.mobile.core.data.repository.ShareAccountRepository
-import org.mifos.mobile.core.data.util.extractErrorMessage
+import org.mifos.mobile.core.data.util.toMifosException
+import org.mifos.mobile.core.data.util.toMifosExceptionSuspend
 import org.mifos.mobile.core.model.entity.Page
 import org.mifos.mobile.core.model.entity.accounts.share.ShareAccountWithAssociations
 import org.mifos.mobile.core.model.entity.payload.ShareApplicationPayload
@@ -47,7 +45,7 @@ class ShareAccountRepositoryImp(
                     },
                 )
             }
-            .catch { exception -> DataState.Error(exception, exception.message) }
+            .catch { exception -> DataState.Error(exception.toMifosException(), null) }
             .flowOn(ioDispatcher)
     }
 
@@ -57,7 +55,7 @@ class ShareAccountRepositoryImp(
     ): Flow<DataState<ShareProductDetails>> {
         return dataManager.shareAccountApi.getShareProductById(productId, clientId)
             .map { it.toModel() }
-            .asDataStateFlow().flowOn(ioDispatcher)
+            .asDataStateFlow(Throwable::toMifosException).flowOn(ioDispatcher)
     }
 
     override suspend fun submitShareApplication(payload: ShareApplicationPayload?): DataState<String> {
@@ -66,13 +64,8 @@ class ShareAccountRepositoryImp(
                 val response =
                     dataManager.shareAccountApi.submitShareApplication(payload?.toDto())
                 DataState.Success(response.bodyAsText())
-            } catch (e: ClientRequestException) {
-                val errorMessage = extractErrorMessage(e.response)
-                DataState.Error(Exception(errorMessage), null)
-            } catch (e: IOException) {
-                DataState.Error(Exception("Network error", e), null)
-            } catch (e: ServerResponseException) {
-                DataState.Error(Exception("Server error", e), null)
+            } catch (e: Exception) {
+                DataState.Error(e.toMifosExceptionSuspend(), null)
             }
         }
     }
@@ -80,7 +73,7 @@ class ShareAccountRepositoryImp(
     override fun getShareAccountDetails(accountId: Long): Flow<DataState<ShareAccountWithAssociations>> {
         return dataManager.shareAccountApi.getShareAccountDetails(accountId)
             .map { it.toModel() }
-            .asDataStateFlow()
+            .asDataStateFlow(Throwable::toMifosException)
             .flowOn(ioDispatcher)
     }
 }

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/ThirdPartyTransferRepositoryImp.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/ThirdPartyTransferRepositoryImp.kt
@@ -11,23 +11,20 @@ package org.mifos.mobile.core.data.repositoryImpl
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import org.mifos.mobile.core.common.DataState
-import org.mifos.mobile.core.common.asDataStateFlow
 import org.mifos.mobile.core.data.mapper.templates.toModel
 import org.mifos.mobile.core.data.repository.ThirdPartyTransferRepository
-import org.mifos.mobile.core.data.util.toMifosException
 import org.mifos.mobile.core.model.entity.templates.account.AccountOptionsTemplate
 import org.mifos.mobile.core.network.DataManager
 
 class ThirdPartyTransferRepositoryImp(
     private val dataManager: DataManager,
-    private val ioDispatcher: CoroutineDispatcher,
-) : ThirdPartyTransferRepository {
+    ioDispatcher: CoroutineDispatcher,
+) : BaseRepository(ioDispatcher), ThirdPartyTransferRepository {
     override fun thirdPartyTransferTemplate(): Flow<DataState<AccountOptionsTemplate>> {
         return dataManager.thirdPartyTransferApi.accountTransferTemplate()
             .map { it.toModel() }
-            .asDataStateFlow(Throwable::toMifosException).flowOn(ioDispatcher)
+            .asDataState()
     }
 }

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/ThirdPartyTransferRepositoryImp.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/ThirdPartyTransferRepositoryImp.kt
@@ -17,6 +17,7 @@ import org.mifos.mobile.core.common.DataState
 import org.mifos.mobile.core.common.asDataStateFlow
 import org.mifos.mobile.core.data.mapper.templates.toModel
 import org.mifos.mobile.core.data.repository.ThirdPartyTransferRepository
+import org.mifos.mobile.core.data.util.toMifosException
 import org.mifos.mobile.core.model.entity.templates.account.AccountOptionsTemplate
 import org.mifos.mobile.core.network.DataManager
 
@@ -27,6 +28,6 @@ class ThirdPartyTransferRepositoryImp(
     override fun thirdPartyTransferTemplate(): Flow<DataState<AccountOptionsTemplate>> {
         return dataManager.thirdPartyTransferApi.accountTransferTemplate()
             .map { it.toModel() }
-            .asDataStateFlow().flowOn(ioDispatcher)
+            .asDataStateFlow(Throwable::toMifosException).flowOn(ioDispatcher)
     }
 }

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/TransferRepositoryImp.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/TransferRepositoryImp.kt
@@ -9,17 +9,14 @@
  */
 package org.mifos.mobile.core.data.repositoryImpl
 
-import io.ktor.client.plugins.ClientRequestException
-import io.ktor.client.plugins.ServerResponseException
 import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
-import kotlinx.io.IOException
 import kotlinx.serialization.json.Json
 import org.mifos.mobile.core.common.DataState
 import org.mifos.mobile.core.data.mapper.payloads.toDto
 import org.mifos.mobile.core.data.repository.TransferRepository
-import org.mifos.mobile.core.data.util.extractErrorMessage
+import org.mifos.mobile.core.data.util.toMifosExceptionSuspend
 import org.mifos.mobile.core.model.entity.TransferResponse
 import org.mifos.mobile.core.model.entity.payload.TransferPayload
 import org.mifos.mobile.core.model.enums.TransferType
@@ -44,13 +41,8 @@ class TransferRepositoryImp(
 
                 val transferResponse = Json.decodeFromString<TransferResponse>(response.bodyAsText())
                 DataState.Success(transferResponse.resourceId.toString())
-            } catch (e: ClientRequestException) {
-                val errorMessage = extractErrorMessage(e.response)
-                DataState.Error(Exception(errorMessage), null)
-            } catch (e: IOException) {
-                DataState.Error(Exception("Network error", e), null)
-            } catch (e: ServerResponseException) {
-                DataState.Error(Exception("Server error", e), null)
+            } catch (e: Exception) {
+                DataState.Error(e.toMifosExceptionSuspend(), null)
             }
         }
     }

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/TransferRepositoryImp.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/TransferRepositoryImp.kt
@@ -11,12 +11,10 @@ package org.mifos.mobile.core.data.repositoryImpl
 
 import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import org.mifos.mobile.core.common.DataState
 import org.mifos.mobile.core.data.mapper.payloads.toDto
 import org.mifos.mobile.core.data.repository.TransferRepository
-import org.mifos.mobile.core.data.util.toMifosExceptionSuspend
 import org.mifos.mobile.core.model.entity.TransferResponse
 import org.mifos.mobile.core.model.entity.payload.TransferPayload
 import org.mifos.mobile.core.model.enums.TransferType
@@ -24,26 +22,20 @@ import org.mifos.mobile.core.network.DataManager
 
 class TransferRepositoryImp(
     private val dataManager: DataManager,
-    private val ioDispatcher: CoroutineDispatcher,
-) : TransferRepository {
+    ioDispatcher: CoroutineDispatcher,
+) : BaseRepository(ioDispatcher), TransferRepository {
     override suspend fun makeTransfer(
         payload: TransferPayload,
         transferType: TransferType?,
-    ): DataState<String> {
-        return withContext(ioDispatcher) {
-            try {
-                val response = when (transferType) {
-                    TransferType.SELF ->
-                        dataManager.savingAccountsListApi.makeTransfer(payload.toDto())
-                    else ->
-                        dataManager.thirdPartyTransferApi.makeTransfer(payload.toDto())
-                }
-
-                val transferResponse = Json.decodeFromString<TransferResponse>(response.bodyAsText())
-                DataState.Success(transferResponse.resourceId.toString())
-            } catch (e: Exception) {
-                DataState.Error(e.toMifosExceptionSuspend(), null)
-            }
+    ): DataState<String> = safeCall {
+        val response = when (transferType) {
+            TransferType.SELF ->
+                dataManager.savingAccountsListApi.makeTransfer(payload.toDto())
+            else ->
+                dataManager.thirdPartyTransferApi.makeTransfer(payload.toDto())
         }
+
+        val transferResponse = Json.decodeFromString<TransferResponse>(response.bodyAsText())
+        transferResponse.resourceId.toString()
     }
 }

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/UserAuthRepositoryImp.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/UserAuthRepositoryImp.kt
@@ -11,13 +11,11 @@ package org.mifos.mobile.core.data.repositoryImpl
 
 import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.withContext
 import org.mifos.mobile.core.common.DataState
 import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.mapper.auth.toModel
 import org.mifos.mobile.core.data.mapper.payloads.toDto
 import org.mifos.mobile.core.data.repository.UserAuthRepository
-import org.mifos.mobile.core.data.util.toMifosExceptionSuspend
 import org.mifos.mobile.core.model.entity.UpdatePasswordPayload
 import org.mifos.mobile.core.model.entity.User
 import org.mifos.mobile.core.model.entity.payload.LoginPayload
@@ -27,80 +25,59 @@ import org.mifos.mobile.core.network.DataManager
 
 class UserAuthRepositoryImp(
     private val dataManager: DataManager,
-    private val ioDispatcher: CoroutineDispatcher,
-) : UserAuthRepository {
+    ioDispatcher: CoroutineDispatcher,
+) : BaseRepository(ioDispatcher), UserAuthRepository {
 
     override suspend fun registerUser(
         registerPayload: RegisterPayload,
-    ): DataState<String> {
-        return withContext(ioDispatcher) {
-            try {
-                val response = dataManager.registrationApi.registerUser(registerPayload.toDto())
-                DataState.Success(response.bodyAsText())
-            } catch (e: Exception) {
-                DataState.Error(e.toMifosExceptionSuspend(), null)
-            }
-        }
+    ): DataState<String> = safeCall {
+        dataManager.registrationApi
+            .registerUser(registerPayload.toDto())
+            .bodyAsText()
     }
 
-    override suspend fun login(username: String, password: String): DataState<User> {
+    override suspend fun login(username: String, password: String): DataState<User> = safeCall {
         val loginPayload = LoginPayload(
             username = username,
             password = password,
         ).toDto()
 
-        return try {
-            withContext(ioDispatcher) {
-                val user = dataManager.authenticationApi
-                    .authenticate(loginPayload)
-                    .toModel()
+        val user = dataManager.authenticationApi
+            .authenticate(loginPayload)
+            .toModel()
 
-                if (user.base64EncodedAuthenticationKey != null) {
-                    DataState.Success(user)
-                } else {
-                    DataState.Error(MifosException.ClientError("Invalid Credentials"), null)
-                }
-            }
-        } catch (e: Exception) {
-            DataState.Error(e.toMifosExceptionSuspend(), null)
+        if (user.base64EncodedAuthenticationKey != null) {
+            user
+        } else {
+            throw MifosException.ClientError("Invalid Credentials")
         }
     }
 
     override suspend fun verifyUser(
         authenticationToken: String?,
         requestId: String?,
-    ): DataState<String> {
+    ): DataState<String> = safeCall {
         val userVerify = UserVerify(
             authenticationToken = authenticationToken,
             requestId = requestId,
         ).toDto()
 
-        return withContext(ioDispatcher) {
-            try {
-                val response = dataManager.registrationApi.verifyUser(userVerify)
-                DataState.Success(response.bodyAsText())
-            } catch (e: Exception) {
-                DataState.Error(e.toMifosExceptionSuspend(), null)
-            }
-        }
+        dataManager.registrationApi
+            .verifyUser(userVerify)
+            .bodyAsText()
     }
 
     override suspend fun updateAccountPassword(
         newPassword: String,
         confirmPassword: String,
-    ): DataState<String> {
+    ): DataState<String> = safeCall {
         val payload = UpdatePasswordPayload(
             password = newPassword,
             repeatPassword = confirmPassword,
         ).toDto()
 
-        return withContext(ioDispatcher) {
-            try {
-                val response = dataManager.userDetailsApi.updateAccountPassword(payload)
-                DataState.Success(response.bodyAsText())
-            } catch (e: Exception) {
-                DataState.Error(e.toMifosExceptionSuspend(), null)
-            }
-        }
+        dataManager.userDetailsApi
+            .updateAccountPassword(payload)
+            .bodyAsText()
     }
 }

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/UserAuthRepositoryImp.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/UserAuthRepositoryImp.kt
@@ -9,17 +9,15 @@
  */
 package org.mifos.mobile.core.data.repositoryImpl
 
-import io.ktor.client.plugins.ClientRequestException
-import io.ktor.client.plugins.ServerResponseException
 import io.ktor.client.statement.bodyAsText
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
-import kotlinx.io.IOException
 import org.mifos.mobile.core.common.DataState
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.mapper.auth.toModel
 import org.mifos.mobile.core.data.mapper.payloads.toDto
 import org.mifos.mobile.core.data.repository.UserAuthRepository
-import org.mifos.mobile.core.data.util.extractErrorMessage
+import org.mifos.mobile.core.data.util.toMifosExceptionSuspend
 import org.mifos.mobile.core.model.entity.UpdatePasswordPayload
 import org.mifos.mobile.core.model.entity.User
 import org.mifos.mobile.core.model.entity.payload.LoginPayload
@@ -39,13 +37,8 @@ class UserAuthRepositoryImp(
             try {
                 val response = dataManager.registrationApi.registerUser(registerPayload.toDto())
                 DataState.Success(response.bodyAsText())
-            } catch (e: ClientRequestException) {
-                val errorMessage = extractErrorMessage(e.response)
-                DataState.Error(Exception(errorMessage), null)
-            } catch (e: IOException) {
-                DataState.Error(Exception("Network error", e), null)
-            } catch (e: ServerResponseException) {
-                DataState.Error(Exception("Server error", e), null)
+            } catch (e: Exception) {
+                DataState.Error(e.toMifosExceptionSuspend(), null)
             }
         }
     }
@@ -65,16 +58,11 @@ class UserAuthRepositoryImp(
                 if (user.base64EncodedAuthenticationKey != null) {
                     DataState.Success(user)
                 } else {
-                    DataState.Error(Exception("Invalid Credentials"), null)
+                    DataState.Error(MifosException.ClientError("Invalid Credentials"), null)
                 }
             }
-        } catch (e: ClientRequestException) {
-            val errorMessage = extractErrorMessage(e.response)
-            DataState.Error(Exception(errorMessage), null)
-        } catch (e: IOException) {
-            DataState.Error(Exception("Network error", e), null)
-        } catch (e: ServerResponseException) {
-            DataState.Error(Exception("Server error", e), null)
+        } catch (e: Exception) {
+            DataState.Error(e.toMifosExceptionSuspend(), null)
         }
     }
 
@@ -91,13 +79,8 @@ class UserAuthRepositoryImp(
             try {
                 val response = dataManager.registrationApi.verifyUser(userVerify)
                 DataState.Success(response.bodyAsText())
-            } catch (e: ClientRequestException) {
-                val errorMessage = extractErrorMessage(e.response)
-                DataState.Error(Exception(errorMessage), null)
-            } catch (e: IOException) {
-                DataState.Error(Exception("Network error", e), null)
-            } catch (e: ServerResponseException) {
-                DataState.Error(Exception("Server error", e), null)
+            } catch (e: Exception) {
+                DataState.Error(e.toMifosExceptionSuspend(), null)
             }
         }
     }
@@ -115,13 +98,8 @@ class UserAuthRepositoryImp(
             try {
                 val response = dataManager.userDetailsApi.updateAccountPassword(payload)
                 DataState.Success(response.bodyAsText())
-            } catch (e: ClientRequestException) {
-                val errorMessage = extractErrorMessage(e.response)
-                DataState.Error(Exception(errorMessage), null)
-            } catch (e: IOException) {
-                DataState.Error(Exception("Network error", e), null)
-            } catch (e: ServerResponseException) {
-                DataState.Error(Exception("Server error", e), null)
+            } catch (e: Exception) {
+                DataState.Error(e.toMifosExceptionSuspend(), null)
             }
         }
     }

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/UserDetailRepositoryImp.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/UserDetailRepositoryImp.kt
@@ -19,6 +19,8 @@ import org.mifos.mobile.core.common.asDataStateFlow
 import org.mifos.mobile.core.data.mapper.client.toModel
 import org.mifos.mobile.core.data.mapper.payloads.toDto
 import org.mifos.mobile.core.data.repository.UserDetailRepository
+import org.mifos.mobile.core.data.util.toMifosException
+import org.mifos.mobile.core.data.util.toMifosExceptionSuspend
 import org.mifos.mobile.core.model.entity.notification.NotificationRegisterPayload
 import org.mifos.mobile.core.model.entity.notification.NotificationUserDetail
 import org.mifos.mobile.core.network.DataManager
@@ -35,14 +37,14 @@ class UserDetailRepositoryImp(
             }
             DataState.Success("Notification Registered Successfully")
         } catch (e: Exception) {
-            DataState.Error(e, null)
+            DataState.Error(e.toMifosExceptionSuspend(), null)
         }
     }
 
     override fun getUserNotificationId(id: Long): Flow<DataState<NotificationUserDetail>> {
         return dataManager.notificationApi.getUserNotificationId(id)
             .map { it.toModel() }
-            .asDataStateFlow().flowOn(ioDispatcher)
+            .asDataStateFlow(Throwable::toMifosException).flowOn(ioDispatcher)
     }
 
     override suspend fun updateRegisterNotification(
@@ -55,7 +57,7 @@ class UserDetailRepositoryImp(
             }
             DataState.Success("Notification Updated Successfully")
         } catch (e: Exception) {
-            DataState.Error(e, null)
+            DataState.Error(e.toMifosExceptionSuspend(), null)
         }
     }
 }

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/UserDetailRepositoryImp.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/repositoryImpl/UserDetailRepositoryImp.kt
@@ -11,53 +11,37 @@ package org.mifos.mobile.core.data.repositoryImpl
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.withContext
 import org.mifos.mobile.core.common.DataState
-import org.mifos.mobile.core.common.asDataStateFlow
 import org.mifos.mobile.core.data.mapper.client.toModel
 import org.mifos.mobile.core.data.mapper.payloads.toDto
 import org.mifos.mobile.core.data.repository.UserDetailRepository
-import org.mifos.mobile.core.data.util.toMifosException
-import org.mifos.mobile.core.data.util.toMifosExceptionSuspend
 import org.mifos.mobile.core.model.entity.notification.NotificationRegisterPayload
 import org.mifos.mobile.core.model.entity.notification.NotificationUserDetail
 import org.mifos.mobile.core.network.DataManager
 
 class UserDetailRepositoryImp(
     private val dataManager: DataManager,
-    private val ioDispatcher: CoroutineDispatcher,
-) : UserDetailRepository {
+    ioDispatcher: CoroutineDispatcher,
+) : BaseRepository(ioDispatcher), UserDetailRepository {
 
-    override suspend fun registerNotification(payload: NotificationRegisterPayload?): DataState<String> {
-        return try {
-            withContext(ioDispatcher) {
-                dataManager.notificationApi.registerNotification(payload?.toDto())
-            }
-            DataState.Success("Notification Registered Successfully")
-        } catch (e: Exception) {
-            DataState.Error(e.toMifosExceptionSuspend(), null)
+    override suspend fun registerNotification(payload: NotificationRegisterPayload?): DataState<String> =
+        safeCall {
+            dataManager.notificationApi.registerNotification(payload?.toDto())
+            "Notification Registered Successfully"
         }
-    }
 
     override fun getUserNotificationId(id: Long): Flow<DataState<NotificationUserDetail>> {
         return dataManager.notificationApi.getUserNotificationId(id)
             .map { it.toModel() }
-            .asDataStateFlow(Throwable::toMifosException).flowOn(ioDispatcher)
+            .asDataState()
     }
 
     override suspend fun updateRegisterNotification(
         id: Long,
         payload: NotificationRegisterPayload?,
-    ): DataState<String> {
-        return try {
-            withContext(ioDispatcher) {
-                dataManager.notificationApi.updateRegisterNotification(id, payload?.toDto())
-            }
-            DataState.Success("Notification Updated Successfully")
-        } catch (e: Exception) {
-            DataState.Error(e.toMifosExceptionSuspend(), null)
-        }
+    ): DataState<String> = safeCall {
+        dataManager.notificationApi.updateRegisterNotification(id, payload?.toDto())
+        "Notification Updated Successfully"
     }
 }

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/util/ExceptionMapper.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/util/ExceptionMapper.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Mifos Initiative
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+ */
+package org.mifos.mobile.core.data.util
+
+import io.ktor.client.plugins.ClientRequestException
+import io.ktor.client.plugins.ServerResponseException
+import kotlinx.io.IOException
+import org.mifos.mobile.core.common.MifosException
+
+fun Throwable.toMifosException(): MifosException = when (this) {
+    is MifosException -> this
+    is ClientRequestException -> MifosException.ClientError(message, this)
+    is ServerResponseException -> MifosException.ServerError(message, this)
+    is IOException -> MifosException.NetworkError(message ?: "Network error", this)
+    else -> MifosException.GenericError(message ?: "Unknown error", this)
+}
+
+suspend fun Throwable.toMifosExceptionSuspend(): MifosException = when (this) {
+    is MifosException -> this
+    is ClientRequestException -> {
+        val errorMessage = extractErrorMessage(response)
+        MifosException.ClientError(errorMessage, this)
+    }
+    is ServerResponseException -> MifosException.ServerError(message, this)
+    is IOException -> MifosException.NetworkError(message ?: "Network error", this)
+    else -> MifosException.GenericError(message ?: "Unknown error", this)
+}

--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/util/ExceptionMapper.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/util/ExceptionMapper.kt
@@ -12,13 +12,25 @@ package org.mifos.mobile.core.data.util
 import io.ktor.client.plugins.ClientRequestException
 import io.ktor.client.plugins.ServerResponseException
 import kotlinx.io.IOException
+import kotlinx.serialization.SerializationException
 import org.mifos.mobile.core.common.MifosException
 
 fun Throwable.toMifosException(): MifosException = when (this) {
     is MifosException -> this
-    is ClientRequestException -> MifosException.ClientError(message, this)
+    is ClientRequestException -> when (response.status.value) {
+        400 -> MifosException.BadRequest(message, this)
+        401 -> MifosException.Unauthorized(message, this)
+        404 -> MifosException.NotFound(message, this)
+        408 -> MifosException.RequestTimeout(message, this)
+        429 -> MifosException.TooManyRequests(message, this)
+        else -> MifosException.ClientError(message, this)
+    }
     is ServerResponseException -> MifosException.ServerError(message, this)
     is IOException -> MifosException.NetworkError(message ?: "Network error", this)
+    is SerializationException -> MifosException.SerializationError(
+        message ?: "Serialization error",
+        this,
+    )
     else -> MifosException.GenericError(message ?: "Unknown error", this)
 }
 
@@ -26,9 +38,20 @@ suspend fun Throwable.toMifosExceptionSuspend(): MifosException = when (this) {
     is MifosException -> this
     is ClientRequestException -> {
         val errorMessage = extractErrorMessage(response)
-        MifosException.ClientError(errorMessage, this)
+        when (response.status.value) {
+            400 -> MifosException.BadRequest(errorMessage, this)
+            401 -> MifosException.Unauthorized(errorMessage, this)
+            404 -> MifosException.NotFound(errorMessage, this)
+            408 -> MifosException.RequestTimeout(errorMessage, this)
+            429 -> MifosException.TooManyRequests(errorMessage, this)
+            else -> MifosException.ClientError(errorMessage, this)
+        }
     }
     is ServerResponseException -> MifosException.ServerError(message, this)
     is IOException -> MifosException.NetworkError(message ?: "Network error", this)
+    is SerializationException -> MifosException.SerializationError(
+        message ?: "Serialization error",
+        this,
+    )
     else -> MifosException.GenericError(message ?: "Unknown error", this)
 }

--- a/feature/accounts/src/commonMain/kotlin/org/mifos/mobile/feature/accounts/accountTransactions/TransactionViewModel.kt
+++ b/feature/accounts/src/commonMain/kotlin/org/mifos/mobile/feature/accounts/accountTransactions/TransactionViewModel.kt
@@ -21,7 +21,6 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.minus
 import kotlinx.datetime.toLocalDateTime
-import kotlinx.io.IOException
 import mifos_mobile.feature.accounts.generated.resources.Res
 import mifos_mobile.feature.accounts.generated.resources.feature_generic_error_server
 import mifos_mobile.feature.accounts.generated.resources.feature_no__filtered_transactions_found
@@ -36,6 +35,7 @@ import org.jetbrains.compose.resources.StringResource
 import org.mifos.mobile.core.common.Constants
 import org.mifos.mobile.core.common.DataState
 import org.mifos.mobile.core.common.DateHelper
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.LoanRepository
 import org.mifos.mobile.core.data.repository.RecentTransactionRepository
 import org.mifos.mobile.core.data.repository.SavingsAccountRepository
@@ -341,9 +341,7 @@ internal class AccountsTransactionViewModel(
                 updateState {
                     it.copy(
                         isRefreshing = false,
-                        uiState = if (dataState.exception is IOException ||
-                            dataState.exception.cause is IOException
-                        ) {
+                        uiState = if (dataState.exception is MifosException.NetworkError) {
                             ScreenUiState.Network
                         } else {
                             ScreenUiState.Error(Res.string.feature_generic_error_server)
@@ -447,7 +445,7 @@ internal class AccountsTransactionViewModel(
                 updateState {
                     it.copy(
                         isRefreshing = false,
-                        uiState = if (dataState.exception.cause is IOException) {
+                        uiState = if (dataState.exception is MifosException.NetworkError) {
                             ScreenUiState.Network
                         } else {
                             ScreenUiState.Error(Res.string.feature_generic_error_server)
@@ -504,7 +502,7 @@ internal class AccountsTransactionViewModel(
                 updateState {
                     it.copy(
                         isRefreshing = false,
-                        uiState = if (dataState.exception.cause is IOException) {
+                        uiState = if (dataState.exception is MifosException.NetworkError) {
                             ScreenUiState.Network
                         } else {
                             ScreenUiState.Error(Res.string.feature_generic_error_server)
@@ -560,7 +558,7 @@ internal class AccountsTransactionViewModel(
                 updateState {
                     it.copy(
                         isRefreshing = false,
-                        uiState = if (dataState.exception.cause is IOException) {
+                        uiState = if (dataState.exception is MifosException.NetworkError) {
                             ScreenUiState.Network
                         } else {
                             ScreenUiState.Error(Res.string.feature_generic_error_server)

--- a/feature/accounts/src/commonMain/kotlin/org/mifos/mobile/feature/accounts/accountTransactions/TransactionViewModel.kt
+++ b/feature/accounts/src/commonMain/kotlin/org/mifos/mobile/feature/accounts/accountTransactions/TransactionViewModel.kt
@@ -12,7 +12,6 @@ package org.mifos.mobile.feature.accounts.accountTransactions
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -23,7 +22,6 @@ import kotlinx.datetime.minus
 import kotlinx.datetime.toLocalDateTime
 import mifos_mobile.feature.accounts.generated.resources.Res
 import mifos_mobile.feature.accounts.generated.resources.feature_generic_error_server
-import mifos_mobile.feature.accounts.generated.resources.feature_no__filtered_transactions_found
 import mifos_mobile.feature.accounts.generated.resources.feature_transaction_filter_credit
 import mifos_mobile.feature.accounts.generated.resources.feature_transaction_filter_debit
 import mifos_mobile.feature.accounts.generated.resources.feature_transaction_filter_past_1_year
@@ -169,6 +167,17 @@ internal class AccountsTransactionViewModel(
                 val id = action.id ?: return
                 sendEvent(AccountTransactionEvent.NavigateToDetails(id.toString()))
             }
+        }
+    }
+
+    private fun handleError(exception: Throwable) {
+        updateState {
+            it.copy(
+                uiState = when (exception) {
+                    is MifosException.NetworkError -> ScreenUiState.Network
+                    else -> ScreenUiState.Error(Res.string.feature_generic_error_server)
+                },
+            )
         }
     }
 
@@ -338,16 +347,8 @@ internal class AccountsTransactionViewModel(
     private fun handleShareTransactionsResult(dataState: DataState<ShareAccountWithAssociations>) {
         when (dataState) {
             is DataState.Error -> {
-                updateState {
-                    it.copy(
-                        isRefreshing = false,
-                        uiState = if (dataState.exception is MifosException.NetworkError) {
-                            ScreenUiState.Network
-                        } else {
-                            ScreenUiState.Error(Res.string.feature_generic_error_server)
-                        },
-                    )
-                }
+                updateState { it.copy(isRefreshing = false) }
+                handleError(dataState.exception)
             }
             DataState.Loading -> updateState { it.copy(uiState = ScreenUiState.Loading) }
             is DataState.Success -> {
@@ -421,14 +422,6 @@ internal class AccountsTransactionViewModel(
     private fun loadRecentTransactions() {
         viewModelScope.launch {
             recentTransactionRepositoryImpl.recentTransactions(state.clientId, offset, limit)
-                .catch { error ->
-                    updateState {
-                        it.copy(
-                            isRefreshing = false,
-                            uiState = ScreenUiState.Error(Res.string.feature_no__filtered_transactions_found),
-                        )
-                    }
-                }
                 .collect { result ->
                     sendAction(AccountTransactionAction.Internal.ReceiveTransactions(result))
                 }
@@ -442,16 +435,8 @@ internal class AccountsTransactionViewModel(
     private fun handleTransactionResult(dataState: DataState<Page<Transaction>>) {
         when (dataState) {
             is DataState.Error -> {
-                updateState {
-                    it.copy(
-                        isRefreshing = false,
-                        uiState = if (dataState.exception is MifosException.NetworkError) {
-                            ScreenUiState.Network
-                        } else {
-                            ScreenUiState.Error(Res.string.feature_generic_error_server)
-                        },
-                    )
-                }
+                updateState { it.copy(isRefreshing = false) }
+                handleError(dataState.exception)
             }
 
             DataState.Loading -> {
@@ -499,16 +484,8 @@ internal class AccountsTransactionViewModel(
     private fun handleSavingsTransactionsResult(dataState: DataState<SavingsWithAssociations>) {
         when (dataState) {
             is DataState.Error -> {
-                updateState {
-                    it.copy(
-                        isRefreshing = false,
-                        uiState = if (dataState.exception is MifosException.NetworkError) {
-                            ScreenUiState.Network
-                        } else {
-                            ScreenUiState.Error(Res.string.feature_generic_error_server)
-                        },
-                    )
-                }
+                updateState { it.copy(isRefreshing = false) }
+                handleError(dataState.exception)
             }
 
             DataState.Loading -> {
@@ -555,16 +532,8 @@ internal class AccountsTransactionViewModel(
     private fun handleLoanTransactionsResult(dataState: DataState<LoanWithAssociations?>) {
         when (dataState) {
             is DataState.Error -> {
-                updateState {
-                    it.copy(
-                        isRefreshing = false,
-                        uiState = if (dataState.exception is MifosException.NetworkError) {
-                            ScreenUiState.Network
-                        } else {
-                            ScreenUiState.Error(Res.string.feature_generic_error_server)
-                        },
-                    )
-                }
+                updateState { it.copy(isRefreshing = false) }
+                handleError(dataState.exception)
             }
 
             DataState.Loading -> {

--- a/feature/accounts/src/commonMain/kotlin/org/mifos/mobile/feature/accounts/transactionDetail/TransactionDetailsViewModel.kt
+++ b/feature/accounts/src/commonMain/kotlin/org/mifos/mobile/feature/accounts/transactionDetail/TransactionDetailsViewModel.kt
@@ -12,13 +12,13 @@ package org.mifos.mobile.feature.accounts.transactionDetail
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import mifos_mobile.feature.accounts.generated.resources.Res
 import mifos_mobile.feature.accounts.generated.resources.feature_generic_error_server
 import org.mifos.mobile.core.common.Constants
 import org.mifos.mobile.core.common.DataState
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.LoanRepository
 import org.mifos.mobile.core.data.repository.SavingsAccountRepository
 import org.mifos.mobile.core.model.entity.TransactionDetails
@@ -71,6 +71,17 @@ class TransactionDetailsViewModel(
         }
     }
 
+    private fun handleError(exception: Throwable) {
+        updateState {
+            it.copy(
+                uiState = when (exception) {
+                    is MifosException.NetworkError -> ScreenUiState.Network
+                    else -> ScreenUiState.Error(Res.string.feature_generic_error_server)
+                },
+            )
+        }
+    }
+
     private fun fetchTransactionDetails() {
         updateState { it.copy(uiState = ScreenUiState.Loading) }
 
@@ -92,9 +103,6 @@ class TransactionDetailsViewModel(
 
     private suspend fun loadSavingsTransaction() {
         savingsRepository.getSavingsAccountTransactionDetails(state.accountId, state.transactionId)
-            .catch { exception ->
-                emit(DataState.Error(exception))
-            }
             .collect { dataState ->
                 handleDataState(dataState)
             }
@@ -102,9 +110,6 @@ class TransactionDetailsViewModel(
 
     private suspend fun loadLoanTransaction() {
         loanRepository.getLoanTransactionDetails(state.accountId, state.transactionId)
-            .catch { exception ->
-                emit(DataState.Error(exception))
-            }
             .collect { dataState ->
                 handleDataState(dataState)
             }
@@ -121,7 +126,7 @@ class TransactionDetailsViewModel(
                 }
             }
             is DataState.Error -> {
-                updateState { it.copy(uiState = ScreenUiState.Error(Res.string.feature_generic_error_server)) }
+                handleError(dataState.exception)
             }
             DataState.Loading -> {
                 updateState { it.copy(uiState = ScreenUiState.Loading) }

--- a/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/login/LoginViewModel.kt
+++ b/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/login/LoginViewModel.kt
@@ -11,7 +11,6 @@ package org.mifos.mobile.feature.auth.login
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
-import io.ktor.client.plugins.ServerResponseException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.update
@@ -24,6 +23,7 @@ import mifos_mobile.feature.auth.generated.resources.no_client_assigned
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.getString
 import org.mifos.mobile.core.common.DataState
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.UserAuthRepository
 import org.mifos.mobile.core.datastore.UserPreferencesRepository
 import org.mifos.mobile.core.datastore.model.UserData
@@ -97,7 +97,7 @@ class LoginViewModel(
             when (action.loginResult) {
                 is DataState.Error -> {
                     val errorMsg =
-                        if (action.loginResult.exception.cause is ServerResponseException) {
+                        if (action.loginResult.exception is MifosException.ServerError) {
                             getString(
                                 UiRes.string.internal_server_error,
                             )

--- a/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/otpAuthentication/OtpAuthenticationViewModel.kt
+++ b/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/otpAuthentication/OtpAuthenticationViewModel.kt
@@ -12,7 +12,6 @@ package org.mifos.mobile.feature.auth.otpAuthentication
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
-import io.ktor.client.plugins.ServerResponseException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.update
@@ -32,6 +31,7 @@ import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.getString
 import org.mifos.mobile.core.common.Constants
 import org.mifos.mobile.core.common.DataState
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.UserAuthRepository
 import org.mifos.mobile.core.model.EventType
 import org.mifos.mobile.core.ui.utils.BaseViewModel
@@ -196,7 +196,7 @@ internal class OtpAuthenticationViewModel(
                 delay(1500)
                 sendEvent(
                     OtpAuthEvent.NavigateToStatus(
-                        eventType = if (action.exception.cause is ServerResponseException) {
+                        eventType = if (action.exception is MifosException.ServerError) {
                             EventType.SERVER_EXCEPTION.name
                         } else {
                             EventType.FAILURE.name

--- a/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/registration/RegistrationViewModel.kt
+++ b/feature/auth/src/commonMain/kotlin/org/mifos/mobile/feature/auth/registration/RegistrationViewModel.kt
@@ -10,7 +10,6 @@
 package org.mifos.mobile.feature.auth.registration
 
 import androidx.lifecycle.viewModelScope
-import io.ktor.client.plugins.ServerResponseException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.update
@@ -30,6 +29,7 @@ import mifos_mobile.feature.auth.generated.resources.feature_signup_error_passwo
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.getString
 import org.mifos.mobile.core.common.DataState
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.UserAuthRepository
 import org.mifos.mobile.core.model.entity.register.RegisterPayload
 import org.mifos.mobile.core.ui.PasswordStrengthState
@@ -553,7 +553,7 @@ class RegistrationViewModel(
 
                 is DataState.Error -> {
                     val errorMsg =
-                        if (result.exception.cause is ServerResponseException) {
+                        if (result.exception is MifosException.ServerError) {
                             getString(UiRes.string.internal_server_error)
                         } else {
                             result.message

--- a/feature/beneficiary/src/commonMain/kotlin/org/mifos/mobile/feature/beneficiary/beneficiaryApplication/BeneficiaryApplicationViewModel.kt
+++ b/feature/beneficiary/src/commonMain/kotlin/org/mifos/mobile/feature/beneficiary/beneficiaryApplication/BeneficiaryApplicationViewModel.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.io.IOException
 import mifos_mobile.feature.beneficiary.generated.resources.Res
 import mifos_mobile.feature.beneficiary.generated.resources.add_beneficiary
 import mifos_mobile.feature.beneficiary.generated.resources.enter_account_number
@@ -30,6 +29,7 @@ import mifos_mobile.feature.beneficiary.generated.resources.select_account_type
 import mifos_mobile.feature.beneficiary.generated.resources.update_beneficiary
 import org.jetbrains.compose.resources.StringResource
 import org.mifos.mobile.core.common.DataState
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.BeneficiaryRepository
 import org.mifos.mobile.core.data.util.NetworkMonitor
 import org.mifos.mobile.core.model.entity.beneficiary.Beneficiary
@@ -197,7 +197,7 @@ internal class BeneficiaryApplicationViewModel(
             }.catch { error ->
                 updateState {
                     it.copy(
-                        uiState = if (error.cause is IOException) {
+                        uiState = if (error.cause is MifosException.NetworkError) {
                             ScreenUiState.Network
                         } else {
                             ScreenUiState.Error(Res.string.feature_generic_error_server)

--- a/feature/beneficiary/src/commonMain/kotlin/org/mifos/mobile/feature/beneficiary/beneficiaryApplication/BeneficiaryApplicationViewModel.kt
+++ b/feature/beneficiary/src/commonMain/kotlin/org/mifos/mobile/feature/beneficiary/beneficiaryApplication/BeneficiaryApplicationViewModel.kt
@@ -12,7 +12,6 @@ package org.mifos.mobile.feature.beneficiary.beneficiaryApplication
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
@@ -102,6 +101,17 @@ internal class BeneficiaryApplicationViewModel(
      */
     private fun setLoadingState(loading: ScreenUiState.Loading) {
         updateState { it.copy(uiState = loading) }
+    }
+
+    private fun handleError(exception: Throwable) {
+        updateState {
+            it.copy(
+                uiState = when (exception) {
+                    is MifosException.NetworkError -> ScreenUiState.Network
+                    else -> ScreenUiState.Error(Res.string.feature_generic_error_server)
+                },
+            )
+        }
     }
 
     /**
@@ -194,16 +204,6 @@ internal class BeneficiaryApplicationViewModel(
                 beneficiaryRepositoryImp.beneficiaryTemplate(),
             ) { beneficiaryList, beneficiaryTemplate ->
                 beneficiaryList to beneficiaryTemplate
-            }.catch { error ->
-                updateState {
-                    it.copy(
-                        uiState = if (error.cause is MifosException.NetworkError) {
-                            ScreenUiState.Network
-                        } else {
-                            ScreenUiState.Error(Res.string.feature_generic_error_server)
-                        },
-                    )
-                }
             }.collect { (beneficiaryList, beneficiaryTemplate) ->
                 sendAction(
                     BeneficiaryApplicationAction.Internal.ReceiveBeneficiaryResult(
@@ -223,18 +223,11 @@ internal class BeneficiaryApplicationViewModel(
         beneficiaryTemplate: DataState<BeneficiaryTemplate>,
     ) {
         when {
-            beneficiaryList is DataState.Loading && beneficiaryTemplate is DataState.Loading -> {
-                setLoadingState(ScreenUiState.Loading)
-            }
+            beneficiaryList is DataState.Error -> handleError(beneficiaryList.exception)
+            beneficiaryTemplate is DataState.Error -> handleError(beneficiaryTemplate.exception)
 
-            beneficiaryList is DataState.Error && beneficiaryTemplate is DataState.Error -> {
-                updateState {
-                    it.copy(
-                        uiState = ScreenUiState.Error(
-                            Res.string.feature_generic_error_server,
-                        ),
-                    )
-                }
+            beneficiaryList is DataState.Loading || beneficiaryTemplate is DataState.Loading -> {
+                setLoadingState(ScreenUiState.Loading)
             }
 
             beneficiaryList is DataState.Success && beneficiaryTemplate is DataState.Success -> {

--- a/feature/beneficiary/src/commonMain/kotlin/org/mifos/mobile/feature/beneficiary/beneficiaryApplicationConfirmation/BeneficiaryApplicationConfirmationViewModel.kt
+++ b/feature/beneficiary/src/commonMain/kotlin/org/mifos/mobile/feature/beneficiary/beneficiaryApplicationConfirmation/BeneficiaryApplicationConfirmationViewModel.kt
@@ -12,7 +12,6 @@ package org.mifos.mobile.feature.beneficiary.beneficiaryApplicationConfirmation
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
-import io.ktor.client.plugins.ServerResponseException
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -39,6 +38,7 @@ import mifos_mobile.feature.beneficiary.generated.resources.update_beneficiary
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.getString
 import org.mifos.mobile.core.common.DataState
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.BeneficiaryRepository
 import org.mifos.mobile.core.data.util.NetworkMonitor
 import org.mifos.mobile.core.model.EventType
@@ -179,14 +179,14 @@ internal class BeneficiaryApplicationConfirmationViewModel(
                     updateState {
                         it.copy(showOverlay = false)
                     }
-                    val errorMsg = if (response.exception.cause is ServerResponseException) {
+                    val errorMsg = if (response.exception is MifosException.ServerError) {
                         getString(UiRes.string.internal_server_error)
                     } else {
                         response.message
                     }
                     sendEvent(
                         BeneficiaryApplicationConfirmationEvent.NavigateToStatus(
-                            eventType = if (response.exception.cause is ServerResponseException) {
+                            eventType = if (response.exception is MifosException.ServerError) {
                                 EventType.SERVER_EXCEPTION.name
                             } else {
                                 EventType.FAILURE.name
@@ -257,7 +257,7 @@ internal class BeneficiaryApplicationConfirmationViewModel(
                         it.copy(showOverlay = false)
                     }
 
-                    val errorMsg = if (response.exception.cause is ServerResponseException) {
+                    val errorMsg = if (response.exception is MifosException.ServerError) {
                         getString(UiRes.string.internal_server_error)
                     } else {
                         response.message
@@ -265,7 +265,7 @@ internal class BeneficiaryApplicationConfirmationViewModel(
 
                     sendEvent(
                         BeneficiaryApplicationConfirmationEvent.NavigateToStatus(
-                            eventType = if (response.exception.cause is ServerResponseException) {
+                            eventType = if (response.exception is MifosException.ServerError) {
                                 EventType.SERVER_EXCEPTION.name
                             } else {
                                 EventType.FAILURE.name

--- a/feature/beneficiary/src/commonMain/kotlin/org/mifos/mobile/feature/beneficiary/beneficiaryDetail/BeneficiaryDetailViewModel.kt
+++ b/feature/beneficiary/src/commonMain/kotlin/org/mifos/mobile/feature/beneficiary/beneficiaryDetail/BeneficiaryDetailViewModel.kt
@@ -12,17 +12,16 @@ package org.mifos.mobile.feature.beneficiary.beneficiaryDetail
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
-import io.ktor.client.plugins.ServerResponseException
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.io.IOException
 import mifos_mobile.core.ui.generated.resources.internal_server_error
 import mifos_mobile.feature.beneficiary.generated.resources.Res
 import mifos_mobile.feature.beneficiary.generated.resources.delete_beneficiary_confirmation
 import mifos_mobile.feature.beneficiary.generated.resources.feature_generic_error_server
 import org.jetbrains.compose.resources.getString
 import org.mifos.mobile.core.common.DataState
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.BeneficiaryRepository
 import org.mifos.mobile.core.data.util.NetworkMonitor
 import org.mifos.mobile.core.model.entity.beneficiary.Beneficiary
@@ -150,7 +149,7 @@ internal class BeneficiaryDetailViewModel(
             is DataState.Error -> {
                 updateState {
                     it.copy(
-                        uiState = if (beneficiary.exception is IOException) {
+                        uiState = if (beneficiary.exception is MifosException.NetworkError) {
                             ScreenUiState.Network
                         } else {
                             ScreenUiState.Error(Res.string.feature_generic_error_server)
@@ -220,7 +219,7 @@ internal class BeneficiaryDetailViewModel(
                             showOverlay = false,
                         )
                     }
-                    val errorMsg = if (response.exception.cause is ServerResponseException) {
+                    val errorMsg = if (response.exception is MifosException.ServerError) {
                         getString(UiRes.string.internal_server_error)
                     } else {
                         response.message

--- a/feature/beneficiary/src/commonMain/kotlin/org/mifos/mobile/feature/beneficiary/beneficiaryList/BeneficiaryListViewModel.kt
+++ b/feature/beneficiary/src/commonMain/kotlin/org/mifos/mobile/feature/beneficiary/beneficiaryList/BeneficiaryListViewModel.kt
@@ -14,11 +14,11 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.io.IOException
 import mifos_mobile.feature.beneficiary.generated.resources.Res
 import mifos_mobile.feature.beneficiary.generated.resources.beneficiary
 import mifos_mobile.feature.beneficiary.generated.resources.feature_generic_error_server
 import org.mifos.mobile.core.common.DataState
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.BeneficiaryRepository
 import org.mifos.mobile.core.data.util.NetworkMonitor
 import org.mifos.mobile.core.model.entity.beneficiary.Beneficiary
@@ -189,7 +189,7 @@ internal class BeneficiaryListViewModel(
             is DataState.Error -> {
                 updateState {
                     it.copy(
-                        uiState = if (beneficiaryList.exception is IOException) {
+                        uiState = if (beneficiaryList.exception is MifosException.NetworkError) {
                             ScreenUiState.Network
                         } else {
                             ScreenUiState.Error(Res.string.feature_generic_error_server)

--- a/feature/client-charge/src/commonMain/kotlin/org/mifos/mobile/feature/charge/charges/ClientChargeViewModel.kt
+++ b/feature/client-charge/src/commonMain/kotlin/org/mifos/mobile/feature/charge/charges/ClientChargeViewModel.kt
@@ -15,7 +15,6 @@ import androidx.navigation.toRoute
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.io.IOException
 import mifos_mobile.feature.client_charge.generated.resources.Res
 import mifos_mobile.feature.client_charge.generated.resources.charges
 import mifos_mobile.feature.client_charge.generated.resources.client_charges
@@ -25,6 +24,7 @@ import mifos_mobile.feature.client_charge.generated.resources.savings_charges
 import org.jetbrains.compose.resources.StringResource
 import org.mifos.mobile.core.common.Constants
 import org.mifos.mobile.core.common.DataState
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.AccountsRepository
 import org.mifos.mobile.core.data.repository.ClientChargeRepository
 import org.mifos.mobile.core.data.util.NetworkMonitor
@@ -336,7 +336,7 @@ internal class ClientChargeViewModel(
             is DataState.Loading -> updateState { it.copy(uiState = ScreenUiState.Loading) }
             is DataState.Error -> updateState {
                 it.copy(
-                    uiState = if (result.exception.cause is IOException) {
+                    uiState = if (result.exception is MifosException.NetworkError) {
                         ScreenUiState.Network
                     } else {
                         ScreenUiState.Error(Res.string.feature_generic_error_server)
@@ -355,7 +355,7 @@ internal class ClientChargeViewModel(
             is DataState.Loading -> updateState { it.copy(uiState = ScreenUiState.Loading) }
             is DataState.Error -> updateState {
                 it.copy(
-                    uiState = if (result.exception.cause is IOException) {
+                    uiState = if (result.exception is MifosException.NetworkError) {
                         ScreenUiState.Network
                     } else {
                         ScreenUiState.Error(Res.string.feature_generic_error_server)

--- a/feature/home/src/commonMain/kotlin/org/mifos/mobile/feature/home/HomeViewModel.kt
+++ b/feature/home/src/commonMain/kotlin/org/mifos/mobile/feature/home/HomeViewModel.kt
@@ -15,7 +15,6 @@ import co.touchlab.kermit.Logger
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -24,6 +23,7 @@ import mifos_mobile.feature.home.generated.resources.feature_server_error
 import org.jetbrains.compose.resources.StringResource
 import org.mifos.mobile.core.common.CurrencyFormatter
 import org.mifos.mobile.core.common.DataState
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.HomeRepository
 import org.mifos.mobile.core.data.util.NetworkMonitor
 import org.mifos.mobile.core.datastore.UserPreferencesRepository
@@ -83,6 +83,17 @@ internal class HomeViewModel(
                     sendAction(HomeAction.ObserveNetworkStatus(isOnline))
                     isHandlingNetworkChange = false
                 }
+        }
+    }
+
+    private fun handleError(exception: Throwable) {
+        updateState {
+            it.copy(
+                uiState = when (exception) {
+                    is MifosException.NetworkError -> HomeScreenState.Network
+                    else -> HomeScreenState.Error(Res.string.feature_server_error)
+                },
+            )
         }
     }
 
@@ -193,10 +204,11 @@ internal class HomeViewModel(
 
     private suspend fun checkAuthorization() {
         homeRepositoryImpl.currentClient(clientId = state.clientId ?: 0)
-            .catch {
-                updateState { it.copy(uiState = HomeScreenState.Error(Res.string.feature_server_error)) }
+            .collect { result ->
+                if (result is DataState.Error) {
+                    handleError(result.exception)
+                }
             }
-            .collect {}
     }
 
     /**
@@ -340,9 +352,6 @@ internal class HomeViewModel(
 
         viewModelScope.launch {
             homeRepositoryImpl.currentClient(clientId = state.clientId ?: 0)
-                .catch {
-                    updateState { it.copy(uiState = HomeScreenState.Error(Res.string.feature_server_error)) }
-                }
                 .collect { client ->
                     sendAction(HomeAction.Internal.ReceiveClientDetails(client))
                 }
@@ -361,11 +370,7 @@ internal class HomeViewModel(
      */
     private fun handleClientDetails(dataState: DataState<Client>) {
         when (dataState) {
-            is DataState.Error -> updateState {
-                it.copy(
-                    uiState = HomeScreenState.Error(Res.string.feature_server_error),
-                )
-            }
+            is DataState.Error -> handleError(dataState.exception)
 
             DataState.Loading -> updateState { it.copy(uiState = HomeScreenState.Loading) }
 
@@ -385,9 +390,6 @@ internal class HomeViewModel(
     private fun loadClientAccountDetails() {
         viewModelScope.launch {
             homeRepositoryImpl.clientAccounts(clientId = state.clientId ?: 0)
-                .catch {
-                    updateState { it.copy(uiState = HomeScreenState.Error(Res.string.feature_server_error)) }
-                }
                 .collect { clientAccounts ->
                     sendAction(HomeAction.Internal.ReceiveClientAccounts(clientAccounts))
                 }
@@ -405,11 +407,7 @@ internal class HomeViewModel(
      */
     private fun handleClientAccounts(dataState: DataState<ClientAccounts>) {
         when (dataState) {
-            is DataState.Error -> updateState {
-                it.copy(
-                    uiState = HomeScreenState.Error(Res.string.feature_server_error),
-                )
-            }
+            is DataState.Error -> handleError(dataState.exception)
 
             DataState.Loading -> updateState { it.copy(uiState = HomeScreenState.Loading) }
 
@@ -458,11 +456,7 @@ internal class HomeViewModel(
      */
     private fun unreadNotificationsCount() {
         viewModelScope.launch {
-            homeRepositoryImpl.unreadNotificationsCount().catch {
-                updateState {
-                    it.copy(notificationCount = 0)
-                }
-            }.collect { count ->
+            homeRepositoryImpl.unreadNotificationsCount().collect { count ->
                 when (count) {
                     is DataState.Error -> updateState {
                         it.copy(notificationCount = 0)

--- a/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/loanAccount/LoanAccountViewModel.kt
+++ b/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/loanAccount/LoanAccountViewModel.kt
@@ -13,13 +13,13 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.io.IOException
 import mifos_mobile.feature.loan_account.generated.resources.Res
 import mifos_mobile.feature.loan_account.generated.resources.feature_generic_error_server
 import org.jetbrains.compose.resources.StringResource
 import org.mifos.mobile.core.common.Constants
 import org.mifos.mobile.core.common.CurrencyFormatter
 import org.mifos.mobile.core.common.DataState
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.AccountsRepository
 import org.mifos.mobile.core.data.util.NetworkMonitor
 import org.mifos.mobile.core.datastore.UserPreferencesRepository
@@ -209,7 +209,7 @@ class LoanAccountsViewmodel(
             is DataState.Error -> {
                 updateState {
                     it.copy(
-                        uiState = if (dataState.exception.cause is IOException) {
+                        uiState = if (dataState.exception is MifosException.NetworkError) {
                             ScreenUiState.Network
                         } else {
                             ScreenUiState.Error(Res.string.feature_generic_error_server)

--- a/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/loanAccountDetails/LoanAccountDetailsViewModel.kt
+++ b/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/loanAccountDetails/LoanAccountDetailsViewModel.kt
@@ -17,7 +17,6 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.io.IOException
 import mifos_mobile.feature.loan_account.generated.resources.Res
 import mifos_mobile.feature.loan_account.generated.resources.feature_generic_error_server
 import mifos_mobile.feature.loan_account.generated.resources.feature_loan_account_number_label
@@ -30,6 +29,7 @@ import org.mifos.mobile.core.common.Constants
 import org.mifos.mobile.core.common.CurrencyFormatter
 import org.mifos.mobile.core.common.DataState
 import org.mifos.mobile.core.common.DateHelper
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.LoanRepository
 import org.mifos.mobile.core.data.util.NetworkMonitor
 import org.mifos.mobile.core.datastore.UserPreferencesRepository
@@ -203,7 +203,7 @@ internal class LoanAccountDetailsViewModel(
             is DataState.Error -> {
                 updateState {
                     it.copy(
-                        uiState = if (dataState.exception is IOException) {
+                        uiState = if (dataState.exception is MifosException.NetworkError) {
                             ScreenUiState.Network
                         } else {
                             ScreenUiState.Error(Res.string.feature_generic_error_server)

--- a/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/loanAccountRepaymentSchedule/RepaymentScheduleViewModel.kt
+++ b/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/loanAccountRepaymentSchedule/RepaymentScheduleViewModel.kt
@@ -12,7 +12,6 @@ package org.mifos.mobile.feature.loanaccount.loanAccountRepaymentSchedule
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -76,6 +75,17 @@ internal class RepaymentScheduleViewModel(
                 .collect { isOnline ->
                     sendAction(RepaymentScheduleAction.ReceiveNetworkStatus(isOnline))
                 }
+        }
+    }
+
+    private fun handleError(exception: Throwable) {
+        updateState {
+            it.copy(
+                uiState = when (exception) {
+                    is MifosException.NetworkError -> ScreenUiState.Network
+                    else -> ScreenUiState.Error(Res.string.feature_generic_error_server)
+                },
+            )
         }
     }
 
@@ -174,17 +184,6 @@ internal class RepaymentScheduleViewModel(
         updateState { it.copy(uiState = ScreenUiState.Loading) }
         viewModelScope.launch {
             loanRepositoryImp.getLoanWithAssociations(Constants.REPAYMENT_SCHEDULE, state.accountId)
-                .catch { error ->
-                    updateState {
-                        it.copy(
-                            uiState = if (error.cause is MifosException.NetworkError) {
-                                ScreenUiState.Network
-                            } else {
-                                ScreenUiState.Error(Res.string.feature_generic_error_server)
-                            },
-                        )
-                    }
-                }
                 .collect { loanData ->
                     sendAction(RepaymentScheduleAction.Internal.ReceivedRepaymentSchedule(loanData))
                 }
@@ -316,15 +315,7 @@ internal class RepaymentScheduleViewModel(
     private fun handleRepaymentScheduleResult(dataState: DataState<LoanWithAssociations?>) {
         when (dataState) {
             is DataState.Error -> {
-                updateState {
-                    it.copy(
-                        uiState = if (dataState.exception is MifosException.NetworkError) {
-                            ScreenUiState.Network
-                        } else {
-                            ScreenUiState.Error(Res.string.feature_generic_error_server)
-                        },
-                    )
-                }
+                handleError(dataState.exception)
             }
 
             DataState.Loading -> updateState { it.copy(uiState = ScreenUiState.Loading) }

--- a/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/loanAccountRepaymentSchedule/RepaymentScheduleViewModel.kt
+++ b/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/loanAccountRepaymentSchedule/RepaymentScheduleViewModel.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.io.IOException
 import mifos_mobile.feature.loan_account.generated.resources.Res
 import mifos_mobile.feature.loan_account.generated.resources.feature_generic_error_server
 import mifos_mobile.feature.loan_account.generated.resources.feature_loan_account_number_label
@@ -32,6 +31,7 @@ import org.mifos.mobile.core.common.Constants
 import org.mifos.mobile.core.common.CurrencyFormatter
 import org.mifos.mobile.core.common.DataState
 import org.mifos.mobile.core.common.DateHelper
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.LoanRepository
 import org.mifos.mobile.core.data.util.NetworkMonitor
 import org.mifos.mobile.core.model.entity.TransferSuccessDestination
@@ -177,7 +177,7 @@ internal class RepaymentScheduleViewModel(
                 .catch { error ->
                     updateState {
                         it.copy(
-                            uiState = if (error.cause is IOException) {
+                            uiState = if (error.cause is MifosException.NetworkError) {
                                 ScreenUiState.Network
                             } else {
                                 ScreenUiState.Error(Res.string.feature_generic_error_server)
@@ -318,7 +318,7 @@ internal class RepaymentScheduleViewModel(
             is DataState.Error -> {
                 updateState {
                     it.copy(
-                        uiState = if (dataState.exception is IOException) {
+                        uiState = if (dataState.exception is MifosException.NetworkError) {
                             ScreenUiState.Network
                         } else {
                             ScreenUiState.Error(Res.string.feature_generic_error_server)

--- a/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/loanAccountSummary/AccountSummaryViewModel.kt
+++ b/feature/loan-account/src/commonMain/kotlin/org/mifos/mobile/feature/loanaccount/loanAccountSummary/AccountSummaryViewModel.kt
@@ -16,7 +16,6 @@ import androidx.navigation.toRoute
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.io.IOException
 import mifos_mobile.feature.loan_account.generated.resources.Res
 import mifos_mobile.feature.loan_account.generated.resources.feature_generic_error_server
 import mifos_mobile.feature.loan_account.generated.resources.feature_loan_account_number_label
@@ -45,6 +44,7 @@ import org.mifos.mobile.core.common.Constants
 import org.mifos.mobile.core.common.CurrencyFormatter
 import org.mifos.mobile.core.common.DataState
 import org.mifos.mobile.core.common.DateHelper
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.LoanRepository
 import org.mifos.mobile.core.data.util.NetworkMonitor
 import org.mifos.mobile.core.model.entity.accounts.loan.LoanWithAssociations
@@ -180,7 +180,7 @@ internal class LoanAccountSummaryViewModel(
             is DataState.Error -> {
                 updateState {
                     it.copy(
-                        uiState = if (dataState.exception is IOException) {
+                        uiState = if (dataState.exception is MifosException.NetworkError) {
                             ScreenUiState.Network
                         } else {
                             ScreenUiState.Error(Res.string.feature_generic_error_server)

--- a/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/confirmDetails/ConfirmDetailsViewModel.kt
+++ b/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/confirmDetails/ConfirmDetailsViewModel.kt
@@ -12,7 +12,6 @@ package org.mifos.mobile.feature.loan.application.confirmDetails
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
-import io.ktor.client.plugins.ServerResponseException
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import mifos_mobile.core.ui.generated.resources.internal_server_error
@@ -28,10 +27,10 @@ import mifos_mobile.feature.loan_application.generated.resources.feature_apply_l
 import mifos_mobile.feature.loan_application.generated.resources.feature_apply_loan_status_success
 import mifos_mobile.feature.loan_application.generated.resources.feature_apply_loan_status_success_action
 import mifos_mobile.feature.loan_application.generated.resources.feature_apply_loan_status_success_tip
-import okio.IOException
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.getString
 import org.mifos.mobile.core.common.DataState
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.LoanRepository
 import org.mifos.mobile.core.data.repository.ReviewLoanApplicationRepository
 import org.mifos.mobile.core.datastore.UserPreferencesRepository
@@ -245,7 +244,7 @@ internal class ConfirmDetailsViewModel(
                 updateState {
                     it.copy(
                         showOverlay = false,
-                        uiState = if (template.exception is IOException) {
+                        uiState = if (template.exception is MifosException.NetworkError) {
                             ScreenUiState.Network
                         } else {
                             ScreenUiState.Error(Res.string.feature_apply_loan_error_server)
@@ -286,14 +285,14 @@ internal class ConfirmDetailsViewModel(
                 updateState {
                     it.copy(showOverlay = false)
                 }
-                val errorMsg = if (status.exception.cause is ServerResponseException) {
+                val errorMsg = if (status.exception is MifosException.ServerError) {
                     getString(UiRes.string.internal_server_error)
                 } else {
                     status.message
                 }
                 sendEvent(
                     ConfirmDetailsEvent.NavigateToStatus(
-                        eventType = if (status.exception.cause is ServerResponseException) {
+                        eventType = if (status.exception is MifosException.ServerError) {
                             EventType.SERVER_EXCEPTION.name
                         } else {
                             EventType.FAILURE.name

--- a/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/loanApplication/LoanApplyViewModel.kt
+++ b/feature/loan-application/src/commonMain/kotlin/org/mifos/mobile/feature/loan/application/loanApplication/LoanApplyViewModel.kt
@@ -15,7 +15,6 @@ import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
@@ -32,10 +31,10 @@ import mifos_mobile.feature.loan_application.generated.resources.feature_apply_l
 import mifos_mobile.feature.loan_application.generated.resources.feature_apply_loan_error_server
 import mifos_mobile.feature.loan_application.generated.resources.feature_apply_loan_error_submit_failed
 import mifos_mobile.feature.loan_application.generated.resources.feature_apply_loan_error_too_many_attempts
-import okio.IOException
 import org.jetbrains.compose.resources.StringResource
 import org.mifos.mobile.core.common.DataState
 import org.mifos.mobile.core.common.DateHelper
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.HomeRepository
 import org.mifos.mobile.core.data.repository.LoanRepository
 import org.mifos.mobile.core.data.util.NetworkMonitor
@@ -125,6 +124,17 @@ internal class LoanApplyViewModel(
      *
      * @param action The [LoanApplicationAction] to be handled.
      */
+    private fun handleError(exception: Throwable) {
+        updateState {
+            it.copy(
+                uiState = when (exception) {
+                    is MifosException.NetworkError -> ScreenUiState.Network
+                    else -> ScreenUiState.Error(Res.string.feature_apply_loan_error_server)
+                },
+            )
+        }
+    }
+
     override fun handleAction(action: LoanApplicationAction) {
         when (action) {
             is LoanApplicationAction.PurposeOfLoanChange -> {
@@ -203,28 +213,15 @@ internal class LoanApplyViewModel(
                 loanAccountRepositoryImp.getLoanTemplateByProduct(state.clientId, state.loanProductId),
             ) { client, template, purpose ->
                 Triple(client, template, purpose)
+            }.collect { (client, template, purpose) ->
+                sendAction(
+                    LoanApplicationAction.Internal.ReceiveClientAndTemplateResult(
+                        client,
+                        template,
+                        purpose,
+                    ),
+                )
             }
-                .catch { throwable ->
-
-                    updateState {
-                        it.copy(
-                            uiState = if (throwable.cause is IOException) {
-                                ScreenUiState.Network
-                            } else {
-                                ScreenUiState.Error(Res.string.feature_apply_loan_error_server)
-                            },
-                        )
-                    }
-                }
-                .collect { (client, template, purpose) ->
-                    sendAction(
-                        LoanApplicationAction.Internal.ReceiveClientAndTemplateResult(
-                            client,
-                            template,
-                            purpose,
-                        ),
-                    )
-                }
         }
     }
 
@@ -243,7 +240,11 @@ internal class LoanApplyViewModel(
         purpose: DataState<LoanTemplate?>,
     ) {
         when {
-            listOf(client, template, purpose).any { it is DataState.Loading } -> {
+            client is DataState.Error -> handleError(client.exception)
+            template is DataState.Error -> handleError(template.exception)
+            purpose is DataState.Error -> handleError(purpose.exception)
+
+            client is DataState.Loading || template is DataState.Loading || purpose is DataState.Loading -> {
                 showLoading()
             }
 
@@ -311,8 +312,6 @@ internal class LoanApplyViewModel(
                     )
                 }
             }
-
-            else -> updateState { it.copy(uiState = ScreenUiState.Error(Res.string.feature_apply_loan_error_server)) }
         }
     }
 

--- a/feature/notification/src/commonMain/kotlin/org/mifos/mobile/feature/notification/NotificationViewModel.kt
+++ b/feature/notification/src/commonMain/kotlin/org/mifos/mobile/feature/notification/NotificationViewModel.kt
@@ -14,7 +14,6 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import org.mifos.mobile.core.common.DataState
@@ -59,6 +58,10 @@ internal class NotificationViewModel(
         }
     }
 
+    private fun handleError(exception: Throwable) {
+        _notificationUiState.value = NotificationUiState.Error(exception.message)
+    }
+
     /**
      * Kicks off the process of loading notifications from the repository. This function updates the
      * UI state to reflect the current status of the operation, such as Loading, Success, or Error.
@@ -67,15 +70,10 @@ internal class NotificationViewModel(
         _notificationUiState.value = Loading
         viewModelScope.launch {
             notificationRepositoryImp.loadNotifications()
-                .catch {
-                    _isRefreshing.emit(false)
-                    _notificationUiState.value =
-                        NotificationUiState.Error(errorMessage = it.message)
-                }.collect { notifications ->
+                .collect { notifications ->
                     when (notifications) {
                         is DataState.Error -> {
-                            _notificationUiState.value =
-                                NotificationUiState.Error(notifications.message)
+                            handleError(notifications.exception)
                         }
                         DataState.Loading -> {
                             Loading

--- a/feature/recent-transaction/src/commonMain/kotlin/org/mifos/mobile/feature/recent/transaction/viewmodel/RecentTransactionViewModel.kt
+++ b/feature/recent-transaction/src/commonMain/kotlin/org/mifos/mobile/feature/recent/transaction/viewmodel/RecentTransactionViewModel.kt
@@ -10,13 +10,13 @@
 package org.mifos.mobile.feature.recent.transaction.viewmodel
 
 import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.mifos.mobile.core.common.Constants
 import org.mifos.mobile.core.common.DataState
 import org.mifos.mobile.core.common.DateHelper
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.AccountsRepository
 import org.mifos.mobile.core.data.repository.SavingsAccountRepository
 import org.mifos.mobile.core.data.util.NetworkMonitor
@@ -123,6 +123,17 @@ internal class RecentTransactionViewModel(
             } else {
                 loadTransactions()
             }
+        }
+    }
+
+    private fun handleError(exception: Throwable) {
+        updateState {
+            it.copy(
+                viewState = when (exception) {
+                    is MifosException.NetworkError -> ScreenUiState.Network
+                    else -> ScreenUiState.ErrorString(exception.message ?: "Something went wrong")
+                },
+            )
         }
     }
 
@@ -235,13 +246,7 @@ internal class RecentTransactionViewModel(
                         }
                     }
                     is DataState.Error -> {
-                        updateState {
-                            it.copy(
-                                viewState = ScreenUiState.ErrorString(
-                                    dataState.exception.message ?: "Something went wrong",
-                                ),
-                            )
-                        }
+                        handleError(dataState.exception)
                     }
                 }
             }
@@ -263,15 +268,6 @@ internal class RecentTransactionViewModel(
                     accountId = selectedAccount.id,
                     associationType = Constants.TRANSACTIONS,
                 )
-                .catch { e ->
-                    updateState {
-                        it.copy(
-                            viewState = ScreenUiState.ErrorString(
-                                e.message ?: "Something went wrong",
-                            ),
-                        )
-                    }
-                }
                 .collect { dataState ->
                     sendAction(RecentTransactionAction.Internal.HandleTransactions(dataState))
                 }
@@ -302,13 +298,7 @@ internal class RecentTransactionViewModel(
             }
 
             is DataState.Error -> {
-                updateState {
-                    it.copy(
-                        viewState = ScreenUiState.ErrorString(
-                            dataState.exception.message ?: "Something went wrong",
-                        ),
-                    )
-                }
+                handleError(dataState.exception)
             }
 
             is DataState.Loading -> {

--- a/feature/savings-account/src/commonMain/kotlin/org/mifos/mobile/feature/savingsaccount/savingsAccount/SavingsAccountViewmodel.kt
+++ b/feature/savings-account/src/commonMain/kotlin/org/mifos/mobile/feature/savingsaccount/savingsAccount/SavingsAccountViewmodel.kt
@@ -13,13 +13,13 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.io.IOException
 import mifos_mobile.feature.savings_account.generated.resources.Res
 import mifos_mobile.feature.savings_account.generated.resources.feature_generic_error_server
 import org.jetbrains.compose.resources.StringResource
 import org.mifos.mobile.core.common.Constants
 import org.mifos.mobile.core.common.CurrencyFormatter
 import org.mifos.mobile.core.common.DataState
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.AccountsRepository
 import org.mifos.mobile.core.data.util.NetworkMonitor
 import org.mifos.mobile.core.datastore.UserPreferencesRepository
@@ -208,7 +208,7 @@ class SavingsAccountViewmodel(
             is DataState.Error -> {
                 updateState {
                     it.copy(
-                        uiState = if (dataState.exception.cause is IOException) {
+                        uiState = if (dataState.exception is MifosException.NetworkError) {
                             ScreenUiState.Network
                         } else {
                             ScreenUiState.Error(Res.string.feature_generic_error_server)

--- a/feature/savings-account/src/commonMain/kotlin/org/mifos/mobile/feature/savingsaccount/savingsAccountDetails/SavingsAccountDetailsViewModel.kt
+++ b/feature/savings-account/src/commonMain/kotlin/org/mifos/mobile/feature/savingsaccount/savingsAccountDetails/SavingsAccountDetailsViewModel.kt
@@ -17,7 +17,6 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.io.IOException
 import mifos_mobile.feature.savings_account.generated.resources.Res
 import mifos_mobile.feature.savings_account.generated.resources.feature_generic_error_server
 import mifos_mobile.feature.savings_account.generated.resources.feature_savings_account_number_label
@@ -32,6 +31,7 @@ import org.mifos.mobile.core.common.Constants
 import org.mifos.mobile.core.common.CurrencyFormatter
 import org.mifos.mobile.core.common.DataState
 import org.mifos.mobile.core.common.DateHelper
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.SavingsAccountRepository
 import org.mifos.mobile.core.data.util.NetworkMonitor
 import org.mifos.mobile.core.datastore.UserPreferencesRepository
@@ -186,7 +186,7 @@ internal class SavingsAccountDetailsViewModel(
             is DataState.Error -> {
                 updateState {
                     it.copy(
-                        uiState = if (dataState.exception is IOException) {
+                        uiState = if (dataState.exception is MifosException.NetworkError) {
                             ScreenUiState.Network
                         } else {
                             ScreenUiState.Error(Res.string.feature_generic_error_server)

--- a/feature/savings-account/src/commonMain/kotlin/org/mifos/mobile/feature/savingsaccount/savingsAccountUpdate/AccountUpdateViewModel.kt
+++ b/feature/savings-account/src/commonMain/kotlin/org/mifos/mobile/feature/savingsaccount/savingsAccountUpdate/AccountUpdateViewModel.kt
@@ -12,7 +12,6 @@ package org.mifos.mobile.feature.savingsaccount.savingsAccountUpdate
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
-import io.ktor.client.plugins.ServerResponseException
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -34,6 +33,7 @@ import mifos_mobile.feature.savings_account.generated.resources.feature_savings_
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.getString
 import org.mifos.mobile.core.common.DataState
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.SavingsAccountRepository
 import org.mifos.mobile.core.data.util.NetworkMonitor
 import org.mifos.mobile.core.datastore.UserPreferencesRepository
@@ -317,14 +317,14 @@ internal class AccountUpdateViewModel(
                 updateState {
                     it.copy(showOverlay = false)
                 }
-                val errorMsg = if (dataState.exception.cause is ServerResponseException) {
+                val errorMsg = if (dataState.exception is MifosException.ServerError) {
                     getString(UiRes.string.internal_server_error)
                 } else {
                     getString(Res.string.feature_savings_update_request_failed_message)
                 }
                 sendEvent(
                     AccountUpdateEvent.NavigateToStatus(
-                        eventType = if (dataState.exception.cause is ServerResponseException) {
+                        eventType = if (dataState.exception is MifosException.ServerError) {
                             EventType.SERVER_EXCEPTION.name
                         } else {
                             EventType.FAILURE.name

--- a/feature/savings-account/src/commonMain/kotlin/org/mifos/mobile/feature/savingsaccount/savingsAccountWithdraw/AccountWithdrawViewModel.kt
+++ b/feature/savings-account/src/commonMain/kotlin/org/mifos/mobile/feature/savingsaccount/savingsAccountWithdraw/AccountWithdrawViewModel.kt
@@ -12,7 +12,6 @@ package org.mifos.mobile.feature.savingsaccount.savingsAccountWithdraw
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
-import io.ktor.client.plugins.ServerResponseException
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -33,6 +32,7 @@ import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.getString
 import org.mifos.mobile.core.common.DataState
 import org.mifos.mobile.core.common.DateHelper
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.SavingsAccountRepository
 import org.mifos.mobile.core.model.EventType
 import org.mifos.mobile.core.model.StatusNavigationDestination
@@ -198,7 +198,7 @@ internal class AccountWithdrawViewModel(
             }
 
             is DataState.Error -> {
-                val errorMsg = if (dataState.exception.cause is ServerResponseException) {
+                val errorMsg = if (dataState.exception is MifosException.ServerError) {
                     getString(UiRes.string.internal_server_error)
                 } else {
                     getString(Res.string.feature_savings_withdraw_request_failed_message)
@@ -206,7 +206,7 @@ internal class AccountWithdrawViewModel(
 
                 sendEvent(
                     AccountWithdrawEvent.NavigateToStatus(
-                        eventType = if (dataState.exception.cause is ServerResponseException) {
+                        eventType = if (dataState.exception is MifosException.ServerError) {
                             EventType.SERVER_EXCEPTION.name
                         } else {
                             EventType.FAILURE.name

--- a/feature/savings-application/src/commonMain/kotlin/org/mifos/mobile/feature/savings/application/fillApplication/FillApplicationViewModel.kt
+++ b/feature/savings-application/src/commonMain/kotlin/org/mifos/mobile/feature/savings/application/fillApplication/FillApplicationViewModel.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.io.IOException
 import mifos_mobile.core.ui.generated.resources.validation_amount_empty
 import mifos_mobile.feature.savings_application.generated.resources.Res
 import mifos_mobile.feature.savings_application.generated.resources.feature_apply_savings_error_frequency_invalid
@@ -29,6 +28,7 @@ import mifos_mobile.feature.savings_application.generated.resources.feature_appl
 import org.jetbrains.compose.resources.StringResource
 import org.mifos.mobile.core.common.DataState
 import org.mifos.mobile.core.common.DateHelper
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.SavingsAccountRepository
 import org.mifos.mobile.core.data.util.NetworkMonitor
 import org.mifos.mobile.core.datastore.UserPreferencesRepository
@@ -506,7 +506,7 @@ internal class SavingsFillApplicationViewModel(
             is DataState.Error -> {
                 updateState {
                     it.copy(
-                        uiState = if (template.exception is IOException) {
+                        uiState = if (template.exception is MifosException.NetworkError) {
                             ScreenUiState.Network
                         } else {
                             ScreenUiState.Error(Res.string.feature_apply_savings_error_server)

--- a/feature/savings-application/src/commonMain/kotlin/org/mifos/mobile/feature/savings/application/savingsApplication/SavingsApplyViewModel.kt
+++ b/feature/savings-application/src/commonMain/kotlin/org/mifos/mobile/feature/savings/application/savingsApplication/SavingsApplyViewModel.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.io.IOException
 import mifos_mobile.feature.savings_application.generated.resources.Res
 import mifos_mobile.feature.savings_application.generated.resources.feature_apply_savings_error_product_empty
 import mifos_mobile.feature.savings_application.generated.resources.feature_apply_savings_error_server
@@ -27,6 +26,7 @@ import mifos_mobile.feature.savings_application.generated.resources.feature_appl
 import org.jetbrains.compose.resources.StringResource
 import org.mifos.mobile.core.common.DataState
 import org.mifos.mobile.core.common.DateHelper
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.HomeRepository
 import org.mifos.mobile.core.data.repository.SavingsAccountRepository
 import org.mifos.mobile.core.data.util.NetworkMonitor
@@ -191,7 +191,7 @@ internal class SavingsApplyViewModel(
 
                     updateState {
                         it.copy(
-                            uiState = if (throwable.cause is IOException) {
+                            uiState = if (throwable.cause is MifosException.NetworkError) {
                                 ScreenUiState.Network
                             } else {
                                 ScreenUiState.Error(Res.string.feature_apply_savings_error_server)

--- a/feature/savings-application/src/commonMain/kotlin/org/mifos/mobile/feature/savings/application/savingsApplication/SavingsApplyViewModel.kt
+++ b/feature/savings-application/src/commonMain/kotlin/org/mifos/mobile/feature/savings/application/savingsApplication/SavingsApplyViewModel.kt
@@ -13,7 +13,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
@@ -119,6 +118,17 @@ internal class SavingsApplyViewModel(
     private var submitAttempts = 0
     private val maxSubmitAttempts = 5
 
+    private fun handleError(exception: Throwable) {
+        updateState {
+            it.copy(
+                uiState = when (exception) {
+                    is MifosException.NetworkError -> ScreenUiState.Network
+                    else -> ScreenUiState.Error(Res.string.feature_apply_savings_error_server)
+                },
+            )
+        }
+    }
+
     /**
      * Handles incoming actions from the UI and dispatches them to the appropriate
      * business logic functions.
@@ -186,27 +196,14 @@ internal class SavingsApplyViewModel(
                 savingsAccountRepositoryImpl.getSavingAccountApplicationTemplate(state.clientId),
             ) { client, template ->
                 client to template
+            }.collect { (client, template) ->
+                sendAction(
+                    SavingsApplicationAction.Internal.ReceiveClientAndTemplateResult(
+                        client,
+                        template,
+                    ),
+                )
             }
-                .catch { throwable ->
-
-                    updateState {
-                        it.copy(
-                            uiState = if (throwable.cause is MifosException.NetworkError) {
-                                ScreenUiState.Network
-                            } else {
-                                ScreenUiState.Error(Res.string.feature_apply_savings_error_server)
-                            },
-                        )
-                    }
-                }
-                .collect { (client, template) ->
-                    sendAction(
-                        SavingsApplicationAction.Internal.ReceiveClientAndTemplateResult(
-                            client,
-                            template,
-                        ),
-                    )
-                }
         }
     }
 
@@ -238,7 +235,10 @@ internal class SavingsApplyViewModel(
         template: DataState<SavingsAccountTemplate?>,
     ) {
         when {
-            listOf(client, template).any { it is DataState.Loading } -> {
+            client is DataState.Error -> handleError(client.exception)
+            template is DataState.Error -> handleError(template.exception)
+
+            client is DataState.Loading || template is DataState.Loading -> {
                 showLoading()
             }
 
@@ -250,12 +250,6 @@ internal class SavingsApplyViewModel(
                         uiState = ScreenUiState.Success,
                     )
                 }
-            }
-
-            else -> updateState {
-                it.copy(
-                    uiState = ScreenUiState.Error(Res.string.feature_apply_savings_error_server),
-                )
             }
         }
     }

--- a/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/password/ChangePasswordViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/password/ChangePasswordViewModel.kt
@@ -10,7 +10,6 @@
 package org.mifos.mobile.feature.settings.password
 
 import androidx.lifecycle.viewModelScope
-import io.ktor.client.plugins.ServerResponseException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.launchIn
@@ -31,6 +30,7 @@ import mifos_mobile.feature.settings.generated.resources.password_update_failed
 import mifos_mobile.feature.settings.generated.resources.password_update_success
 import org.jetbrains.compose.resources.StringResource
 import org.mifos.mobile.core.common.DataState
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.UserAuthRepository
 import org.mifos.mobile.core.data.repository.UserDataRepository
 import org.mifos.mobile.core.ui.PasswordStrengthState
@@ -368,7 +368,7 @@ internal class ChangePasswordViewModel(
             when (action.result) {
                 is DataState.Error -> {
                     val errorMsg =
-                        if (action.result.exception.cause is ServerResponseException) {
+                        if (action.result.exception is MifosException.ServerError) {
                             UiRes.string.internal_server_error
                         } else {
                             Res.string.password_update_failed

--- a/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/settings/SettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/org/mifos/mobile/feature/settings/settings/SettingsViewModel.kt
@@ -12,7 +12,6 @@ package org.mifos.mobile.feature.settings.settings
 import androidx.compose.runtime.Immutable
 import androidx.lifecycle.viewModelScope
 import kotlinx.collections.immutable.ImmutableList
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -208,9 +207,6 @@ internal class SettingsViewModel(
 
         viewModelScope.launch {
             homeRepositoryImpl.clientImage(state.clientId ?: -1L)
-                .catch {
-                    // Do nothing on image fetch error, as it's not critical.
-                }
                 .collect { sendAction(SettingsAction.Internal.ReceiveClientImage(it)) }
         }
     }

--- a/feature/share-account/src/commonMain/kotlin/org/mifos/mobile/feature/shareaccount/shareAccount/ShareAccountViewModel.kt
+++ b/feature/share-account/src/commonMain/kotlin/org/mifos/mobile/feature/shareaccount/shareAccount/ShareAccountViewModel.kt
@@ -13,13 +13,13 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.io.IOException
 import mifos_mobile.feature.share_account.generated.resources.Res
 import mifos_mobile.feature.share_account.generated.resources.feature_share_account_generic_error_server
 import org.jetbrains.compose.resources.StringResource
 import org.mifos.mobile.core.common.Constants
 import org.mifos.mobile.core.common.CurrencyFormatter
 import org.mifos.mobile.core.common.DataState
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.AccountsRepository
 import org.mifos.mobile.core.data.util.NetworkMonitor
 import org.mifos.mobile.core.datastore.UserPreferencesRepository
@@ -208,7 +208,7 @@ class ShareAccountsViewmodel(
             is DataState.Error -> {
                 updateState {
                     it.copy(
-                        uiState = if (dataState.exception.cause is IOException) {
+                        uiState = if (dataState.exception is MifosException.NetworkError) {
                             ScreenUiState.Network
                         } else {
                             ScreenUiState.Error(Res.string.feature_share_account_generic_error_server)

--- a/feature/share-account/src/commonMain/kotlin/org/mifos/mobile/feature/shareaccount/shareAccountDetails/ShareAccountDetailsViewModel.kt
+++ b/feature/share-account/src/commonMain/kotlin/org/mifos/mobile/feature/shareaccount/shareAccountDetails/ShareAccountDetailsViewModel.kt
@@ -17,7 +17,6 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.io.IOException
 import mifos_mobile.feature.share_account.generated.resources.Res
 import mifos_mobile.feature.share_account.generated.resources.feature_share_account_activation_date
 import mifos_mobile.feature.share_account.generated.resources.feature_share_account_application_date
@@ -32,6 +31,7 @@ import mifos_mobile.feature.share_account.generated.resources.feature_share_acco
 import org.mifos.mobile.core.common.CurrencyFormatter
 import org.mifos.mobile.core.common.DataState
 import org.mifos.mobile.core.common.DateHelper
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.ShareAccountRepository
 import org.mifos.mobile.core.data.util.NetworkMonitor
 import org.mifos.mobile.core.datastore.UserPreferencesRepository
@@ -125,9 +125,7 @@ internal class ShareAccountDetailsViewModel(
             is DataState.Error -> {
                 updateState {
                     it.copy(
-                        uiState = if (dataState.exception is IOException ||
-                            dataState.exception.cause is IOException
-                        ) {
+                        uiState = if (dataState.exception is MifosException.NetworkError) {
                             ScreenUiState.Network
                         } else {
                             ScreenUiState.Error(Res.string.feature_share_account_generic_error_server)

--- a/feature/share-application/src/commonMain/kotlin/org/mifos/mobile/feature/share/application/fillApplication/FillApplicationViewModel.kt
+++ b/feature/share-application/src/commonMain/kotlin/org/mifos/mobile/feature/share/application/fillApplication/FillApplicationViewModel.kt
@@ -13,7 +13,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
-import io.ktor.client.plugins.ServerResponseException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.catch
@@ -42,6 +41,7 @@ import org.jetbrains.compose.resources.getString
 import org.mifos.mobile.core.common.Constants
 import org.mifos.mobile.core.common.DataState
 import org.mifos.mobile.core.common.DateHelper
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.AccountsRepository
 import org.mifos.mobile.core.data.repository.ShareAccountRepository
 import org.mifos.mobile.core.data.util.NetworkMonitor
@@ -651,7 +651,7 @@ internal class ShareFillApplicationViewModel(
             is DataState.Error -> {
                 updateState { it.copy(showOverlay = false) }
 
-                val errorMsg = if (response.exception.cause is ServerResponseException) {
+                val errorMsg = if (response.exception is MifosException.ServerError) {
                     getString(UiRes.string.internal_server_error)
                 } else {
                     "${response.message}, ${getString(
@@ -661,7 +661,7 @@ internal class ShareFillApplicationViewModel(
                 }
                 sendEvent(
                     ShareApplicationEvent.NavigateToStatus(
-                        eventType = if (response.exception.cause is ServerResponseException) {
+                        eventType = if (response.exception is MifosException.ServerError) {
                             EventType.SERVER_EXCEPTION.name
                         } else {
                             EventType.FAILURE.name

--- a/feature/share-application/src/commonMain/kotlin/org/mifos/mobile/feature/share/application/fillApplication/FillApplicationViewModel.kt
+++ b/feature/share-application/src/commonMain/kotlin/org/mifos/mobile/feature/share/application/fillApplication/FillApplicationViewModel.kt
@@ -15,7 +15,6 @@ import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -111,6 +110,17 @@ internal class ShareFillApplicationViewModel(
     init {
         observeNetworkStatus()
         observeAuthResult()
+    }
+
+    private fun handleError(exception: Throwable) {
+        updateState {
+            it.copy(
+                uiState = when (exception) {
+                    is MifosException.NetworkError -> ShareApplicationUiState.Network
+                    else -> ShareApplicationUiState.Error(Res.string.feature_apply_share_error_server)
+                },
+            )
+        }
     }
 
     /**
@@ -280,13 +290,7 @@ internal class ShareFillApplicationViewModel(
             accountsRepositoryImpl.loadAccounts(
                 clientId = state.clientId,
                 accountType = Constants.SAVINGS_ACCOUNTS,
-            ).catch { e ->
-                mutableStateFlow.update {
-                    it.copy(
-                        uiState = ShareApplicationUiState.Error(Res.string.feature_apply_share_error_server),
-                    )
-                }
-            }.collect { clientAccounts ->
+            ).collect { clientAccounts ->
                 sendAction(
                     ShareApplicationAction.Internal.ReceiveClientSavingsAccounts(
                         accounts = clientAccounts,
@@ -307,15 +311,7 @@ internal class ShareFillApplicationViewModel(
     private fun handleClientAccountResult(response: DataState<ClientAccounts>) {
         when (response) {
             is DataState.Loading -> showLoading()
-            is DataState.Error -> {
-                updateState {
-                    it.copy(
-                        uiState = ShareApplicationUiState.Error(
-                            Res.string.feature_apply_share_error_server,
-                        ),
-                    )
-                }
-            }
+            is DataState.Error -> handleError(response.exception)
             is DataState.Success -> {
                 val shareTemplate = response.data
                 updateState {
@@ -339,15 +335,7 @@ internal class ShareFillApplicationViewModel(
     private fun handleShareTemplateResult(template: DataState<ShareProductDetails?>) {
         when (template) {
             is DataState.Loading -> showLoading()
-            is DataState.Error -> {
-                updateState {
-                    it.copy(
-                        uiState = ShareApplicationUiState.Error(
-                            Res.string.feature_apply_share_error_server,
-                        ),
-                    )
-                }
-            }
+            is DataState.Error -> handleError(template.exception)
             is DataState.Success -> {
                 val shareTemplate = template.data ?: return
                 updateState {

--- a/feature/share-application/src/commonMain/kotlin/org/mifos/mobile/feature/share/application/shareApplication/ShareApplyViewModel.kt
+++ b/feature/share-application/src/commonMain/kotlin/org/mifos/mobile/feature/share/application/shareApplication/ShareApplyViewModel.kt
@@ -11,7 +11,6 @@ package org.mifos.mobile.feature.share.application.shareApplication
 
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
@@ -64,6 +63,17 @@ internal class ShareApplyViewModel(
 
     init {
         observeNetworkStatus()
+    }
+
+    private fun handleError(exception: Throwable) {
+        updateState {
+            it.copy(
+                uiState = when (exception) {
+                    is MifosException.NetworkError -> ShareApplicationUiState.Network
+                    else -> ShareApplicationUiState.Error(Res.string.feature_apply_share_error_server)
+                },
+            )
+        }
     }
 
     /**
@@ -131,27 +141,14 @@ internal class ShareApplyViewModel(
                 shareAccountRepositoryImpl.getShareProducts(state.clientId),
             ) { client, template ->
                 client to template
+            }.collect { (client, template) ->
+                sendAction(
+                    ShareApplicationAction.Internal.ReceiveClientAndTemplateResult(
+                        client,
+                        template,
+                    ),
+                )
             }
-                .catch { throwable ->
-
-                    updateState {
-                        it.copy(
-                            uiState = if (throwable.cause is MifosException.NetworkError) {
-                                ShareApplicationUiState.Network
-                            } else {
-                                ShareApplicationUiState.Error(Res.string.feature_apply_share_error_server)
-                            },
-                        )
-                    }
-                }
-                .collect { (client, template) ->
-                    sendAction(
-                        ShareApplicationAction.Internal.ReceiveClientAndTemplateResult(
-                            client,
-                            template,
-                        ),
-                    )
-                }
         }
     }
 
@@ -168,7 +165,10 @@ internal class ShareApplyViewModel(
         template: DataState<Page<ShareProduct>>,
     ) {
         when {
-            listOf(client, template).any { it is DataState.Loading } -> {
+            client is DataState.Error -> handleError(client.exception)
+            template is DataState.Error -> handleError(template.exception)
+
+            client is DataState.Loading || template is DataState.Loading -> {
                 showLoading()
             }
 
@@ -185,12 +185,6 @@ internal class ShareApplyViewModel(
                         },
                     )
                 }
-            }
-
-            else -> updateState {
-                it.copy(
-                    uiState = ShareApplicationUiState.Error(Res.string.feature_apply_share_error_server),
-                )
             }
         }
     }

--- a/feature/share-application/src/commonMain/kotlin/org/mifos/mobile/feature/share/application/shareApplication/ShareApplyViewModel.kt
+++ b/feature/share-application/src/commonMain/kotlin/org/mifos/mobile/feature/share/application/shareApplication/ShareApplyViewModel.kt
@@ -16,13 +16,13 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.io.IOException
 import mifos_mobile.feature.share_application.generated.resources.Res
 import mifos_mobile.feature.share_application.generated.resources.feature_apply_share_error_server
 import mifos_mobile.feature.share_application.generated.resources.feature_apply_share_error_submit_failed
 import org.jetbrains.compose.resources.StringResource
 import org.mifos.mobile.core.common.DataState
 import org.mifos.mobile.core.common.DateHelper
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.HomeRepository
 import org.mifos.mobile.core.data.repository.ShareAccountRepository
 import org.mifos.mobile.core.data.util.NetworkMonitor
@@ -136,7 +136,7 @@ internal class ShareApplyViewModel(
 
                     updateState {
                         it.copy(
-                            uiState = if (throwable.cause is IOException) {
+                            uiState = if (throwable.cause is MifosException.NetworkError) {
                                 ShareApplicationUiState.Network
                             } else {
                                 ShareApplicationUiState.Error(Res.string.feature_apply_share_error_server)

--- a/feature/transfer-process/src/commonMain/kotlin/org/mifos/mobile/feature/transfer/process/transferProcess/TransferProcessViewModel.kt
+++ b/feature/transfer-process/src/commonMain/kotlin/org/mifos/mobile/feature/transfer/process/transferProcess/TransferProcessViewModel.kt
@@ -12,7 +12,6 @@ package org.mifos.mobile.feature.transfer.process.transferProcess
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
-import io.ktor.client.plugins.ServerResponseException
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -26,6 +25,7 @@ import org.jetbrains.compose.resources.getString
 import org.mifos.mobile.core.common.DataState
 import org.mifos.mobile.core.common.DateHelper
 import org.mifos.mobile.core.common.DateHelper.currentDate
+import org.mifos.mobile.core.common.MifosException
 import org.mifos.mobile.core.data.repository.TransferRepository
 import org.mifos.mobile.core.data.util.NetworkMonitor
 import org.mifos.mobile.core.model.EventType
@@ -236,7 +236,7 @@ internal class TransferProcessViewModel(
                     )
                 }
 
-                val errorMsg = if (response.exception.cause is ServerResponseException) {
+                val errorMsg = if (response.exception is MifosException.ServerError) {
                     getString(UiRes.string.internal_server_error)
                 } else {
                     response.message
@@ -244,7 +244,7 @@ internal class TransferProcessViewModel(
 
                 sendEvent(
                     TransferProcessEvent.NavigateToStatus(
-                        eventType = if (response.exception.cause is ServerResponseException) {
+                        eventType = if (response.exception is MifosException.ServerError) {
                             EventType.SERVER_EXCEPTION.name
                         } else {
                             EventType.FAILURE.name


### PR DESCRIPTION
- Introduce `MifosException` sealed class to categorize errors into `ServerError`, `ClientError`, `NetworkError`, and `GenericError`.
- Add `ExceptionMapper` utility to convert `Throwable` and Ktor exceptions into `MifosException` types, including a suspend version for async error extraction.
- Update `asDataStateFlow` extension to support custom exception mapping.
- Refactor all repository implementations (`BeneficiaryRepositoryImp`, `LoanRepositoryImp`, `SavingsAccountRepositoryImp`, etc.) to use the new exception mapping logic.
- Update ViewModels across all features to handle specific `MifosException` types instead of raw IO or Ktor exceptions for UI state management.

Fixes - [Jira-#577](https://mifosforge.jira.com/browse/MM-577)

Please Add Screenshots If there are any UI changes.

| Before                                     | After                                  |
|--------------------------------------------|----------------------------------------|
|                                            |                                        |


Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the static analysis check `./gradlew check` or `ci-prepush.sh` to make sure you didn't break anything

- [ ] If you have multiple commits please combine them into one commit by squashing them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized error handling across repositories and view models for consistent network vs server error classification
  * User-facing messages now distinguish network, server, client, and generic errors more reliably
  * Reduced silent/ignored failures so error states propagate to UI collectors, improving refresh/error indicators and status dialogs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->