### PR TITLE
fix(security): enforce HTTPS-only connections (MM-557)

### DIFF
--- a/cmp-android/src/main/AndroidManifest.xml
+++ b/cmp-android/src/main/AndroidManifest.xml
@@ -37,6 +37,7 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.MifosSplash">

--- a/cmp-android/src/main/res/xml/network_security_config.xml
+++ b/cmp-android/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2026 Mifos Initiative
+
+    This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+    If a copy of the MPL was not distributed with this file,
+    You can obtain one at https://mozilla.org/MPL/2.0/.
+
+    See https://github.com/openMF/mobile-mobile/blob/master/LICENSE.md
+-->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/core/network/src/commonMain/kotlin/org/mifos/mobile/core/network/utils/BaseURL.kt
+++ b/core/network/src/commonMain/kotlin/org/mifos/mobile/core/network/utils/BaseURL.kt
@@ -16,10 +16,6 @@ class BaseURL {
     val defaultBaseUrl: String
         get() = PROTOCOL_HTTPS + API_ENDPOINT
 
-    fun getUrl(endpoint: String): String {
-        return endpoint + API_PATH
-    }
-
     companion object {
         const val API_ENDPOINT = "tt.mifos.community"
         const val API_PATH = "/fineract-provider/api/v1/self/"


### PR DESCRIPTION
Fixes - [MM-557](https://mifosforge.jira.com/browse/MM-557)

No UI changes.

- [x] Run the static analysis check `./gradlew check` or `ci-prepush.sh` to make sure you didn't break anything

- [x] If you have multiple commits please combine them into one commit by squashing them.

[MM-557]: https://mifosforge.jira.com/browse/MM-557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Enforced HTTPS encryption for all network communications to enhance data protection
  * Disabled cleartext network traffic to prevent unencrypted data transmission
  * Updated network security configuration to use system certificate authorities for secure connections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->