### PR TITLE
fix(loan): fix typo in allowPartialPeriodInterestCalculation

### DIFF
--- a/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/mapper/templates/LoanTemplateMapper.kt
+++ b/core/data/src/commonMain/kotlin/org/mifos/mobile/core/data/mapper/templates/LoanTemplateMapper.kt
@@ -263,8 +263,8 @@ fun LoanProductResponseDto.toModel(): Product =
         interestType = interestType.toInterestType(),
         interestCalculationPeriodType =
         interestCalculationPeriodType?.toInterestCalculationPeriodType(),
-        allowPartialPeriodInterestCalcualtion =
-        allowPartialPeriodInterestCalcualtion,
+        allowPartialPeriodInterestCalculation =
+        allowPartialPeriodInterestCalculation,
         transactionProcessingStrategyId =
         transactionProcessingStrategyId,
         transactionProcessingStrategyName =

--- a/core/model/src/commonMain/kotlin/org/mifos/mobile/core/model/entity/templates/loans/Product.kt
+++ b/core/model/src/commonMain/kotlin/org/mifos/mobile/core/model/entity/templates/loans/Product.kt
@@ -90,7 +90,7 @@ data class Product(
 
     val interestCalculationPeriodType: InterestCalculationPeriodType? = null,
 
-    val allowPartialPeriodInterestCalcualtion: Boolean? = null,
+    val allowPartialPeriodInterestCalculation: Boolean? = null,
 
     val transactionProcessingStrategyId: Int? = null,
 

--- a/core/network/src/commonMain/kotlin/org/mifos/mobile/core/network/dto/products/loan/LoanProductResponseDto.kt
+++ b/core/network/src/commonMain/kotlin/org/mifos/mobile/core/network/dto/products/loan/LoanProductResponseDto.kt
@@ -83,7 +83,7 @@ data class LoanProductResponseDto(
 
     val interestCalculationPeriodType: TypeResponseDto? = null,
 
-    val allowPartialPeriodInterestCalcualtion: Boolean? = null,
+    val allowPartialPeriodInterestCalculation: Boolean? = null,
 
     val transactionProcessingStrategyId: Int? = null,
 


### PR DESCRIPTION
Fixes - [Jira-#MM-580](https://mifosforge.jira.com/browse/MM-580)

Replaced occurences of `allowPartialPeriodInterestCalcualtion` which is a typo with the right word `allowPartialPeriodInterestCalculation`

No observable UI changes.
Before:

https://github.com/user-attachments/assets/a0c59bad-da30-4a68-a963-8ae009da7555      

After:

https://github.com/user-attachments/assets/c1a751df-3bf0-4ed7-a881-4eb80e3ff727

   

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the static analysis check `./gradlew check` or `ci-prepush.sh` to make sure you didn't break anything

- [ ] If you have multiple commits please combine them



 into one commit by squashing them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected spelling error in loan product partial period interest calculation field across system components, ensuring consistent data handling and API compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->